### PR TITLE
Podman volumes

### DIFF
--- a/.monkeyci/build.clj
+++ b/.monkeyci/build.clj
@@ -27,18 +27,21 @@
 
 (def app-uberjar (clj-app "-X:jar:uber"))
 
+;; Full path to the docker config file, used to push images
+(def docker-config (fs/expand-home "~/.docker/config.json"))
+
 (defn dockerhub-creds
   "Fetches docker hub credentials from the params and writes them to Docker `config.json`"
   [ctx]
-  (let [cf (fs/expand-home "~/.docker/config.json")]
-    (when-not (fs/exists? cf)
-      (println "Writing dockerhub credentials")
-      (shell/param-to-file ctx "dockerhub-creds" cf))))
+  (when-not (fs/exists? docker-config)
+    (println "Writing dockerhub credentials")
+    (shell/param-to-file ctx "dockerhub-creds" docker-config)))
 
 (def container-image
-  ;; TODO Credentials, must be mounted to /kaniko/.docker/config.json
   {:container/image "docker.io/bitnami/kaniko:latest"
-   :container/cmd ["-d" "docker.io/monkeyci/app:latest" "-f" "docker/Dockerfile" "-c" "."]})
+   :container/cmd ["-d" "docker.io/dormeur/monkey-ci:latest" "-f" "docker/Dockerfile" "-c" "."]
+   ;; Credentials, must be mounted to /kaniko/.docker/config.json
+   :container/mounts [[(str docker-config) "/kaniko/.docker/config.json"]]})
 
 (defn set-name [s n]
   (assoc s :name n))

--- a/.monkeyci/build.clj
+++ b/.monkeyci/build.clj
@@ -6,6 +6,9 @@
 (require '[config.core :refer [env]])
 (require '[babashka.fs :as fs])
 
+(defn set-name [s n]
+  (assoc s :name n))
+
 (defn clj [& args]
   (apply str "clojure " args))
 
@@ -22,8 +25,8 @@
 (def clj-lib (partial clj-dir "lib"))
 (def clj-app (partial clj-dir "app"))
 
-(def test-lib (clj-lib "-X:test:junit"))
-(def test-app (clj-app "-M:test:junit"))
+(def test-lib (set-name (clj-lib "-X:test:junit") "test-lib"))
+(def test-app (set-name (clj-app "-M:test:junit") "test-app"))
 
 (def app-uberjar (clj-app "-X:jar:uber"))
 
@@ -43,14 +46,11 @@
    ;; Credentials, must be mounted to /kaniko/.docker/config.json
    :container/mounts [[(str docker-config) "/kaniko/.docker/config.json"]]})
 
-(defn set-name [s n]
-  (assoc s :name n))
-
 (def test-pipeline
   (core/pipeline
    {:name "test"
-    :steps [(set-name test-lib "test-lib")
-            (set-name test-app "test-app")]}))
+    :steps [test-lib
+            test-app]}))
 
 (def publish-pipeline
   (core/pipeline

--- a/app/test/monkey/ci/test/podman_test.clj
+++ b/app/test/monkey/ci/test/podman_test.clj
@@ -24,6 +24,15 @@
                          "test-img"))
           (is (= "first && second" (last (:cmd r)))))))))
 
+(defn- contains-subseq? [l expected]
+  (let [n (count expected)]
+    (loop [t l]
+      (if (= (take n t) expected)
+        true
+        (if (< (count t) n)
+          false
+          (recur (rest t)))))))
+
 (deftest build-cmd-args
   (let [base-ctx {:build-id "test-build"
                   :work-dir "test-dir"
@@ -43,4 +52,9 @@
 
     (testing "adds all script entries as a single arg"
       (let [r (sut/build-cmd-args base-ctx)]
-        (is (= "first && second" (last r)))))))
+        (is (= "first && second" (last r)))))
+
+    (testing "adds mounts if provided"
+      (let [r (sut/build-cmd-args (assoc-in base-ctx
+                                            [:step :container/mounts] [["/host/path" "/container/path"]]))]
+        (is (contains-subseq? r ["-v" "/host/path:/container/path"]))))))

--- a/lib/src/monkey/ci/build/spec.clj
+++ b/lib/src/monkey/ci/build/spec.clj
@@ -10,6 +10,8 @@
 (s/def :container/image string?)
 (s/def :container/entrypoint (s/coll-of string?))
 (s/def :container/cmd (s/coll-of string?))
+(s/def :container/mount (s/coll-of string? :count 2))
+(s/def :container/mounts (s/coll-of :container/mount))
 
 (s/def :ci/step (s/or :fn fn?
                       :action
@@ -17,7 +19,7 @@
                               :opt-un [:ci/name])
                       :container
                       (s/keys :req [:container/image]
-                              :opt [:container/entrypoint :container/cmd]
+                              :opt [:container/entrypoint :container/cmd :container/mounts]
                               :opt-un [:ci/script :ci/name])))
 (s/def :ci/output string?)
 (s/def :ci/exception (partial instance? java.lang.Exception))

--- a/lib/test/monkey/ci/test/build/container_test.clj
+++ b/lib/test/monkey/ci/test/build/container_test.clj
@@ -14,4 +14,8 @@
 (deftest image-spec
   (testing "allows valid steps"
     (is (s/valid? :ci/step {:container/image "test-image"
-                            :container/cmd ["test" "cmd"]}))))
+                            :container/cmd ["test" "cmd"]})))
+
+  (testing "allows mounts"
+    (is (s/valid? :ci/step {:container/image "test-image"
+                            :container/mounts [["/host/vol" "/container/vol"]]}))))


### PR DESCRIPTION
Allowed to specify container mounts using the `:container/mounts` property in a step.  This is handled by the podman runner, but not by docker (yet).