### PR TITLE
Remove project

### DIFF
--- a/app/env/dev/config.clj
+++ b/app/env/dev/config.clj
@@ -53,7 +53,7 @@
   (oci-config :container))
 
 (defn account->sid []
-  (let [v (juxt :customer-id :project-id :repo-id)]
+  (let [v (juxt :customer-id :repo-id)]
     (->> @global-config
          :account
          (v)

--- a/app/env/dev/migration.clj
+++ b/app/env/dev/migration.clj
@@ -2,6 +2,8 @@
   (:require [clojure.java.io :as io]
             [clojure.tools.logging :as log]
             [config :refer [load-edn]]
+            [storage :refer [make-storage]]
+            [medley.core :as mc]
             [monkey.ci.storage :as s]))
 
 (defn- migrate-dir [p sid st]
@@ -27,3 +29,146 @@
   (let [f (io/file dir)]
     (log/info "Migrating storage from" (.getCanonicalPath f))
     (migrate-dir f [] st)))
+
+(defn- repo-list [cust]
+  (->> cust
+       :projects
+       (mapcat (fn [[pid p]]
+                 (->> p
+                      :repos
+                      (map (fn [[rid r]]
+                             (assoc r :project-id pid))))))))
+
+(defn- unique-repo-ids? [l]
+  (->> l
+       (group-by :id)
+       (vals)
+       (every? (comp (partial = 1) count))))
+
+(defn- verify-unique-repo-ids! [l]
+  (when-not (unique-repo-ids? l)
+    (throw (ex-info "There are repository id collisions, please fix these first" l))))
+
+(defn- add-project-label [r]
+  (-> r
+      (update :labels conj {:name "project" :value (:project-id r)})
+      (dissoc :project-id)))
+
+(defn- remove-build-projects
+  "Looks up all builds for the repo and rewrites them to remove project from the sid.
+   Returns a list of actions to perform."
+  [st {:keys [customer-id project-id id]}]
+  (let [old-repo-sid [customer-id project-id id]
+        new-sid [customer-id id]
+        builds (s/list-builds st old-repo-sid)]
+    (log/info "Found" (count builds) "builds for repo" old-repo-sid)
+    (mapcat
+     (fn [bid]
+       (let [old-bid (conj old-repo-sid bid)
+             new-bid (conj new-sid bid)
+             ;; Look up build info
+             md  (-> (s/find-build-metadata st old-bid)
+                     (dissoc :project-id))
+             res (s/find-build-results st old-bid)]
+         (log/info "Moving build" bid)
+         ;; Prepare to store objects in new location
+         [{:action :write
+           :obj md
+           :sid (s/build-metadata-sid new-bid)}
+          {:action :write
+           :obj res
+           :sid (s/build-results-sid new-bid)}
+          {:action :delete
+           :sid (s/build-metadata-sid old-bid)}
+          {:action :delete
+           :sid (s/build-results-sid old-bid)}]))
+     builds)))
+
+(defn- remove-parameter-projects
+  "Rewrites parameters so they are only attached to customer.  Project and repo
+   info is replaced with label filters."
+  [st cust repos]
+  (let [cid (:id cust)
+        cust-params {:parameters (s/find-legacy-params st [cid])
+                     :label-filters []}
+        project-params (->> cust
+                            :projects
+                            (keys)
+                            (map (fn [pid]
+                                   [pid {:parameters (s/find-legacy-params st [cid pid])
+                                         :label-filters [[{:label "project" :value pid}]]}]))
+                            (filter (comp not-empty :parameters second))
+                            (into {}))
+        repo-params (->> repos
+                         (map (fn [{:keys [project-id id] :as r}]
+                                [r {:parameters (s/find-legacy-params st [cid project-id id])
+                                    :label-filters [[{:label "project" :value project-id}
+                                                     {:label "repo" :value id}]]}]))
+                         (filter (comp not-empty :parameters second))
+                         (into {}))
+        all-params (-> (concat (when (not-empty (:parameters cust-params))
+                                 [cust-params])
+                               (vals project-params)
+                               (vals repo-params))
+                       (vec))]
+    (log/info "Parameters to migrate:")
+    (log/info "  -" (count (:parameters cust-params)) "customer params")
+    (log/info "  -" (reduce + 0 (map (comp count :parameters) (vals project-params))) "project params")
+    (log/info "  -" (reduce + 0 (map (comp count :parameters) (vals repo-params))) "repository params")
+    (log/info "Total parameter group count:" (count all-params))
+    (concat (when (not-empty all-params)
+              [{:action :write
+                :sid (s/params-sid cid)
+                :obj all-params}])
+            (when (not-empty (:parameters cust-params))
+              [{:action :delete
+                :sid (s/legacy-params-sid [cid])}])
+            (map (fn [[pid]]
+                   {:action :delete
+                    :sid (s/legacy-params-sid [cid pid])})
+                 project-params)
+            (map (fn [[{:keys [project-id id]}]]
+                   {:action :delete
+                    :sid (s/legacy-params-sid [cid project-id id])})
+                 repo-params))))
+
+(defn remove-project-actions
+  "Removes the project from the given customer.  This rewrites the customer,
+   builds and parameters to link the repos directly to the customer.  The
+   project is added to the parameters as a label filter, and to the repos
+   as a label."
+  [cust-id]
+  (let [st (make-storage)
+        cust (s/find-customer st cust-id)
+        repos (repo-list cust)]
+    (log/info "Migrating customer" (:name cust) "to remove project...")
+    (verify-unique-repo-ids! repos)
+    (log/info "Updating customer info...")
+    (let [upd-repos (->> (repo-list cust)
+                         (map add-project-label)
+                         (group-by :id)
+                         (mc/map-vals first))
+          upd {:action :write
+               :sid (s/customer-sid cust-id)
+               :obj (-> cust
+                        (dissoc :projects)
+                        (assoc :repos upd-repos))}
+          actions (concat [upd]
+                          (mapcat (partial remove-build-projects st) repos)
+                          (remove-parameter-projects st cust repos))]
+      (log/info "Actions to execute:" (count actions))
+      actions)))
+
+(defn execute-actions! [actions]
+  (let [st (make-storage)]
+    (log/info "Executing" (count actions) "migration actions")
+    (doseq [a actions]
+      (log/debug "Executing action:" a)
+      (case (:action a)
+        :write  (s/write-obj st (:sid a) (:obj a))
+        :delete (s/delete-obj st (:sid a))))
+    (log/info "Actions executed")))
+
+(defn remove-project! [cust-id]
+  (-> (remove-project-actions cust-id)
+      (execute-actions!)))

--- a/app/src/monkey/ci/cli.clj
+++ b/app/src/monkey/ci/cli.clj
@@ -35,12 +35,12 @@
 
 (def list-build-cmd
   {:command "list"
-   :description "Lists builds for customer, project or repo"
+   :description "Lists builds for customer or repo"
    :runs {:command cmd/list-builds}})
 
 (def watch-cmd
   {:command "watch"
-   :description "Logs build events for customer, project or repo"
+   :description "Logs build events for customer or repo"
    :runs {:command cmd/watch}})
 
 (def build-cmd
@@ -53,10 +53,6 @@
           {:as "Customer id"
            :option "customer-id"
            :short "c"
-           :type :string}
-          {:as "Project id"
-           :option "project-id"
-           :short "p"
            :type :string}
           {:as "Repository id"
            :option "repo-id"

--- a/app/src/monkey/ci/storage.clj
+++ b/app/src/monkey/ci/storage.clj
@@ -166,18 +166,32 @@
   [s sid]
   (list-obj s (concat [builds] sid)))
 
-(defn params-sid [sid]
+(defn ^:deprecated legacy-params-sid [sid]
   ;; Prepend params prefix, but also store at "params" leaf
   (vec (concat ["params"] sid ["params"])))
 
-(defn save-params
+(defn ^:deprecated save-legacy-params
   "Stores build parameters.  This can be done on customer, project or repo level.
    The `sid` is a vector that determines on which level the information is stored."
   [s sid p]
-  (write-obj s (params-sid sid) p))
+  (write-obj s (legacy-params-sid sid) p))
 
-(defn find-params
+(defn ^:deprecated find-legacy-params
   "Loads parameters on the given level.  This does not automatically include the
    parameters of higher levels."
   [s sid]
-  (read-obj s (params-sid sid)))
+  (read-obj s (legacy-params-sid sid)))
+
+;; (def params-sid legacy-params-sid)
+;; (def find-params find-legacy-params)
+;; (def save-params save-legacy-params)
+
+(defn params-sid [customer-id]
+  ;; All parameters for a customer are stored together
+  ["build-params" customer-id])
+
+(defn find-params [s cust-id]
+  (read-obj s (params-sid cust-id)))
+
+(defn save-params [s cust-id p]
+  (write-obj s (params-sid cust-id) p))

--- a/app/src/monkey/ci/storage.clj
+++ b/app/src/monkey/ci/storage.clj
@@ -77,27 +77,27 @@
 (defn find-customer [s id]
   (read-obj s (customer-sid id)))
 
-(defn save-project
+(defn ^:deprecated save-project
   "Saves the project by updating the customer it belongs to"
   [s {:keys [customer-id id] :as pr}]
   (update-obj s (customer-sid customer-id) assoc-in [:projects id] pr))
 
-(defn find-project
+(defn ^:deprecated find-project
   "Reads the project, as part of the customer object"
   [s [cust-id pid]]
   (some-> (find-customer s cust-id)
           (get-in [:projects pid])))
 
 (defn save-repo
-  "Saves the repository by updating the customer and project it belongs to"
-  [s {:keys [customer-id project-id id] :as r}]
-  (update-obj s (customer-sid customer-id) assoc-in [:projects project-id :repos id] r))
+  "Saves the repository by updating the customer it belongs to"
+  [s {:keys [customer-id id] :as r}]
+  (update-obj s (customer-sid customer-id) assoc-in [:repos id] r))
 
 (defn find-repo
   "Reads the repo, as part of the customer object's projects"
-  [s [cust-id p-id id]]
+  [s [cust-id id]]
   (some-> (find-customer s cust-id)
-          (get-in [:projects p-id :repos id])))
+          (get-in [:repos id])))
 
 (def webhook-sid (partial global-sid :webhooks))
 
@@ -108,7 +108,7 @@
   (read-obj s (webhook-sid id)))
 
 (def builds "builds")
-(def build-sid-keys [:customer-id :project-id :repo-id :build-id])
+(def build-sid-keys [:customer-id :repo-id :build-id])
 ;; Build sid, for external representation
 (def ext-build-sid (apply juxt build-sid-keys))
 (def build-sid (comp (partial into [builds])
@@ -181,10 +181,6 @@
    parameters of higher levels."
   [s sid]
   (read-obj s (legacy-params-sid sid)))
-
-;; (def params-sid legacy-params-sid)
-;; (def find-params find-legacy-params)
-;; (def save-params save-legacy-params)
 
 (defn params-sid [customer-id]
   ;; All parameters for a customer are stored together

--- a/app/src/monkey/ci/web/api.clj
+++ b/app/src/monkey/ci/web/api.clj
@@ -2,7 +2,6 @@
   (:require [camel-snake-kebab.core :as csk]
             [clojure.core.async :as ca]
             [clojure.tools.logging :as log]
-            [java-time.api :as jt]
             [medley.core :as mc]
             [monkey.ci
              [context :as ctx]
@@ -273,7 +272,7 @@
                   (select-keys [:customer-id :project-id :repo-id])
                   (assoc :build-id bid
                          :source :api
-                         :timestamp (str (jt/instant))
+                         :timestamp (System/currentTimeMillis)
                          :ref (str "refs/heads/" (get-in p [:query :branch])))
                   (merge (:query p)))]
        (log/debug "Triggering build for repo sid:" repo-sid)

--- a/app/src/monkey/ci/web/handler.clj
+++ b/app/src/monkey/ci/web/handler.clj
@@ -45,16 +45,8 @@
 (s/defschema UpdateCustomer
   (assoc-id NewCustomer))
 
-(s/defschema NewProject
-  {:customer-id Id
-   :name Name})
-
-(s/defschema UpdateProject
-  (assoc-id NewProject))
-
 (s/defschema NewWebhook
   {:customer-id Id
-   :project-id Id
    :repo-id Id})
 
 (s/defschema UpdateWebhook
@@ -62,7 +54,6 @@
 
 (s/defschema NewRepo
   {:customer-id Id
-   :project-id Id
    :name Name
    :url s/Str
    (s/optional-key :labels) [Label]})
@@ -112,10 +103,13 @@
                                                  :body s/Any}}
                              :middleware [:github-security]}]))])
 
