### PR TITLE
Generate and store secret key for webhooks

### DIFF
--- a/app/env/dev/user.clj
+++ b/app/env/dev/user.clj
@@ -26,25 +26,20 @@
                     (sc/stop-system s))
                   nil)))
 
-(def secret "test-secret")
-
 (defn start-server []
   (stop-server)
   (reset! server (-> c/base-system                     
                      (assoc :config (-> (config/app-config cc/env {:dev-mode true :workdir "tmp"})
-                                        (assoc :github {:secret secret}
-                                               :log-dir (u/abs-path "target/logs"))))
+                                        (assoc :log-dir (u/abs-path "target/logs"))))
                      (sc/subsystem [:http])
                      (sc/start-system)))
   nil)
 
 (defn generate-signature
-  ([secret payload]
-   (-> payload
-       (mac/hash {:key secret :alg :hmac+sha256})
-       (codecs/bytes->hex)))
-  ([payload]
-   (generate-signature secret payload)))
+  [secret payload]
+  (-> payload
+      (mac/hash {:key secret :alg :hmac+sha256})
+      (codecs/bytes->hex)))
 
 (defn load-example-github-webhook []
   (with-open [r (-> "test/example-github-webhook.edn"

--- a/app/src/monkey/ci/web/handler.clj
+++ b/app/src/monkey/ci/web/handler.clj
@@ -24,16 +24,6 @@
    :body "ok"
    :headers {"Content-Type" "text/plain"}})
 
-(defn- maybe-generate
-  "If no secret key has been configured, generate one and log it.  Don't
-   use this in production!"
-  [s g]
-  (if (some? s)
-    s
-    (let [gen (g)]
-      (log/info "Generated secret key:" gen)
-      gen)))
-
 (def Id s/Str)
 
 (defn- assoc-id [s]
@@ -191,9 +181,7 @@
      {:github-security (if dev-mode
                          ;; Disable security in dev mode
                          [passthrough-middleware]
-                         [github/validate-security (maybe-generate
-                                                    (get-in opts [:github :secret])
-                                                    github/generate-secret-key)])}}))
+                         [github/validate-security])}}))
   ([opts]
    (make-router opts routes)))
 

--- a/app/test/monkey/ci/test/process_test.clj
+++ b/app/test/monkey/ci/test/process_test.clj
@@ -115,3 +115,9 @@
                     :args
                     :extra-env
                     :monkeyci-event-socket))))))
+
+(deftest process-env
+  (testing "passes build id"
+    (is (= "test-build" (-> {:build {:build-id "test-build"}}
+                            (sut/process-env "test-socket")
+                            :monkeyci-build-id)))))

--- a/app/test/monkey/ci/test/web/api_test.clj
+++ b/app/test/monkey/ci/test/web/api_test.clj
@@ -107,3 +107,26 @@
                   (with-path-params {:customer-id (st/new-id)})
                   (sut/get-params)
                   :body)))))
+
+(deftest create-webhook
+  (testing "assigns secret key"
+    (let [{st :storage :as ctx} (test-ctx)
+          r (-> ctx
+                (->req)
+                (with-body {:customer-id "test-customer"})
+                (sut/create-webhook))]
+      (is (= 201 (:status r)))
+      (is (string? (get-in r [:body :secret-key]))))))
+
+(deftest get-webhook
+  (testing "does not return the secret key"
+    (let [{st :storage :as ctx} (test-ctx)
+          wh {:id (st/new-id)
+              :secret-key "very secret key"}
+          _ (st/save-webhook-details st wh)
+          r (-> ctx
+                (->req)
+                (with-path-param :webhook-id (:id wh))
+                (sut/get-webhook))]
+      (is (= 200 (:status r)))
+      (is (nil? (get-in r [:body :secret-key]))))))


### PR DESCRIPTION
Instead of using a global secret key for github webhook, we now generate a secret key on webhook creation.

Closes #28 