### PR TITLE
Feature/ssh keys

### DIFF
--- a/app/env/dev/git.clj
+++ b/app/env/dev/git.clj
@@ -8,6 +8,6 @@
               :dir (str dir "/checkout")
               :ssh-keys [{:private-key priv
                           :public-key pub}]
-              :ssh-key-dir (str dir "/keys")}]
+              :ssh-keys-dir (str dir "/keys")}]
     (println "Cloning from" url "using private key" pk)
     (g/clone opts)))

--- a/app/env/dev/git.clj
+++ b/app/env/dev/git.clj
@@ -1,0 +1,13 @@
+(ns git
+  (:require [monkey.ci.git :as g]))
+
+(defn clone-private [url dir pk]
+  (let [priv (slurp pk)
+        pub (slurp (str pk ".pub"))
+        opts {:url url
+              :dir (str dir "/checkout")
+              :ssh-keys [{:private-key priv
+                          :public-key pub}]
+              :ssh-key-dir (str dir "/keys")}]
+    (println "Cloning from" url "using private key" pk)
+    (g/clone opts)))

--- a/app/env/dev/logging.clj
+++ b/app/env/dev/logging.clj
@@ -38,3 +38,7 @@
 (defn get-log [path]
   (-> @(call-os os/get-object {:object-name path})
       (bs/to-string)))
+
+(defn move-log [from to]
+  @(call-os os/rename-object {:rename {:source-name from
+                                       :new-name to}}))

--- a/app/env/dev/server.clj
+++ b/app/env/dev/server.clj
@@ -23,7 +23,8 @@
                      (assoc :config (-> @co/global-config
                                         (merge {:dev-mode true
                                                 :work-dir (u/abs-path "tmp")
-                                                :checkout-base-dir (u/abs-path "tmp/checkout")})))
+                                                :checkout-base-dir (u/abs-path "tmp/checkout")
+                                                :ssh-keys-dir (u/abs-path "tmp/ssh-keys")})))
                      (sc/subsystem [:http])
                      (sc/start-system)))
   nil)

--- a/app/src/monkey/ci/components.clj
+++ b/app/src/monkey/ci/components.clj
@@ -60,8 +60,7 @@
 
 (def default-context
   {:git {:fn (fn default-git-clone [opts]
-               (->> ((juxt :url :branch :id :dir) opts)
-                    (apply git/clone+checkout))
+               (git/clone+checkout opts)
                ;; Return the checkout dir
                (:dir opts))}})
 

--- a/app/src/monkey/ci/config.clj
+++ b/app/src/monkey/ci/config.clj
@@ -134,8 +134,14 @@
                                         (:work-dir conf)
                                         (u/cwd)))))
 
