### PR TITLE
Multi platform image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,8 @@ jobs:
   docker:
     executor: clj
     environment:
-      IMAGE_TAG: dormeur/monkey-ci:build-<< pipeline.number >>
+      # Push to OCIR
+      IMAGE_TAG: fra.ocir.io/frjdhmocn5qi/monkeyci:build-<< pipeline.number >>
     steps:
       - checkout
       - setup_remote_docker
@@ -212,7 +213,7 @@ jobs:
       # Build the image, tag it with the current job number
       - run:
           name: Build image
-          command: docker build -t $IMAGE_TAG -f docker/Dockerfile .
+          command: docker build -t $IMAGE_TAG -f docker/Dockerfile --platform linux/amd64,linux/arm64 .
       - run:
           name: Docker login
           command: echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin

--- a/.monkeyci/logback.xml
+++ b/.monkeyci/logback.xml
@@ -13,7 +13,7 @@
   <logger name="net" level="WARN"/>
   <logger name="io" level="WARN"/>
   <logger name="monkey.ci" level="DEBUG"/>
-  <logger name="monkey.ci.build" level="INFO"/>
+  <logger name="monkey.ci.build" level="DEBUG"/>
 
   <root level="INFO">
     <appender-ref ref="STDOUT" />

--- a/app/dev-resources/config.edn
+++ b/app/dev-resources/config.edn
@@ -1,5 +1,3 @@
 {:monkeyci-containers-type "podman"
  :monkeyci-work-dir "tmp"
- :monkeyci-log-dir "tmp/logs"
- :monkeyci-storage-type "file"
- :monkeyci-storage-dir "tmp/storage"}
+ :monkeyci-log-dir "tmp/logs"}

--- a/app/env/dev/user.clj
+++ b/app/env/dev/user.clj
@@ -140,9 +140,15 @@
         ctx {:build {:build-id "test-build"}}
         client (ci/make-context conf)
         ic (-> (oci/instance-config conf ctx)
-               (assoc :containers [{:image-url "debian:latest"
+               (assoc :containers [{:image-url "fra.ocir.io/frjdhmocn5qi/monkeyci:0.1.0"
                                     :display-name "test"
-                                    :arguments ["echo" "hello"]}])
-               (dissoc :volumes :image-pull-secrets))]
+                                    :arguments ["-h"]}])
+               (dissoc :volumes))]
     (log/info "Running instance with config:" ic)
     (oci/run-instance client ic)))
+
+(defn make-storage [conf]
+  (-> conf
+      (load-config)
+      :storage
+      (s/make-storage)))

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -15,11 +15,16 @@
   (cs/join "/" sid))
 
 (defn- container-config [conf ctx]
-  (let [checkout "/opt/monkeyci/checkout"]
+  (let [checkout "/opt/monkeyci/checkout"
+        git (get-in ctx [:build :git])]
     {:display-name "build"
      ;; The image url must point to a container running monkeyci cli
      :image-url (str (:image-url conf) ":" (config/version))
-     :arguments ["-w" checkout "build" "--sid" (format-sid (get-in ctx [:build :sid]))]
+     :arguments (cond-> ["-w" checkout "build"
+                         "--sid" (format-sid (get-in ctx [:build :sid]))]
+                  (not-empty git) (concat ["-u" (:url git)
+                                           "-b" (:branch git)
+                                           "--commit-id" (:id git)]))
      :volume-mounts [{:mount-path checkout
                       :is-read-only false
                       :volume-name checkout-vol}]}))

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -41,7 +41,8 @@
                             :memory-in-g-b-s 1}
              ;; Assign a checkout volume where the repo is checked out
              :volumes [{:name checkout-vol
-                        :volume-type "EMPTYDIR"}]
+                        :volume-type "EMPTYDIR"
+                        :backing-store "EPHEMERAL_STORAGE"}]
              :containers [(container-config conf ctx)])))
 
 (defn wait-for-completion

--- a/app/src/monkey/ci/script.clj
+++ b/app/src/monkey/ci/script.clj
@@ -122,7 +122,7 @@
         :index index
         :status status})
      (fn []
-       (let [{:keys [work-dir step] :as ctx} (make-step-dir-absolute ctx)]
+       (let [{:keys [step] :as ctx} (make-step-dir-absolute ctx)]
          (try
            (log/debug "Running step:" step)
            (run-step step ctx)

--- a/app/src/monkey/ci/web/api.clj
+++ b/app/src/monkey/ci/web/api.clj
@@ -102,7 +102,7 @@
          (if (empty? sid)
            acc
            (recur (drop-last sid)
-                  (concat acc (st/find-params st sid)))))
+                  (concat acc (st/find-params st (st/->sid sid))))))
        (group-by :name)
        (vals)
        (map first)))

--- a/app/test/monkey/ci/test/commands_test.clj
+++ b/app/test/monkey/ci/test/commands_test.clj
@@ -119,7 +119,31 @@
                 :work-dir "work-dir"}
                (sut/prepare-build-ctx)
                :build
