### PR TITLE
OCI runner basics

### DIFF
--- a/app/deps.edn
+++ b/app/deps.edn
@@ -13,6 +13,7 @@
         com.github.oliyh/martian-httpkit {:mvn/version "0.1.25"}
         com.monkeyci/script {:local/root "../lib"}
         com.monkeyprojects/socket-async {:mvn/version "0.1.0"}
+        com.monkeyprojects/oci-container-instance {:mvn/version "0.1.0-SNAPSHOT"}
         com.monkeyprojects/oci-os {:mvn/version "0.1.0-SNAPSHOT"}
         com.stuartsierra/component {:mvn/version "1.1.0"}
         commons-io/commons-io {:mvn/version "2.13.0"}

--- a/app/src/monkey/ci/cli.clj
+++ b/app/src/monkey/ci/cli.clj
@@ -26,6 +26,9 @@
            :type :string}
           {:as "Commit id"
            :option "commit-id"
+           :type :string}
+          {:as "Repository sid"
+           :option "sid"
            :type :string}]
    :runs {:command cmd/build}})
 

--- a/app/src/monkey/ci/config.clj
+++ b/app/src/monkey/ci/config.clj
@@ -29,7 +29,6 @@
   `(or (System/getenv (csk/->SCREAMING_SNAKE_CASE (str env-prefix "-version"))) "0.1.0-SNAPSHOT"))
 
 (defn- merge-if-map [a b]
-  (log/info "Merging" a "and" b)
   (if (map? a)
     (merge a b)
     b))
@@ -194,3 +193,11 @@
        (flatten-nested [])
        (mc/map-keys (fn [k]
                       (keyword (str env-prefix "-" (name k)))))))
+
+(defn ->oci-config
+  "Given a configuration map with credentials, turns it into a config map
+   that can be passed to OCI context creators."
+  [{:keys [credentials] :as conf}]
+  (-> conf
+      (merge (mc/update-existing credentials :private-key u/load-privkey))
+      (dissoc :credentials)))

--- a/app/src/monkey/ci/runners.clj
+++ b/app/src/monkey/ci/runners.clj
@@ -63,7 +63,7 @@
          (vector)
          (ca/map build-completed))))
 
-(defn- download-git
+(defn download-git
   "Downloads from git into a temp dir, and designates that as the working dir."
   [ctx]
   (let [git (get-in ctx [:git :fn])

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -1,0 +1,36 @@
+(ns monkey.ci.runners.oci
+  (:require [manifold.deferred :as md]
+            [monkey.ci
+             [config :as config]
+             [runners :as r]]
+            [monkey.oci.container-instance.core :as ci]))
+
+(defn- container-config [conf ctx]
+  {:display-name "build"
+   :image-url (str (:image-url conf) ":" (config/version))})
+
+(defn instance-config
+  "Creates container instance configuration using the context"
+  [conf ctx]
+  (-> conf
+      (select-keys [:availability-domain :compartment-id :image-pull-secrets :vnics])
+      (assoc :container-restart-policy "NEVER"
+             :display-name (get-in ctx [:build :build-id])
+             :shape "CI.Standard.A1.Flex"
+             :shape-config {:ocpus 1
+                            :memory-in-g-b-s 1}
+             ;; Assign a checkout volume where the repo is checked out
+             :volumes [{:name "checkout"
+                        :volume-type "EMPTYDIR"}]
+             :containers [(container-config conf ctx)])))
+
+(defn oci-runner [client conf ctx]
+  @(md/chain
+    (ci/create-container-instance
+     client
+     {:container-instance (instance-config conf ctx)})
+    (constantly 0)))
+
+(defmethod r/make-runner :oci [conf]
+  (let [client (ci/make-context (config/->oci-config conf))]
+    (partial oci-runner client conf)))

--- a/app/src/monkey/ci/script.clj
+++ b/app/src/monkey/ci/script.clj
@@ -77,6 +77,7 @@
 
   clojure.lang.IPersistentMap
   (run-step [{:keys [action] :as step} ctx]
+    (log/debug "Running step:" step)
     ;; TODO Make more generic
     (cond
       (some? (:container/image step))

--- a/app/src/monkey/ci/storage/oci.clj
+++ b/app/src/monkey/ci/storage/oci.clj
@@ -5,10 +5,9 @@
              [string :as cs]]
             [clojure.tools.logging :as log]
             [manifold.deferred :as md]
-            [medley.core :as mc]
             [monkey.ci
-             [storage :as st]
-             [utils :as u]]
+             [config :as config]
+             [storage :as st]]
             [monkey.oci.os.core :as os]))
 
 (def get-ns (memoize (fn [client]
@@ -72,7 +71,5 @@
     (throw (ex-info "Region must be specified" conf)))
   (->OciObjectStorage (os/make-client conf) conf))
 
-(defmethod st/make-storage :oci [{:keys [credentials] :as conf}]
-  (make-oci-storage (-> conf
-                        (merge (mc/update-existing credentials :private-key u/load-privkey))
-                        (dissoc :credentials))))
+(defmethod st/make-storage :oci [conf]
+  (make-oci-storage (config/->oci-config conf)))

--- a/app/src/monkey/ci/web/script_api.clj
+++ b/app/src/monkey/ci/web/script_api.clj
@@ -104,6 +104,7 @@
   [{:keys [storage] :as ctx}]
   (let [build-sid (get-in ctx [:build :sid])
         handlers {:get-params (fn []
+                                (log/debug "Fetching all build params for sid" build-sid)
                                 (->> (api/fetch-all-params storage (butlast build-sid))
                                      (map (juxt :name :value))
                                      (into {})))}]

--- a/app/test/monkey/ci/test/cli_test.clj
+++ b/app/test/monkey/ci/test/cli_test.clj
@@ -62,7 +62,11 @@
           (is (= "test-file" (-> (run-cli "-c" "test-file" "build")
                                  (get-in [:args :config-file]))))
           (is (= "test-file" (-> (run-cli "--config-file" "test-file" "build")
-                                 (get-in [:args :config-file]))))))
+                                 (get-in [:args :config-file])))))
+
+        (testing "accepts build sid"
+          (is (= "test-sid" (-> (run-cli "build" "--sid" "test-sid")
+                                (get-in [:args :sid]))))))
 
       (testing "`server` command"
         (testing "runs `server` command"

--- a/app/test/monkey/ci/test/commands_test.clj
+++ b/app/test/monkey/ci/test/commands_test.clj
@@ -21,6 +21,13 @@
                    :runner :build}
                   (sut/build)))))
 
+  (testing "adds build sid to build config"
+    (let [{:keys [sid build-id]} (-> {:args {:sid "a/b/c"}
+                                      :runner :build}
+                                     (sut/build))]
+      (is (= build-id (last sid)))
+      (is (= ["a" "b" "c"] (take 3 sid)))))
+
   (testing "accumulates build results from events"
     (let [registered (atom [])]
       (with-redefs [e/register-handler (fn [_ t _]

--- a/app/test/monkey/ci/test/runners/oci_test.clj
+++ b/app/test/monkey/ci/test/runners/oci_test.clj
@@ -1,0 +1,58 @@
+(ns monkey.ci.test.runners.oci-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [monkey.ci.runners :as r]
+            [monkey.ci.runners.oci :as sut]
+            [monkey.oci.container-instance.core :as ci]))
+
+(deftest make-runner
+  (testing "provides for `:oci` type"
+    (is (some? (get-method r/make-runner :oci)))))
+
+(deftest oci-runner
+  (testing "creates container instance"
+    (let [calls (atom [])]
+      (with-redefs [ci/create-container-instance (fn [_ opts]
+                                                   (swap! calls conj opts))]
+        (is (some? (sut/oci-runner {} {} {})))
+        (is (pos? (count @calls)))
+        (is (some? (:container-instance (first @calls))))))))
+
+(deftest instance-config
+  (let [ctx {:build {:build-id "test-build-id"}}
+        conf {:availability-domain "test-ad"
+              :compartment-id "test-compartment"
+              :image-pull-secrets "test-secrets"
+              :vnics "test-vnics"
+              :image-url "test-image"}
+        inst (sut/instance-config conf ctx)]
+
+    (testing "uses settings from context"
+      (is (= "test-ad" (:availability-domain inst)))
+      (is (= "test-compartment" (:compartment-id inst)))
+      (is (= "test-build-id" (:display-name inst))))
+
+    (testing "never restart"
+      (is (= "NEVER" (:container-restart-policy inst))))
+    
+    (testing "uses ARM shape"
+      (is (= "CI.Standard.A1.Flex" (:shape inst)))
+      (is (= {:ocpus 1
+              :memory-in-g-b-s 1}
+             (:shape-config inst))))
+
+    (testing "uses pull secrets from config"
+      (is (= "test-secrets" (:image-pull-secrets inst))))
+
+    (testing "uses vnics from config"
+      (is (= "test-vnics" (:vnics inst))))
+
+    (testing "adds work volume"
+      (is (= {:name "checkout"
+              :volume-type "EMPTYDIR"}
+             (first (:volumes inst)))))
+
+    (testing "configures container"
+      (is (= 1 (count (:containers inst))))
+      (let [c (first (:containers inst))]
+        (is (re-matches #"test-image:.+" (:image-url c)))
+        (is (string? (:display-name c)))))))


### PR DESCRIPTION
Basic implementation of OCI runner.  It allows a configuration of `:runner {:type :oci}` that starts a container instance instead of running the build script as a child process.  This is only the initial PR, more complete functionality will follow.