-(def parameter-routes
-  ["/param" {:get {:handler api/get-params}
+(def customer-parameter-routes
+  ["/param" {:get {:handler api/get-customer-params}
              :put {:handler api/update-params
                    :parameters {:body [Parameters]}}}])
+
+(def repo-parameter-routes
+  ["/param" {:get {:handler api/get-repo-params}}])
 
 (def build-routes
   ["/builds"
@@ -148,20 +142,8 @@
      :new-schema NewRepo
      :update-schema UpdateRepo
      :id-key :repo-id
-     :child-routes [parameter-routes
+     :child-routes [repo-parameter-routes
                     build-routes]})])
-
-(def project-routes
-  ["/project"
-   (generic-routes
-    {:creator api/create-project
-     :updater api/update-project
-     :getter  api/get-project
-     :new-schema NewProject
-     :update-schema UpdateProject
-     :id-key :project-id
-     :child-routes [repo-routes
-                    parameter-routes]})])
 
 (def customer-routes
   ["/customer"
@@ -172,8 +154,8 @@
      :new-schema NewCustomer
      :update-schema UpdateCustomer
      :id-key :customer-id
-     :child-routes [project-routes
-                    parameter-routes]})])
+     :child-routes [repo-routes
+                    customer-parameter-routes]})])
 
 (def event-stream-routes
   ["/events" {:get {:handler api/event-stream}}])