-               :script-dir)))))
+               :script-dir))))
+
+  (testing "when sid specified"
+    (testing "parses on delimiter"
+      (is (= ["a" "b" "c"]
+             (->> {:args {:sid "a/b/c"}}
+                  (sut/prepare-build-ctx)
+                  :build
+                  :sid
+                  (take 3)))))
+    
+    (testing "adds build id"
+      (is (string? (-> {:args {:sid "a/b/c"}}
+                       (sut/prepare-build-ctx)
+                       :build
+                       :sid
+                       last))))
+
+    (testing "when sid includes build id, reuses it"
+      (let [sid "a/b/c/d"
+            ctx (-> {:args {:sid sid}}
+                    (sut/prepare-build-ctx)
+                    :build)]
+        (is (= "d" (:build-id ctx)))
+        (is (= "d" (last (:sid ctx))))))))
 
 (deftest http-server
   (testing "returns a channel"

--- a/app/test/monkey/ci/test/runners/oci_test.clj
+++ b/app/test/monkey/ci/test/runners/oci_test.clj
@@ -77,7 +77,8 @@
 
     (testing "adds work volume"
       (is (= {:name "checkout"
-              :volume-type "EMPTYDIR"}
+              :volume-type "EMPTYDIR"
+              :backing-store "EPHEMERAL_STORAGE"}
              (first (:volumes inst)))))
 
     (testing "container"

--- a/app/test/monkey/ci/test/runners/oci_test.clj
+++ b/app/test/monkey/ci/test/runners/oci_test.clj
@@ -44,7 +44,10 @@
 
 (deftest instance-config
   (let [ctx {:build {:build-id "test-build-id"
-                     :sid ["a" "b" "c" "test-build-id"]}}
+                     :sid ["a" "b" "c" "test-build-id"]
+                     :git {:url "http://git-url"
+                           :branch "main"
+                           :id "test-commit"}}}
         conf {:availability-domain "test-ad"
               :compartment-id "test-compartment"
               :image-pull-secrets "test-secrets"
@@ -91,7 +94,10 @@
         (testing "provides arguments as to monkeyci build"
           (is (= ["-w" "/opt/monkeyci/checkout"
                   "build"
-                  "--sid" "a/b/c/test-build-id"]
+                  "--sid" "a/b/c/test-build-id"
+                  "-u" "http://git-url"
+                  "-b" "main"
+                  "--commit-id" "test-commit"]
                  (:arguments c))))
 
         (testing "mounts checkout dir"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@ FROM docker.io/clojure:temurin-21-tools-deps
 WORKDIR /var/lib/monkeyci
 ENTRYPOINT ["java", "-jar", "monkeyci.jar"]
 
+# Install podman.  When building multi-platform images, this will only
+# work if qemu is installed
 RUN apt-get update && apt-get install -y podman
 
 ENV MONKEYCI_CONTAINERS_TYPE=podman

--- a/lib/src/monkey/ci/build/shell.clj
+++ b/lib/src/monkey/ci/build/shell.clj
@@ -9,7 +9,7 @@
 
 (defn bash [& args]
   (fn [ctx]
-    (let [work-dir (or (get-in ctx [:step :work-dir]) (:work-dir ctx))]
+    (let [work-dir (or (get-in ctx [:step :work-dir]) (:checkout-dir ctx))]
       (log/debug "Executing shell script with args" args "in work dir" work-dir)
       (try
         (let [opts (cond-> {:out :string
@@ -36,7 +36,7 @@
   (let [v (get (api/build-params ctx) param)
         f (fs/file (fs/expand-home out))
         p (fs/file (fs/parent f))
-        d? (or (fs/exists? p) (.mkdirs p))]
+        d? (or (nil? p) (fs/exists? p) (.mkdirs p))]
     (if (and v d?)
       (spit f v)
       (assoc core/failure :message (if v

--- a/lib/test/monkey/ci/test/build/shell_test.clj
+++ b/lib/test/monkey/ci/test/build/shell_test.clj
@@ -35,11 +35,11 @@
       (let [b (sut/bash "test")]
         #(is (= "test-dir" (:output (b {:step {:work-dir "test-dir"}})))))))
 
-  (testing "uses context work dir if no step dir specified"
+  (testing "uses context checkout dir if no step dir specified"
     (with-redefs-fn {#'bp/shell (fn [opts & _]
                                   {:out (:dir opts)})}
       (let [b (sut/bash "test")]
-        #(is (= "test-dir" (:output (b {:work-dir "test-dir"}))))))))
+        #(is (= "test-dir" (:output (b {:checkout-dir "test-dir"}))))))))
 
 (deftest home
   (testing "provides home directory"
@@ -58,4 +58,10 @@
       (testing "replaces ~ with home dir"
         (with-redefs [spit (fn [f _] f)]
           (is (not (cs/starts-with? (sut/param-to-file {} "test-param" "~/test.txt")
-                                    "~"))))))))
+                                    "~")))))
+
+      (testing "writes when no dir specified"
+        (let [dest (io/file "test.txt")]
+          (is (nil? (sut/param-to-file {} "test-param" dest)))
+          (is (true? (.exists dest)))
+          (is (true? (.delete dest))))))))


### PR DESCRIPTION
Did some work to be able to build a multiplatform image, and also changed the tag to the OCIR private repo.
Multiplatform is only possible if qemu is installed on the build agent, so for now this probably will only work with local build.

This PR also adds some small changes regarding how command line args are handled.  We'll need this when we want to run build scripts using OCI container instances.