+(defn- dir-or-work-sub [conf k d]
+  (update conf k #(or (u/abs-path %) (u/combine (:work-dir conf) d))))
+
 (defn- set-checkout-base-dir [conf]
-  (update conf :checkout-base-dir #(or (u/abs-path %) (u/combine (:work-dir conf) "checkout"))))
+  (dir-or-work-sub conf :checkout-base-dir "checkout"))
+
+(defn- set-ssh-keys-dir [conf]
+  (dir-or-work-sub conf :ssh-keys-dir "ssh-keys"))
 
 (defn- set-log-dir [conf]
   (update conf
@@ -173,6 +179,7 @@
       (set-work-dir)
       (set-checkout-base-dir)
       (set-log-dir)
+      (set-ssh-keys-dir)
       (set-account)))
 
 (defn- configure-blob [k ctx]

--- a/app/src/monkey/ci/context.clj
+++ b/app/src/monkey/ci/context.clj
@@ -9,15 +9,21 @@
              [logging :as l]
              [utils :as u]]))
 
+(defn- build-related-dir
+  ([ctx base-dir-key build-id]
+   (some-> ctx
+           (base-dir-key)
+           (u/combine build-id)))
+  ([ctx base-dir-key]
+   (build-related-dir ctx base-dir-key (get-in ctx [:build :build-id]))))
+
 (defn checkout-dir
   "Calculates the checkout directory for the build, by combining the checkout
    base directory and the build id."
-  ([ctx build-id]
-   (some-> ctx
-           :checkout-base-dir
-           (u/combine build-id)))
   ([ctx]
-   (checkout-dir ctx (get-in ctx [:build :build-id]))))
+   (build-related-dir ctx :checkout-base-dir))
+  ([ctx build-id]
+   (build-related-dir ctx :checkout-base-dir build-id)))
 
 (defn ^:deprecated log-dir
   "Gets the directory where to store log files"

--- a/app/src/monkey/ci/context.clj
+++ b/app/src/monkey/ci/context.clj
@@ -10,20 +10,21 @@
              [utils :as u]]))
 
 (defn- build-related-dir
-  ([ctx base-dir-key build-id]
+  ([base-dir-key ctx build-id]
    (some-> ctx
            (base-dir-key)
            (u/combine build-id)))
-  ([ctx base-dir-key]
+  ([base-dir-key ctx]
    (build-related-dir ctx base-dir-key (get-in ctx [:build :build-id]))))
 
-(defn checkout-dir
+(def checkout-dir
   "Calculates the checkout directory for the build, by combining the checkout
    base directory and the build id."
-  ([ctx]
-   (build-related-dir ctx :checkout-base-dir))
-  ([ctx build-id]
-   (build-related-dir ctx :checkout-base-dir build-id)))
+  (partial build-related-dir :checkout-base-dir))
+
+(def ssh-keys-dir
+  "Calculates ssh keys dir for the build"
+  (partial build-related-dir :ssh-keys-dir))
 
 (defn ^:deprecated log-dir
   "Gets the directory where to store log files"

--- a/app/src/monkey/ci/git.clj
+++ b/app/src/monkey/ci/git.clj
@@ -6,12 +6,20 @@
             [clojure.tools.logging :as log]
             [monkey.ci.utils :as u]))
 
+(defn prepare-ssh-keys
+  "Writes any ssh keys in the options to a temp directory and returns their
+   file names and key dir to be used by clj-jgit."
+  [opts]
+  ;; TODO
+  )
+
 (defn clone
   "Clones the repo at given url, and checks out the given branch.  Writes the
    files to `dir`.  Returns a repo object that can be passed to other functions."
-  [url branch dir]
+  [{:keys [url branch dir] :as opts}]
   (log/debug "Cloning" url "into" dir)
-  (git/with-identity {:trust-all? true}
+  (git/with-identity (merge {:trust-all? true}
+                            (prepare-ssh-keys opts))
     (git/git-clone url
                    :branch branch
                    :dir dir
@@ -32,8 +40,8 @@
 
 (defn clone+checkout
   "Clones the repo, then performs a checkout of the given id"
-  [url branch id dir]
-  (let [repo (clone url branch dir)]
+  [{:keys [branch id] :as opts}]
+  (let [repo (clone opts)]
     (when-let [id-or-branch (or id (prefix-origin branch))]
       (checkout repo id-or-branch))
     repo))

--- a/app/src/monkey/ci/git.clj
+++ b/app/src/monkey/ci/git.clj
@@ -10,10 +10,10 @@
 (defn prepare-ssh-keys
   "Writes any ssh keys in the options to a temp directory and returns their
    file names and key dir to be used by clj-jgit."
-  [{:keys [ssh-keys ssh-key-dir]}]
-  (when-let [f (io/file ssh-key-dir)]
+  [{:keys [ssh-keys ssh-keys-dir]}]
+  (when-let [f (io/file ssh-keys-dir)]
     (when-not (or (.exists f) (.mkdirs f))
-      (throw (ex-info "Unable to create ssh key dir" {:dir ssh-key-dir})))
+      (throw (ex-info "Unable to create ssh key dir" {:dir ssh-keys-dir})))
     (log/debug "Writing" (count ssh-keys) "ssh keys to" f)
     (->> ssh-keys
          (map-indexed (fn [idx r]
@@ -29,7 +29,7 @@
                           (merge r (zipmap [:public-key-file :private-key-file] (map str names))))))
          (doall)
          (mapv :private-key-file)
-         (hash-map :key-dir ssh-key-dir :name))))
+         (hash-map :key-dir ssh-keys-dir :name))))
 
 (defn clone
   "Clones the repo at given url, and checks out the given branch.  Writes the

--- a/app/src/monkey/ci/labels.clj
+++ b/app/src/monkey/ci/labels.clj
@@ -1,0 +1,24 @@
+(ns monkey.ci.labels)
+
+(defn apply-label-filters
+  "Given a single set of parameters with label filters, checks if the given
+   labels match.  If there is at least one filter in the params' `:label-filters`
+   for which all labels in the conjunction match, this returns `true`.  If
+   the params don't have any labels, this assumes all labels match."
+  [labels params]
+  (letfn [(filter-applies? [{:keys [label value]}]
+            ;; TODO Add support for regexes
+            (= value (get labels label)))
+          (conjunction-applies? [parts]
+            (every? filter-applies? parts))
+          (disjunction-applies? [parts]
+            (or (empty? parts)
+                (some conjunction-applies? parts)))]
+    (disjunction-applies? (:label-filters params))))
+
+(defn labels->map [l]
+  (->> (map (juxt :name :value) l)
+       (into {})))
+
+(defn filter-by-label [repo entities]
+  (filter (partial apply-label-filters (labels->map (:labels repo))) entities))

--- a/app/src/monkey/ci/runners.clj
+++ b/app/src/monkey/ci/runners.clj
@@ -38,17 +38,20 @@
     :error   (log/error "Failure.")
     :unknown (log/warn "Unknown result.")))
 
-(defn- cleanup-checkout-dir!
+(defn- cleanup-dir! [dir]
+  (when (and dir (not= dir (u/cwd)))
+    (log/debug "Cleaning up dir" dir)
+    (u/delete-dir dir)))
+
+(defn- cleanup-checkout-dirs!
   "Deletes the checkout dir, but only if it is not the current working directory."
   [build]
-  (let [wd (get-in build [:git :dir])]
-    (when (and wd (not= wd (u/cwd)))
-      (log/debug "Cleaning up checkout dir" wd)
-      (u/delete-dir wd))))
+  (doseq [k [:dir :ssh-keys-dir]]
+    (cleanup-dir! (get-in build [:git k]))))
 
 (defn build-completed [{{:keys [exit] :as evt} :event :keys [build]}]
   (log-build-result evt)
-  (cleanup-checkout-dir! build)
+  (cleanup-checkout-dirs! build)
   exit)
 
 (defn build-completed-tx [ctx]

--- a/app/src/monkey/ci/spec.clj
+++ b/app/src/monkey/ci/spec.clj
@@ -89,6 +89,7 @@
 (s/def :conf/log-dir string?)
 (s/def :conf/work-dir string?)
 (s/def :conf/checkout-base-dir string?)
+(s/def :conf/ssh-keys-dir string?)
 (s/def :conf/url url?)
 
 ;; Account configuration
@@ -168,7 +169,7 @@
 
 ;; Application configuration
 (s/def ::app-config (s/keys :req-un [:conf/http :conf/runner :conf/args :conf/logging
-                                     :conf/work-dir :conf/checkout-base-dir]
+                                     :conf/work-dir :conf/checkout-base-dir :conf/ssh-keys-dir]
                             :opt-un [:conf/dev-mode :conf/containers :conf/log-dir
                                      :conf/storage :conf/account :conf/sidecar :conf/workspace]))
 ;; Application context.  This is the result of processing the configuration and is passed

--- a/app/src/monkey/ci/storage.clj
+++ b/app/src/monkey/ci/storage.clj
@@ -77,17 +77,6 @@
 (defn find-customer [s id]
   (read-obj s (customer-sid id)))
 
-(defn ^:deprecated save-project
-  "Saves the project by updating the customer it belongs to"
-  [s {:keys [customer-id id] :as pr}]
-  (update-obj s (customer-sid customer-id) assoc-in [:projects id] pr))
-
-(defn ^:deprecated find-project
-  "Reads the project, as part of the customer object"
-  [s [cust-id pid]]
-  (some-> (find-customer s cust-id)
-          (get-in [:projects pid])))
-
 (defn save-repo
   "Saves the repository by updating the customer it belongs to"
   [s {:keys [customer-id id] :as r}]
@@ -191,3 +180,12 @@
 
 (defn save-params [s cust-id p]
   (write-obj s (params-sid cust-id) p))
+
+(defn ssh-keys-sid [cust-id]
+  ["ssh-keys" cust-id])
+
+(defn save-ssh-keys [s cust-id key]
+  (write-obj s (ssh-keys-sid cust-id) key))
+
+(defn find-ssh-keys [s cust-id]
+  (read-obj s (ssh-keys-sid cust-id)))

--- a/app/src/monkey/ci/web/api.clj
+++ b/app/src/monkey/ci/web/api.clj
@@ -279,6 +279,7 @@
                   (merge (:query p)))]
        (log/debug "Triggering build for repo sid:" repo-sid)
        (when (st/create-build-metadata st md)
+         ;; TODO Add ssh keys
          (trigger-build-event p bid repo))))))
 
 (defn list-build-logs [req]

--- a/app/src/monkey/ci/web/api.clj
+++ b/app/src/monkey/ci/web/api.clj
@@ -6,6 +6,7 @@
             [monkey.ci
              [context :as ctx]
              [events :as e]
+             [labels :as lbl]
              [logging :as l]
              [storage :as st]
              [utils :as u]]
@@ -131,77 +132,53 @@
                       repo-sid))
 (def customer-id (comp :customer-id :path :parameters))
 