--- a/app/src/monkey/ci/web/handler.clj
+++ b/app/src/monkey/ci/web/handler.clj
@@ -70,9 +70,20 @@
 (s/defschema UpdateRepo
   (assoc-id NewRepo))
 
+(s/defschema ParameterValue
+  {:name s/Str
+   :value s/Str})
+
+(s/defschema LabelFilterConjunction
+  {:label s/Str
+   :value s/Str})
+
+(s/defschema LabelFilter
+  [LabelFilterConjunction])
+
 (s/defschema Parameters
-  [{:name s/Str
-    :value s/Str}])
+  {:parameters [ParameterValue]
+   :label-filters [LabelFilter]})
 
 (defn- generic-routes
   "Generates generic entity routes.  If child routes are given, they are added
@@ -104,7 +115,7 @@
 (def parameter-routes
   ["/param" {:get {:handler api/get-params}
              :put {:handler api/update-params
-                   :parameters {:body Parameters}}}])
+                   :parameters {:body [Parameters]}}}])
 
 (def build-routes
   ["/builds"

--- a/app/test/monkey/ci/test/storage_test.clj
+++ b/app/test/monkey/ci/test/storage_test.clj
@@ -77,12 +77,15 @@
   (testing "can store on customer level"
     (h/with-memory-store st
       (let [cid (sut/new-id)
-            params [{:name "param-1"
-                     :value "value 1"}
-                    {:name "param-2"
-                     :value "value 2"}]]
-        (is (sut/sid? (sut/save-params st [cid] params)))
-        (is (= params (sut/find-params st [cid])))))))
+            params {:parameters
+                    [{:name "param-1"
+                      :value "value 1"}
+                     {:name "param-2"
+                      :value "value 2"}]
+                    :label-filters
+                    [[{:label "test-label" :value "test-value"}]]}]
+        (is (sut/sid? (sut/save-params st cid params)))
+        (is (= params (sut/find-params st cid)))))))
 
 (deftest patch-build-results
   (testing "reads result, applies f with args, then writes result back"

--- a/app/test/monkey/ci/test/storage_test.clj
+++ b/app/test/monkey/ci/test/storage_test.clj
@@ -44,7 +44,7 @@
         (is (sut/sid? (sut/save-build-results st md {:status :success})))
         (is (= :success (:status (sut/find-build-results st md))))))))
 
