### PR TITLE
Allow step functions to generate new step configs

### DIFF
--- a/app/test/monkey/ci/test/script_test.clj
+++ b/app/test/monkey/ci/test/script_test.clj
@@ -121,17 +121,25 @@
 
 (defmethod c/run-container :test [ctx]
   {:test-result :run-from-test
+   :status :success
    :exit 0})
 
 (deftest pipeline-run-step
   (testing "executes function directly"
-    (is (= :ok (sut/run-step (constantly :ok) {}))))
+    (is (bc/success? (sut/run-step (constantly bc/success) {}))))
 
   (testing "executes action from map"
-    (is (= :ok (sut/run-step {:action (constantly :ok)} {}))))
+    (is (bc/success? (sut/run-step {:action (constantly bc/success)} {}))))
 
   (testing "executes in container if configured"
     (let [config {:container/image "test-image"}
           r (sut/run-step config {:containers {:type :test}})]
+      (is (= :run-from-test (:test-result r)))
+      (is (bc/success? r))))
+
+  (testing "executes fn that returns container config"
+    (let [step (fn [_]
+                 {:container/image "test-image"})
+          r (sut/run-step step {:containers {:type :test}})]
       (is (= :run-from-test (:test-result r)))
       (is (bc/success? r)))))

--- a/lib/src/monkey/ci/build/core.clj
+++ b/lib/src/monkey/ci/build/core.clj
@@ -13,6 +13,11 @@
 (def success (status :success))
 (def failure (status :failure))
 
+(defn status?
+  "Checks if the given object is a step status"
+  [x]
+  (some? (:status x)))
+
 (defn success? [{:keys [status]}]
   (= :success status))
 

--- a/lib/test/monkey/ci/test/build/core_test.clj
+++ b/lib/test/monkey/ci/test/build/core_test.clj
@@ -14,6 +14,12 @@
     (is (sut/failed? nil))
     (is (not (sut/failed? sut/success)))))
 
+(deftest status?
+  (testing "true if the object has a status"
+    (is (false? (sut/status? nil)))
+    (is (true? (sut/status? sut/success)))
+    (is (false? (sut/status? {:something "else"})))))
+
 (deftest pipeline
 
   (testing "creates pipeline object"


### PR DESCRIPTION
In order for container steps to access the context, they should be generated from a function.  This PR addes the possibility for step functions to return new container maps, in addition to returning a result directly.