-(defn apply-label-filters
-  "Given a single set of parameters with label filters, checks if the given
-   labels match.  If there is at least one filter in the params' `:label-filters`
-   for which all labels in the conjunction match, this returns `true`.  If
-   the params don't have any labels, this assumes all labels match."
-  [labels params]
-  (letfn [(filter-applies? [{:keys [label value]}]
-            ;; TODO Add support for regexes
-            (= value (get labels label)))
-          (conjunction-applies? [parts]
-            (every? filter-applies? parts))
-          (disjunction-applies? [parts]
-            (or (empty? parts)
-                (some conjunction-applies? parts)))]
-    (disjunction-applies? (:label-filters params))))
-
-(defn labels->map [l]
-  (->> (map (juxt :name :value) l)
-       (into {})))
-
-(defn fetch-all-params
-  "Fetches all params that apply to the given sid from storage.  For legacy
-   parameters, this adds all those from higher levels too.  For label-filtered
-   parameters, adds those where the repo labels apply.  For a project, the
-   label `monkeyci/project` is used.  Parameters that don't have any filters
-   are applied to all projects and repos."
-  ([st cust-id repo]
-   (->> (st/find-params st cust-id)
-        (filter (partial apply-label-filters (labels->map (:labels repo))))
-        (mapcat :parameters)))
-  ([st [cust-id repo-id]]
-   (fetch-all-params st cust-id (st/find-repo st [cust-id repo-id]))))
-
-(defn get-customer-params
-  "Retrieves all parameters configured on the customer.  This is for administration purposes."
-  [req]
+(defn- get-list-for-customer [finder req]
   (-> (c/req->storage req)
-      (st/find-params (customer-id req))
+      (finder (customer-id req))
       (or [])
       (rur/response)))
 
-(defn get-repo-params
-  "Retrieves the parameters that are available for the given repository.  This depends
-   on the parameter label filters and the repository labels."
-  [req]
+(defn- update-for-customer [updater req]
+  (let [p (body req)]
+    ;; TODO Allow patching values so we don't have to send back all secrets to client
+    (when (updater (c/req->storage req) (customer-id req) p)
+      (rur/response p))))
+
+(defn- get-for-repo-by-label
+  "Uses the finder to retrieve a list of entities for the repository specified
+   by the request.  Then filters them using the repo labels and their configured
+   label filters.  Applies the transducer `tx` before constructing the response."
+  [finder tx req]
   (let [st (c/req->storage req)
         repo-sid ((juxt :customer-id :repo-id) (get-in req [:parameters :path]))
         repo (st/find-repo st repo-sid)]
     (if repo
-      (-> st
-          (fetch-all-params (customer-id req) repo)
-          (rur/response))
+      (->> (finder st (customer-id req))
+           (lbl/filter-by-label repo)
+           (into [] tx)
+           (rur/response))
       (rur/not-found {:message (format "Repository %s does not exist" repo-sid)}))))
 
-(defn ^:deprecated get-params
-  "Retrieves build parameters for the given location.  This could be at customer, 
-   project or repo level.  This returns all parameters that are available for the
-   given entity."
-  [req]
-  ;; TODO Allow to retrieve only for the specified level using query param
-  ;; TODO Return 404 if customer, project or repo not found.
-  ;; TODO Split this up in a method for customer params and one for repo params.
-  (if (= 1 (count (params-sid req)))
-    (get-customer-params req)
-    (get-repo-params req)))
+(def get-customer-params
+  "Retrieves all parameters configured on the customer.  This is for administration purposes."
+  (partial get-list-for-customer st/find-params))
 
-(defn update-params [req]
-  (let [p (body req)]
-    ;; TODO Allow patching parameters so we don't have to send back all secrets to client
-    (when (st/save-params (c/req->storage req) (customer-id req) p)
-      (rur/response p))))
+(def get-repo-params
+  "Retrieves the parameters that are available for the given repository.  This depends
+   on the parameter label filters and the repository labels."
+  (partial get-for-repo-by-label st/find-params (mapcat :parameters)))
+
+(def update-params
+  (partial update-for-customer st/save-params))
+
+(def get-customer-ssh-keys
+  (partial get-list-for-customer st/find-ssh-keys))
+
+(def get-repo-ssh-keys
+  (partial get-for-repo-by-label st/find-ssh-keys (map :private-key)))
+
+(def update-ssh-keys
+  (partial update-for-customer st/save-ssh-keys))
 
 (defn- fetch-build-details [s sid]
   (log/debug "Fetching details for build" sid)

--- a/app/src/monkey/ci/web/api.clj
+++ b/app/src/monkey/ci/web/api.clj
@@ -251,9 +251,8 @@
 (defn trigger-build-event [{p :parameters :as req} bid]
   (let [acc (:path p)
         st (c/req->storage req)
-        repo-sid (repo-sid req)
-        repo (st/find-repo st repo-sid)
-        ssh-keys (->> (st/find-ssh-keys st (first repo-sid))
+        repo (st/find-repo st (repo-sid req))
+        ssh-keys (->> (st/find-ssh-keys st (customer-id req))
                       (lbl/filter-by-label repo))]
     {:type :build/triggered
      :account acc
@@ -261,7 +260,7 @@
              :git (-> (:query p)
                       (select-keys [:commit-id])
                       (assoc :url (:url repo)
-                             :ssh-keys-dir (c/from-context req :ssh-keys-dir))
+                             :ssh-keys-dir (ctx/ssh-keys-dir (c/req->ctx req) bid))
                       (mc/assoc-some :ref (params->ref p))
                       (mc/assoc-some :ssh-keys ssh-keys))
              :sid (-> acc

--- a/app/src/monkey/ci/web/github.clj
+++ b/app/src/monkey/ci/web/github.clj
@@ -7,8 +7,10 @@
             [clojure.core.async :refer [go <!! <!]]
             [clojure.java.io :as io]
             [clojure.tools.logging :as log]
+            [medley.core :as mc]
             [monkey.ci
              [context :as ctx]
+             [labels :as lbl]
              [storage :as s]
              [utils :as u]]
             [monkey.ci.web.common :as c]
@@ -71,6 +73,13 @@
         :id (req->webhook-id req)
         :payload (:body-params req)}))))
 
+(defn- find-ssh-keys [st {:keys [customer-id repo-id]}]
+  (let [repo (s/find-repo st [customer-id repo-id])
+        ssh-keys (s/find-ssh-keys st customer-id)]
+    (->> ssh-keys
+         (lbl/filter-by-label repo)
+         (map :private-key))))
+
 (defn prepare-build
   "Event handler that looks up details for the given github webhook.  If the webhook 
    refers to a valid configuration, a build id is created and a new event is launched,
@@ -90,10 +99,12 @@
                             :head-commit
                             (select-keys [:timestamp :message :author])))
                  (merge (select-keys payload [:ref])))