-(deftest projects
+(deftest ^:deprecated projects
   (testing "stores project in customer"
     (h/with-memory-store st
       (is (sut/sid? (sut/save-project st {:customer-id "test-customer"
@@ -98,7 +98,7 @@
 (deftest list-builds
   (testing "lists all builds for given repo"
     (h/with-memory-store st
-      (let [repo-sid ["test-customer" "test-project" "test-repo"]
+      (let [repo-sid ["test-customer" "test-repo"]
             builds (->> (range)
                         (map (partial format "build-%d"))
                         (take 2))]
@@ -106,7 +106,7 @@
           (let [sid (conj repo-sid b)]
             (is (sut/sid? (sut/create-build-metadata
                            st
-                           (zipmap [:customer-id :project-id :repo-id :build-id] sid))))))
+                           (zipmap [:customer-id :repo-id :build-id] sid))))))
         (let [l (sut/list-builds st repo-sid)]
           (is (= (count builds) (count l)))
           (is (= builds l)))))))

--- a/app/test/monkey/ci/test/web/api_test.clj
+++ b/app/test/monkey/ci/test/web/api_test.clj
@@ -173,36 +173,37 @@
       (is (= "test-repo-2" (:id r))))))
 
 (deftest get-params
-  (testing "merges with higher levels"
-    (let [{s :storage :as ctx} (test-ctx)
-          [cid pid] (repeatedly st/new-id)]
-      (is (some? (st/save-params s [cid] [{:name "param-1" :value "value 1"}])))
-      (is (some? (st/save-params s [cid pid] [{:name "param-2" :value "value 2"}])))
-      (is (= ["param-1" "param-2"]
-             (->> (-> ctx
-                      (->req)
-                      (with-path-params {:customer-id cid
-                                         :project-id pid})
-                      (sut/get-params)
-                      :body)
-                  (map :name)
-                  (sort))))))
+  (testing "for legacy params"
+    (testing "merges with higher levels"
+      (let [{s :storage :as ctx} (test-ctx)
+            [cid pid] (repeatedly st/new-id)]
+        (is (some? (st/save-legacy-params s [cid] [{:name "param-1" :value "value 1"}])))
+        (is (some? (st/save-legacy-params s [cid pid] [{:name "param-2" :value "value 2"}])))
+        (is (= ["param-1" "param-2"]
+               (->> (-> ctx
+                        (->req)
+                        (with-path-params {:customer-id cid
+                                           :project-id pid})
+                        (sut/get-params)
+                        :body)
+                    (map :name)
+                    (sort))))))
 
-  (testing "gives priority to lower levels"
-    (let [{s :storage :as ctx} (test-ctx)
-          [cid pid rid] (repeatedly st/new-id)]
-      (is (some? (st/save-params s [cid] [{:name "param-1" :value "customer value"}])))
-      (is (some? (st/save-params s [cid pid rid] [{:name "param-1" :value "repo value"}])))
-      (let [r (-> ctx
-                  (->req)
-                  (with-path-params {:customer-id cid
-                                     :project-id pid
-                                     :repo-id rid})
-                  (sut/get-params)
-                  :body)]
-        (is (= "repo value"
-               (-> (zipmap (map :name r) (map :value r))
-                   (get "param-1")))))))
+    (testing "gives priority to lower levels"
+      (let [{s :storage :as ctx} (test-ctx)
+            [cid pid rid] (repeatedly st/new-id)]
+        (is (some? (st/save-legacy-params s [cid] [{:name "param-1" :value "customer value"}])))
+        (is (some? (st/save-legacy-params s [cid pid rid] [{:name "param-1" :value "repo value"}])))
+        (let [r (-> ctx
+                    (->req)
+                    (with-path-params {:customer-id cid
+                                       :project-id pid
+                                       :repo-id rid})
+                    (sut/get-params)
+                    :body)]
+          (is (= "repo value"
+                 (-> (zipmap (map :name r) (map :value r))
+                     (get "param-1"))))))))
 
   (testing "empty vector if no params"
     (is (= [] (-> (test-ctx)

--- a/app/test/monkey/ci/test/web/handler_test.clj
+++ b/app/test/monkey/ci/test/web/handler_test.clj
@@ -219,15 +219,21 @@
                 (test-app)))
           (verify-param-endpoints [desc path]
             (testing (format "parameter endpoints at `%s/param`" desc)
-              (let [params [{:name "test-param"
-                             :value "test value"}]
+              (let [params [{:parameters
+                             [{:name "test-param"
+                               :value "test value"}]
+                             :label-filters []}]
                     path (str path "/param")]
                 (testing "empty when no parameters"
                   (is (empty? (get-params path))))
                 (testing "can write params"
                   (is (= 200 (:status (save-params path params)))))
                 (testing "can read params"
-                  (is (= params (get-params path)))))))]
+                  ;; TODO Refactor this (will be changed anyway when we remove projects)
+                  (is (get-params path)
+                      (= (if (cs/includes? path "project")
+                           (:parameters params)
+                           params)))))))]
     
     (verify-param-endpoints
      "/customer/:customer-id"

--- a/app/test/monkey/ci/test/web/script_api_test.clj
+++ b/app/test/monkey/ci/test/web/script_api_test.clj
@@ -50,12 +50,12 @@
       (is (= :test-server (sut/start-server {:public-api sut/local-api}))))))
 
 (deftest local-api
-  (testing "`get-params` retrieves from local db"
+  (testing "`get-params` retrieves legacy params from local db"
     (let [sid ["test-cust" "test-proj" "test-repo" "test-build"]
           st (st/make-memory-storage)
           api (sut/local-api {:storage st
                               :build {:sid sid}})
           params [{:name "testkey" :value "testvalue"}]]
-      (is (st/sid? (st/save-params st (butlast sid) params)))
+      (is (st/sid? (st/save-legacy-params st (butlast sid) params)))
       (is (fn? api))
       (is (= {"testkey" "testvalue"} (api :get-params))))))

--- a/app/test/monkey/ci/test/web/script_api_test.clj
+++ b/app/test/monkey/ci/test/web/script_api_test.clj
@@ -50,12 +50,14 @@
       (is (= :test-server (sut/start-server {:public-api sut/local-api}))))))
 
 (deftest local-api
-  (testing "`get-params` retrieves legacy params from local db"
-    (let [sid ["test-cust" "test-proj" "test-repo" "test-build"]
+  (testing "`get-params` retrieves params from local db"
+    (let [[cust-id repo-id :as sid] ["test-cust" "test-repo" "test-build"]
           st (st/make-memory-storage)
           api (sut/local-api {:storage st
                               :build {:sid sid}})
-          params [{:name "testkey" :value "testvalue"}]]
-      (is (st/sid? (st/save-legacy-params st (butlast sid) params)))
+          params [{:parameters [{:name "testkey" :value "testvalue"}]}]]
+      (is (st/sid? (st/save-customer st {:id cust-id
+                                         :repos {repo-id {:name "test repo"}}})))
+      (is (st/sid? (st/save-params st cust-id params)))
       (is (fn? api))
       (is (= {"testkey" "testvalue"} (api :get-params))))))

--- a/gui/src/monkey/ci/gui/build/views.cljs
+++ b/gui/src/monkey/ci/gui/build/views.cljs
@@ -21,9 +21,9 @@
 
 (defn- build-path [route]
   (let [p (r/path-params route)
-        get-p (juxt :customer-id :project-id :repo-id :build-id)]
+        get-p (juxt :customer-id :repo-id :build-id)]
     (->> (get-p p)
-         (interleave ["customer" "project" "repo" "builds"])
+         (interleave ["customer" "repo" "builds"])
          (into [m/url])
          (cs/join "/"))))
 
@@ -101,7 +101,7 @@
 
 (defn page [route]
   (let [params (r/path-params route)
-        repo (rf/subscribe [:repo/info (:project-id params) (:repo-id params)])]
+        repo (rf/subscribe [:repo/info (:repo-id params)])]
     [l/default
      [:<>
       [:div.clearfix

--- a/gui/src/monkey/ci/gui/customer/views.cljs
+++ b/gui/src/monkey/ci/gui/customer/views.cljs
@@ -16,23 +16,29 @@
     [:p "Url: " [:a {:href (:url r)} (:url r)]]]
    [:a.btn.btn-primary.float-end
     {:href (r/path-for :page/repo {:customer-id (:id c)
-                                   :project-id (:id p)
                                    :repo-id (:id r)})}
     [co/icon :three-dots-vertical] " Details"]])
 
-(defn- show-project [cust p]
-  (->> (:repos p)
+(defn- show-project [cust [p repos]]
+  (->> repos
        (sort-by :name)
        (map (partial show-repo cust p))
        (into
         [:div.project.card.mb-3
          [:div.card-header
-          [:h5.card-title {:title (:id p)} (:name p)]]])))
+          [:h5.card-title p]]])))
+
+(defn- project-lbl [r]
+  (->> (:labels r)
+       (filter (partial = "project" :name))
+       (map :value)
+       (first)))
 
 (defn- customer-details [id]
   (let [c (rf/subscribe [:customer/info])]
-    (->> (:projects @c)
-         (sort-by :name)
+    (->> (:repos @c)
+         (group-by project-lbl)
+         (sort-by first)
          (map (partial show-project @c))
          (into [:<>
                 [:div.clearfix.mb-3

--- a/gui/src/monkey/ci/gui/martian.cljc
+++ b/gui/src/monkey/ci/gui/martian.cljc
@@ -6,7 +6,7 @@
             [schema.core :as s]))
 
 (def customer-path ["/customer/" :customer-id])
-(def repo-path (into customer-path ["/project/" :project-id "/repo/" :repo-id]))
+(def repo-path (into customer-path ["/repo/" :repo-id]))
 (def build-path (into repo-path ["/builds/" :build-id]))
 
 (def customer-schema
@@ -14,7 +14,6 @@
 
 (def repo-schema
   (assoc customer-schema
-         :project-id s/Str
          :repo-id s/Str))
 
 (def build-schema

--- a/gui/src/monkey/ci/gui/repo/events.cljc
+++ b/gui/src/monkey/ci/gui/repo/events.cljc
@@ -22,7 +22,7 @@
               (db/set-builds nil))
       :dispatch [:martian.re-frame/request
                  :get-builds
-                 (select-keys params [:customer-id :project-id :repo-id])
+                 (select-keys params [:customer-id :repo-id])
                  [:builds/load--success]
                  [:builds/load--failed]]})))
 

--- a/gui/src/monkey/ci/gui/repo/subs.cljc
+++ b/gui/src/monkey/ci/gui/repo/subs.cljc
@@ -7,10 +7,9 @@
 (rf/reg-sub
  :repo/info
  :<- [:customer/info]
- (fn [c [_ proj-id repo-id]]
+ (fn [c [_ repo-id]]
    ;; TODO Optimize customer structure for faster lookup
-   (some->> (:projects c)
-            (u/find-by-id proj-id)
+   (some->> c
             :repos
             (u/find-by-id repo-id))))
 

--- a/gui/src/monkey/ci/gui/repo/views.cljs
+++ b/gui/src/monkey/ci/gui/repo/views.cljs
@@ -40,14 +40,14 @@
 (defn page [route]
   (rf/dispatch [:repo/load (get-in route [:parameters :path :customer-id])])
   (fn [route]
-    (let [{:keys [customer-id project-id repo-id] :as p} (get-in route [:parameters :path])
-          r (rf/subscribe [:repo/info project-id repo-id])]
+    (let [{:keys [customer-id repo-id] :as p} (get-in route [:parameters :path])
+          r (rf/subscribe [:repo/info repo-id])]
       [l/default
        [:<>
         [:h3
          (:name @r)
          [:span.fs-6.p-1
-          [cl/clipboard-copy (u/->sid p :customer-id :project-id :repo-id) "Click to save the sid to clipboard"]]]
+          [cl/clipboard-copy (u/->sid p :customer-id :repo-id) "Click to save the sid to clipboard"]]]
         [:p "Repository url: " [:a {:href (:url @r)} (:url @r)]]
         [co/alerts [:repo/alerts]]
         [builds]

--- a/gui/src/monkey/ci/gui/routing.cljs
+++ b/gui/src/monkey/ci/gui/routing.cljs
@@ -23,9 +23,8 @@
    [["/" :page/root]
     ["/login" :page/login]
     ["/c/:customer-id" :page/customer]
-    ["/c/:customer-id/p/:project-id" :page/project]
-    ["/c/:customer-id/p/:project-id/r/:repo-id" :page/repo]
-    ["/c/:customer-id/p/:project-id/r/:repo-id/b/:build-id" :page/build]]))
+    ["/c/:customer-id/r/:repo-id" :page/repo]
+    ["/c/:customer-id/r/:repo-id/b/:build-id" :page/build]]))
 
 (defn on-route-change [match history]
   (println "Route changed:" match)

--- a/gui/test/monkey/ci/gui/test/repo/subs_test.cljc
+++ b/gui/test/monkey/ci/gui/test/repo/subs_test.cljc
@@ -13,7 +13,7 @@
 (rf/clear-subscription-cache!)
 
 (deftest repo-info
-  (let [r (rf/subscribe [:repo/info "test-project" "test-repo"])]
+  (let [r (rf/subscribe [:repo/info "test-repo"])]
     (testing "exists"
       (is (some? r)))
     
@@ -21,11 +21,9 @@
       (is (nil? @r))
       (is (map? (reset! app-db (cdb/set-customer
                                 {}
-                                {:projects
-                                 [{:id "test-project"
-                                   :repos
-                                   [{:id "test-repo"
-                                     :name "test repository"}]}]}))))
+                                {:repos
+                                 [{:id "test-repo"
+                                   :name "test repository"}]}))))
       (is (= "test repository" (:name @r))))))
 
 (deftest alerts
@@ -47,15 +45,13 @@
                                     {:parameters
                                      {:path
                                       {:customer-id "test-cust"
-                                       :project-id "test-proj"
                                        :repo-id "test-repo"}}}}
                                    (db/set-builds [{:id ::test-build}])))))
       (is (= 1 (count @b)))
       (is (= {:build-id ::test-build
               :customer-id "test-cust"
-              :project-id "test-proj"
               :repo-id "test-repo"}
-             (select-keys (first @b) [:build-id :customer-id :project-id :repo-id]))))
+             (select-keys (first @b) [:build-id :customer-id :repo-id]))))
 
     (testing "sorts by time descending"
       (is (map? (reset! app-db (db/set-builds {} [{:id "old-build"

--- a/gui/test/monkey/ci/gui/test/routing_test.cljs
+++ b/gui/test/monkey/ci/gui/test/routing_test.cljs
@@ -42,7 +42,6 @@
            (sut/path-for :page/customer {:customer-id "test-customer"}))))
 
   (testing "sets multiple path parameters"
-    (is (= "/c/cust/p/proj/r/repo"
+    (is (= "/c/cust/r/repo"
            (sut/path-for :page/repo {:customer-id "cust"
-                                     :project-id "proj"
                                      :repo-id "repo"})))))


### PR DESCRIPTION
Refactor to remove project from customers.  Repos now are directly part of customers.  Projects are migrated to labels, and build parameters are now exposed to repos according to the label filters.  This makes for a much more flexible way to apply parameters.  And also to organize repos: the user can now decide on their own how to group repos using labels.