-          conf {:git {:url (if private ssh-url clone-url)
-                      :main-branch master-branch
-                      :ref (:ref payload)
-                      :id commit-id}
+          ssh-keys (find-ssh-keys st details)
+          conf {:git (-> {:url (if private ssh-url clone-url)
+                          :main-branch master-branch
+                          :ref (:ref payload)
+                          :id commit-id}
+                         (mc/assoc-some :ssh-keys ssh-keys))
                 :sid (s/ext-build-sid md) ; Build storage id
                 :build-id build-id}]
       (when (s/create-build-metadata st md)

--- a/app/src/monkey/ci/web/github.clj
+++ b/app/src/monkey/ci/web/github.clj
@@ -102,7 +102,7 @@
                           :main-branch master-branch
                           :ref (:ref payload)
                           :id commit-id
-                          :ssh-keys-dir (:ssh-keys-dir ctx)}
+                          :ssh-keys-dir (ctx/ssh-keys-dir ctx build-id)}
                          (mc/assoc-some :ssh-keys ssh-keys))
                 :sid (s/ext-build-sid md) ; Build storage id
                 :build-id build-id}]

--- a/app/src/monkey/ci/web/handler.clj
+++ b/app/src/monkey/ci/web/handler.clj
@@ -78,6 +78,7 @@
 
 (s/defschema SshKeys
   {:private-key s/Str
+   :public-key s/Str ; TODO It may be possible to extract public key from private
    (s/optional-key :description) s/Str
    :label-filters [LabelFilter]})
 

--- a/app/src/monkey/ci/web/handler.clj
+++ b/app/src/monkey/ci/web/handler.clj
@@ -76,6 +76,11 @@
   {:parameters [ParameterValue]
    :label-filters [LabelFilter]})
 
+(s/defschema SshKeys
+  {:private-key s/Str
+   (s/optional-key :description) s/Str
+   :label-filters [LabelFilter]})
+
 (defn- generic-routes
   "Generates generic entity routes.  If child routes are given, they are added
    as additional routes after the full path."
@@ -111,6 +116,14 @@
 (def repo-parameter-routes
   ["/param" {:get {:handler api/get-repo-params}}])
 
+(def customer-ssh-keys-routes
+  ["/ssh-keys" {:get {:handler api/get-customer-ssh-keys}
+                :put {:handler api/update-ssh-keys
+                      :parameters {:body [SshKeys]}}}])
+
+(def repo-ssh-keys-routes
+  ["/ssh-keys" {:get {:handler api/get-repo-ssh-keys}}])
+
 (def build-routes
   ["/builds"
    {:conflicting true}
@@ -143,6 +156,7 @@
      :update-schema UpdateRepo
      :id-key :repo-id
      :child-routes [repo-parameter-routes
+                    repo-ssh-keys-routes
                     build-routes]})])
 
 (def customer-routes
@@ -155,7 +169,8 @@
      :update-schema UpdateCustomer
      :id-key :customer-id
      :child-routes [repo-routes
-                    customer-parameter-routes]})])
+                    customer-parameter-routes
+                    customer-ssh-keys-routes]})])
 
 (def event-stream-routes
   ["/events" {:get {:handler api/event-stream}}])

--- a/app/test/monkey/ci/test/components_test.clj
+++ b/app/test/monkey/ci/test/components_test.clj
@@ -66,26 +66,15 @@
                      (c/start)
                      :git
                      :fn)
+          opts {:url "test-url"
+                :branch "test-branch"
+                :dir "test-dir"
+                :id "test-id"}
           captured-args (atom [])]
       (with-redefs [git/clone+checkout (fn [& args]
                                          (reset! captured-args args))]
-        (is (= "test-dir" (git-fn {:url "test-url"
-                                   :branch "test-branch"
-                                   :dir "test-dir"
-                                   :id "test-id"})))
-        (is (= ["test-url" "test-branch" "test-id" "test-dir"] @captured-args)))))
-
-  (testing "passes `nil` for missing opts"
-    (let [git-fn (-> (sut/new-context nil)
-                     (c/start)
-                     :git
-                     :fn)
-          captured-args (atom [])]
-      (with-redefs [git/clone+checkout (fn [& args]
-                                         (reset! captured-args args))]
-        (is (= "test-dir" (git-fn {:url "test-url"
-                                   :dir "test-dir"})))
-        (is (= ["test-url" nil nil "test-dir"] @captured-args)))))
+        (is (= "test-dir" (git-fn opts)))
+        (is (= [opts] @captured-args)))))
 
   (testing "sets storage"
     (is (= :test-storage (-> (sut/new-context :test-cmd)

--- a/app/test/monkey/ci/test/git_test.clj
+++ b/app/test/monkey/ci/test/git_test.clj
@@ -8,7 +8,9 @@
     (with-redefs [git/git-clone (fn [& args]
                                   args)]
       (is (= ["http://url" :branch "master" :dir "tmp" :no-checkout? true]
-             (sut/clone "http://url" "master" "tmp"))))))
+             (sut/clone {:url "http://url"
+                         :branch "master"
+                         :dir "tmp"}))))))
 
 (deftest checkout
   (testing "invokes `git-checkout`"
@@ -24,7 +26,10 @@
                                  {:repo repo
                                   :id id})]
       (is (= :test-repo
-             (sut/clone+checkout "http://test-url" "main" "test-id" "test-dir")))))
+             (sut/clone+checkout {:url "http://test-url"
+                                  :branch "main"
+                                  :id "test-id"
+                                  :dir "test-dir"})))))
 
   (testing "when no commit id, checks out branch instead"
     (let [checkout-ids (atom nil)]
@@ -32,5 +37,13 @@
                     sut/checkout (fn [_ id]
                                    (reset! checkout-ids id))]
         (is (= :test-repo
-               (sut/clone+checkout "http://test-url" "main" nil "test-dir")))
+               (sut/clone+checkout {:url "http://test-url"
+                                    :branch "main"
+                                    :dir "test-dir"})))
         (is (= "origin/main" @checkout-ids))))))
+
+(deftest prepare-ssh-keys
+  (testing "empty if no keys configured"
+    (is (empty? (sut/prepare-ssh-keys {}))))
+
+  (testing "writes keys to configured dir"))

--- a/app/test/monkey/ci/test/git_test.clj
+++ b/app/test/monkey/ci/test/git_test.clj
@@ -75,6 +75,6 @@
         (is (= {:key-dir ssh-dir
                 :name ["key-0"]}
                (sut/prepare-ssh-keys {:ssh-keys [keys]
-                                      :ssh-key-dir ssh-dir})))
+                                      :ssh-keys-dir ssh-dir})))
         (is (fs/exists? (fs/path ssh-dir "key-0")))
         (is (fs/exists? (fs/path ssh-dir "key-0.pub")))))))

--- a/app/test/monkey/ci/test/git_test.clj
+++ b/app/test/monkey/ci/test/git_test.clj
@@ -1,7 +1,11 @@
 (ns monkey.ci.test.git-test
   (:require [clojure.test :refer [deftest testing is]]
+            [babashka.fs :as fs]
+            [buddy.core.codecs :as bcc]
             [clj-jgit.porcelain :as git]
-            [monkey.ci.git :as sut]))
+            [monkey.ci.git :as sut]
+            [monkey.ci.test.helpers :as h]
+            [monkey.oci.common.utils :as ocu]))
 
 (deftest clone
   (testing "invokes `git-clone` without checking out"
@@ -42,8 +46,35 @@
                                     :dir "test-dir"})))
         (is (= "origin/main" @checkout-ids))))))
 
+(defn- make-keypair []
+  (-> (doto (java.security.KeyPairGenerator/getInstance "RSA")
+        (.initialize 2048))
+      (.generateKeyPair)))
+
+(defn- keypair-base64
+  "Generates a new RSA keypair and returns the public and private keys as base64
+   encoded strings."
+  []
+  (let [r (->> (make-keypair)
+               ((juxt (memfn getPrivate) (memfn getPublic)))
+               (map (comp #(String. %) bcc/bytes->b64 (memfn getEncoded)))
+               (zipmap [:private-key :public-key]))]
+    (-> r
+        (update :private-key #(str "----BEGIN RSA PRIVATE KEY-----\n" % "\n-----END RSA PRIVATE KEY-----"))
+        (update :public-key #(str "ssh-rsa " %)))))
+
 (deftest prepare-ssh-keys
   (testing "empty if no keys configured"
     (is (empty? (sut/prepare-ssh-keys {}))))
 
-  (testing "writes keys to configured dir"))
+  (testing "writes keys to configured dir with public key"
+    (h/with-tmp-dir dir
+      (let [ssh-dir (str (fs/path dir "ssh-keys"))
+            keys (keypair-base64)]
+        (is (some? ssh-dir))
+        (is (= {:key-dir ssh-dir
+                :name ["key-0"]}
+               (sut/prepare-ssh-keys {:ssh-keys [keys]
+                                      :ssh-key-dir ssh-dir})))
+        (is (fs/exists? (fs/path ssh-dir "key-0")))
+        (is (fs/exists? (fs/path ssh-dir "key-0.pub")))))))

--- a/app/test/monkey/ci/test/label_test.clj
+++ b/app/test/monkey/ci/test/label_test.clj
@@ -1,0 +1,49 @@
+(ns monkey.ci.test.label-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [monkey.ci.labels :as sut]))
+
+(deftest apply-label-filters
+  (testing "matches params with empty filter"
+    (is (true? (sut/apply-label-filters
+                {"test-label" "test-value"}
+                {:label-filters []}))))
+
+  (testing "matches params with single matching filter"
+    (is (true? (sut/apply-label-filters
+                {"test-label" "test-value"}
+                {:label-filters [[{:label "test-label"
+                                   :value "test-value"}]]}))))
+
+  (testing "does not match when no matching filter"
+    (is (not (sut/apply-label-filters
+              {"test-label" "test-value"}
+              {:label-filters [[{:label "test-label"
+                                 :value "other-value"}]]}))))
+
+  (testing "matches conjunction filter"
+    (is (true? (sut/apply-label-filters
+                {"first-label" "first-value"
+                 "second-label" "second-value"}
+                {:label-filters [[{:label "first-label"
+                                   :value "first-value"}
+                                  {:label "second-label"
+                                   :value "second-value"}]]}))))
+
+  (testing "does not conjunction filter when only one value matches"
+    (is (not (sut/apply-label-filters
+              {"first-label" "first-value"
+               "second-label" "other-value"}
+              {:label-filters [[{:label "first-label"
+                                 :value "first-value"}
+                                {:label "second-label"
+                                 :value "second-value"}]]}))))
+  
+  (testing "matches disjunction filter"
+    (is (true? (sut/apply-label-filters
+                {"first-label" "first-value"
+                 "second-label" "second-value"}
+                {:label-filters [[{:label "first-label"
+                                   :value "first-value"}]
+                                 [{:label "other-label"
+                                   :value "other-value"}]]})))))
+

--- a/app/test/monkey/ci/test/web/api_test.clj
+++ b/app/test/monkey/ci/test/web/api_test.clj
@@ -185,51 +185,6 @@
                  (sut/get-repo-params)
                  :status))))))
 
-(deftest apply-label-filters
-  (testing "matches params with empty filter"
-    (is (true? (sut/apply-label-filters
-                {"test-label" "test-value"}
-                {:label-filters []}))))
-
-  (testing "matches params with single matching filter"
-    (is (true? (sut/apply-label-filters
-                {"test-label" "test-value"}
-                {:label-filters [[{:label "test-label"
-                                   :value "test-value"}]]}))))
-
-  (testing "does not match when no matching filter"
-    (is (not (sut/apply-label-filters
-              {"test-label" "test-value"}
-              {:label-filters [[{:label "test-label"
-                                 :value "other-value"}]]}))))
-
-  (testing "matches conjunction filter"
-    (is (true? (sut/apply-label-filters
-                {"first-label" "first-value"
-                 "second-label" "second-value"}
-                {:label-filters [[{:label "first-label"
-                                   :value "first-value"}
-                                  {:label "second-label"
-                                   :value "second-value"}]]}))))
-
-  (testing "does not conjunction filter when only one value matches"
-    (is (not (sut/apply-label-filters
-              {"first-label" "first-value"
-               "second-label" "other-value"}
-              {:label-filters [[{:label "first-label"
-                                 :value "first-value"}
-                                {:label "second-label"
-                                 :value "second-value"}]]}))))
-  
-  (testing "matches disjunction filter"
-    (is (true? (sut/apply-label-filters
-                {"first-label" "first-value"
-                 "second-label" "second-value"}
-                {:label-filters [[{:label "first-label"
-                                   :value "first-value"}]
-                                 [{:label "other-label"
-                                   :value "other-value"}]]})))))
-
 (deftest create-webhook
   (testing "assigns secret key"
     (let [{st :storage :as ctx} (test-ctx)

--- a/app/test/monkey/ci/test/web/github_test.clj
+++ b/app/test/monkey/ci/test/web/github_test.clj
@@ -54,16 +54,16 @@
       (is (some? (sut/webhook req)))
       (is (= :timeout (h/wait-until #(pos? (count @recv)) 200))))))
 
+(defn- test-webhook []
+  (zipmap [:id :dustomer-id :repo-id] (repeatedly st/new-id)))
+
 (deftest prepare-build
   (testing "creates metadata file for customer/project/repo"
     (h/with-memory-store s
-      (let [wh {:id "test-webhook"
-                :customer-id "test-customer"
-                :project-id "test-project"
-                :repo-id "test-repo"}]
+      (let [wh (test-webhook)]
         (is (st/sid? (st/save-webhook-details s wh)))
         (let [r (sut/prepare-build {:storage s}
-                                   {:id "test-webhook"
+                                   {:id (:id wh)
                                     :payload {}})]
           (is (some? r))
           (is (st/obj-exists? s (-> wh
@@ -73,13 +73,10 @@
 
   (testing "metadata contains commit timestamp and message"
     (h/with-memory-store s
-      (let [wh {:id "test-webhook"
-                :customer-id "test-customer"
-                :project-id "test-project"
-                :repo-id "test-repo"}]
+      (let [wh (test-webhook)]
         (is (st/sid? (st/save-webhook-details s wh)))
         (let [r (sut/prepare-build {:storage s}
-                                   {:id "test-webhook"
+                                   {:id (:id wh)
                                     :payload {:head-commit {:message "test message"
                                                             :timestamp "2023-10-10"}}})
               id (get-in r [:build :sid])
@@ -97,26 +94,20 @@
 
   (testing "uses clone url for public repos"
     (h/with-memory-store s
-      (let [wh {:id "test-webhook"
-                :customer-id "test-customer"
-                :project-id "test-project"
-                :repo-id "test-repo"}]
+      (let [wh (test-webhook)]
         (is (st/sid? (st/save-webhook-details s wh)))
         (let [r (sut/prepare-build {:storage s}
-                                   {:id "test-webhook"
+                                   {:id (:id wh)
                                     :payload {:repository {:ssh-url "ssh-url"
                                                            :clone-url "clone-url"}}})]
           (is (= "clone-url" (get-in r [:build :git :url])))))))
 
   (testing "uses ssh url if repo is private"
     (h/with-memory-store s
-      (let [wh {:id "test-webhook"
-                :customer-id "test-customer"
-                :project-id "test-project"
-                :repo-id "test-repo"}]
+      (let [wh (test-webhook)]
         (is (st/sid? (st/save-webhook-details s wh)))
         (let [r (sut/prepare-build {:storage s}
-                                   {:id "test-webhook"
+                                   {:id (:id wh)
                                     :payload {:repository {:ssh-url "ssh-url"
                                                            :clone-url "clone-url"
                                                            :private true}}})]
@@ -124,14 +115,10 @@
 
   (testing "does not include secret key in metadata"
     (h/with-memory-store s
-      (let [wh {:id "test-webhook"
-                :customer-id "test-customer"
-                :project-id "test-project"
-                :repo-id "test-repo"
-                :secret-key "very very secret!"}]
+      (let [wh (assoc (test-webhook) :secret-key "very very secret!")]
         (is (st/sid? (st/save-webhook-details s wh)))
         (let [r (sut/prepare-build {:storage s}
-                                   {:id "test-webhook"
+                                   {:id (:id wh)
                                     :payload {:head-commit {:message "test message"
                                                             :timestamp "2023-10-10"}}})
               id (get-in r [:build :sid])
@@ -140,26 +127,40 @@
 
   (testing "adds payload ref to build"
     (h/with-memory-store s
-      (let [wh {:id "test-webhook"
-                :customer-id "test-customer"
-                :project-id "test-project"
-                :repo-id "test-repo"}]
+      (let [wh (test-webhook)]
         (is (st/sid? (st/save-webhook-details s wh)))
         (let [r (sut/prepare-build {:storage s}
-                                   {:id "test-webhook"
+                                   {:id (:id wh)
                                     :payload {:ref "test-ref"}})]
           (is (= "test-ref" (get-in r [:build :git :ref])))))))
 
   (testing "sets `main-branch`"
     (h/with-memory-store s
-      (let [wh {:id "test-webhook"
-                :customer-id "test-customer"
-                :project-id "test-project"
-                :repo-id "test-repo"}]
+      (let [wh (test-webhook)]
         (is (st/sid? (st/save-webhook-details s wh)))
         (let [r (sut/prepare-build {:storage s}
-                                   {:id "test-webhook"
+                                   {:id (:id wh)
                                     :payload {:ref "test-ref"
                                               :repository {:master-branch "test-main"}}})]
           (is (= "test-main"
-                 (get-in r [:build :git :main-branch]))))))))
+                 (get-in r [:build :git :main-branch])))))))
+
+  (testing "adds configured ssh key matching repo labels"
+    (h/with-memory-store s
+      (let [wh (test-webhook)
+            cid (:customer-id wh)
+            rid (:repo-id wh)
+            ssh-key "test-ssh-key"]
+        (is (st/sid? (st/save-webhook-details s wh)))
+        (is (st/sid? (st/save-repo s {:customer cid
+                                      :id rid
+                                      :labels [{:name "ssh-lbl"
+                                                :value "lbl-val"}]})))
+        (is (st/sid? (st/save-ssh-keys s cid [{:id "test-key"
+                                               :private-key "test-ssh-key"}])))
+        (let [r (sut/prepare-build {:storage s}
+                                   {:id (:id wh)
+                                    :payload {:ref "test-ref"
+                                              :repository {:master-branch "test-main"}}})]
+          (is (= ["test-ssh-key"]
+                 (get-in r [:build :git :ssh-keys]))))))))

--- a/app/test/monkey/ci/test/web/github_test.clj
+++ b/app/test/monkey/ci/test/web/github_test.clj
@@ -150,17 +150,17 @@
       (let [wh (test-webhook)
             cid (:customer-id wh)
             rid (:repo-id wh)
-            ssh-key "test-ssh-key"]
+            ssh-key {:id "test-key"
+                     :private-key "test-ssh-key"}]
         (is (st/sid? (st/save-webhook-details s wh)))
         (is (st/sid? (st/save-repo s {:customer cid
                                       :id rid
                                       :labels [{:name "ssh-lbl"
                                                 :value "lbl-val"}]})))
-        (is (st/sid? (st/save-ssh-keys s cid [{:id "test-key"
-                                               :private-key "test-ssh-key"}])))
+        (is (st/sid? (st/save-ssh-keys s cid [ssh-key])))
         (let [r (sut/prepare-build {:storage s}
                                    {:id (:id wh)
                                     :payload {:ref "test-ref"
                                               :repository {:master-branch "test-main"}}})]
-          (is (= ["test-ssh-key"]
+          (is (= [ssh-key]
                  (get-in r [:build :git :ssh-keys]))))))))

--- a/app/test/monkey/ci/test/web/handler_test.clj
+++ b/app/test/monkey/ci/test/web/handler_test.clj
@@ -196,60 +196,70 @@
                             :updated-entity {:repo-id "updated-repo"}
                             :creator st/save-webhook-details}))
 
-(deftest parameter-endpoints
+(defn- verify-label-filter-like-endpoints [path desc entity prep-match]
   (let [st (st/make-memory-storage)
         app (make-test-app st)
-        get-params
+        get-entity
         (fn [path]
           (some-> (mock/request :get path)
                   (app)
                   :body
                   slurp
                   (h/parse-json)))
-        save-params
+        save-entity
         (fn [path params]
-          (-> (h/json-request :put path params)
+          (-> (h/json-request :put path entity)
               (app)))]
 
     (testing "/customer/:customer-id"
       
-      (testing "/params"
-        (let [params [{:parameters
-                       [{:name "test-param"
-                         :value "test value"}]
-                       :label-filters []}]
-              cust-id (st/new-id)
-              path (format "/customer/%s/param" cust-id)]
+      (testing path
+        (let [cust-id (st/new-id)
+              full-path (format "/customer/%s%s" cust-id path)]
           
-          (testing "empty when no parameters"
-            (is (empty? (get-params path))))
+          (testing (str "empty when no " desc)
+            (is (empty? (get-entity full-path))))
           
-          (testing "can write params"
-            (is (= 200 (:status (save-params path params)))))
+          (testing (str "can write " desc)
+            (is (= 200 (:status (save-entity full-path entity)))))
           
-          (testing "can read params"
-            (is (get-params path)
-                params))))
+          (testing (str "can read " desc)
+            (is (get-entity full-path)
+                entity))))
 
-      (testing "/repo/:repo-id/params"
-        (let [params [{:parameters
-                       [{:name "test-repo-param"
-                         :value "test value"}]
-                       :label-filters []}]
-              [cust-id repo-id] (repeatedly st/new-id)
-              path (format "/customer/%s/repo/%s/param" cust-id repo-id)
+      (testing (str "/repo/:repo-id" path)
+        (let [[cust-id repo-id] (repeatedly st/new-id)
+              full-path (format "/customer/%s/repo/%s%s" cust-id repo-id path)
               _ (st/save-customer st {:id cust-id
                                       :repos {repo-id {:name "test repo"}}})]
           
-          (testing "empty when no parameters"
-            (is (empty? (get-params path))))
+          (testing (str "empty when no " desc)
+            (is (empty? (get-entity full-path))))
           
-          (testing "can not write params"
-            (is (= 405 (:status (save-params path params)))))
+          (testing (str "can not write " desc)
+            (is (= 405 (:status (save-entity full-path entity)))))
           
-          (testing "can read params"
-            (is (get-params path)
-                (:parameters params))))))))
+          (testing (str "can read " desc)
+            (is (get-entity full-path)
+                (prep-match entity))))))))
+
+(deftest parameter-endpoints
+  (verify-label-filter-like-endpoints
+   "/param"
+   "params"
+   [{:parameters
+     [{:name "test-param"
+       :value "test value"}]
+     :label-filters []}]
+   :parameters))
+
+(deftest ssh-keys-endpoints
+  (verify-label-filter-like-endpoints
+   "/ssh-keys"
+   "ssh keys"
+   [{:private-key "test-key"
+     :label-filters []}]
+   :private-key))
 
 (defn- generate-build-sid []
   (->> (repeatedly st/new-id)

--- a/app/test/monkey/ci/test/web/handler_test.clj
+++ b/app/test/monkey/ci/test/web/handler_test.clj
@@ -257,7 +257,8 @@
   (verify-label-filter-like-endpoints
    "/ssh-keys"
    "ssh keys"
-   [{:private-key "test-key"
+   [{:private-key "private-test-key"
+     :public-key "public-test-key"
      :label-filters []}]
    :private-key))
 

--- a/app/tests.edn
+++ b/app/tests.edn
@@ -1,3 +1,4 @@
 #kaocha/v1
-{:kaocha.plugin.junit-xml/omit-system-out? true
- :kaocha.watch/ignore ["\\.#*.clj"]}
+{:omit-system-out? true
+ :ignore ["\\.#*.clj"]
+ :fail-fast? true}

--- a/gui/src/monkey/ci/gui/customer/views.cljs
+++ b/gui/src/monkey/ci/gui/customer/views.cljs
@@ -30,7 +30,7 @@
 
 (defn- project-lbl [r]
   (->> (:labels r)
-       (filter (partial = "project" :name))
+       (filter (comp (partial = "project") :name))
        (map :value)
        (first)))
 


### PR DESCRIPTION
Add ssh keys to be configured on the customer.  They are assigned to repos using the label filters, and used when checking out git repos.  This is meant for private git repos.