### PR TITLE
Feature/config refactoring

### DIFF
--- a/.monkeyci/build.clj
+++ b/.monkeyci/build.clj
@@ -155,7 +155,7 @@
    :caches [;; Disabled for now, problem with permissions
             #_{:id "mvn-repo"
                :path "/root/.m2"}
-            {:id "node-modules"
+            #_{:id "node-modules"
              :path "node_modules"}]})
 
 (def test-gui

--- a/app/env/dev/server.clj
+++ b/app/env/dev/server.clj
@@ -25,7 +25,8 @@
                                         (merge {:dev-mode true
                                                 :work-dir (u/abs-path "tmp")
                                                 :checkout-base-dir (u/abs-path "tmp/checkout")
-                                                :ssh-keys-dir (u/abs-path "tmp/ssh-keys")})))
+                                                :ssh-keys-dir (u/abs-path "tmp/ssh-keys")})
+                                        (config/normalize-config {} {})))
                      (sc/subsystem [:http])
                      (sc/start-system)))
   nil)

--- a/app/src/monkey/ci/artifacts.clj
+++ b/app/src/monkey/ci/artifacts.clj
@@ -80,5 +80,7 @@
         (save-artifacts ctx)
         r))))
 
-(defmethod config/normalize-key :artifacts [_ conf]
-  (oci/group-credentials conf))
+;;; Config handling
+
+(defmethod config/normalize-key :artifacts [k conf]
+  (config/normalize-typed k conf (partial blob/normalize-blob-config k)))

--- a/app/src/monkey/ci/artifacts.clj
+++ b/app/src/monkey/ci/artifacts.clj
@@ -9,7 +9,9 @@
             [manifold.deferred :as md]
             [monkey.ci
              [blob :as blob]
-             [context :as c]]))
+             [config :as config]
+             [context :as c]
+             [oci :as oci]]))
 
 (defn- get-store [ctx k]
   (get-in ctx [k :store]))
@@ -77,3 +79,6 @@
       (fn [r]
         (save-artifacts ctx)
         r))))
+
+(defmethod config/normalize-key :artifacts [_ conf]
+  (oci/group-credentials conf))

--- a/app/src/monkey/ci/blob.clj
+++ b/app/src/monkey/ci/blob.clj
@@ -217,4 +217,6 @@
   config)
 
 (defmethod normalize-blob-config :oci [t config]
-  (oci/normalize-config config t))
+  (-> config
+      (oci/normalize-config t)
+      (update t select-keys [:type :ns :region :bucket-name :credentials :prefix])))

--- a/app/src/monkey/ci/blob.clj
+++ b/app/src/monkey/ci/blob.clj
@@ -210,3 +210,11 @@
                    (oci/->oci-config)
                    (os/make-client))]
     (->OciBlobStore client oci-conf)))
+
+(defmulti normalize-blob-config (fn [t conf] (get-in conf [t :type])))
+
+(defmethod normalize-blob-config :default [_ config]
+  config)
+
+(defmethod normalize-blob-config :oci [t config]
+  (oci/normalize-config config t))

--- a/app/src/monkey/ci/cache.clj
+++ b/app/src/monkey/ci/cache.clj
@@ -7,7 +7,9 @@
             [monkey.ci
              [artifacts :as art]
              [blob :as blob]
-             [context :as c]]))
+             [config :as config]
+             [context :as c]
+             [oci :as oci]]))
 
 (defn cache-archive-path [{:keys [build]} id]
   ;; The cache archive path is the repo sid with the cache id added.
@@ -40,3 +42,6 @@
       (fn [r]
         (save-caches ctx)
         r))))
+
+(defmethod config/normalize-key :cache [_ conf]
+  (oci/group-credentials conf))

--- a/app/src/monkey/ci/cache.clj
+++ b/app/src/monkey/ci/cache.clj
@@ -43,5 +43,7 @@
         (save-caches ctx)
         r))))
 
-(defmethod config/normalize-key :cache [_ conf]
-  (oci/group-credentials conf))
+;;; Config handling
+
+(defmethod config/normalize-key :cache [k conf]
+  (config/normalize-typed k conf (partial blob/normalize-blob-config k)))

--- a/app/src/monkey/ci/components.clj
+++ b/app/src/monkey/ci/components.clj
@@ -7,6 +7,7 @@
             [monkey.ci
              [commands :as co]
              [config :as config]
+             [context :as ctx]
              [events :as e]
              [listeners :as li]
              [logging :as l]
@@ -78,12 +79,12 @@
                :public-api wsa/local-api
                :reporter (rep/make-reporter (:reporter config)))
         (mc/assoc-some :jwk (auth/config->keypair config))
-        (config/configure-workspace)
-        (config/configure-cache)
-        (config/configure-artifacts)
-        (config/initialize-events)
-        (config/initialize-log-maker)
-        (config/initialize-log-retriever)))
+        (ctx/configure-workspace)
+        (ctx/configure-cache)
+        (ctx/configure-artifacts)
+        (ctx/initialize-events)
+        (ctx/initialize-log-maker)
+        (ctx/initialize-log-retriever)))
   (stop [this]
     this))
 

--- a/app/src/monkey/ci/config.clj
+++ b/app/src/monkey/ci/config.clj
@@ -256,3 +256,8 @@
          (mc/map-keys (fn [k]
                         (keyword (str env-prefix "-" (name k)))))
          (mc/map-vals ->str))))
+
+(defn normalize-typed [k conf f]
+  (-> conf
+      (update k keywordize-type)
+      (f)))

--- a/app/src/monkey/ci/containers.clj
+++ b/app/src/monkey/ci/containers.clj
@@ -1,6 +1,7 @@
 (ns monkey.ci.containers
   "Generic functionality for running containers"
-  (:require [medley.core :as mc]))
+  (:require [medley.core :as mc]
+            [monkey.ci.config :as c]))
 
 (defmulti run-container (comp :type :containers))
 
@@ -17,3 +18,13 @@
        (mc/filter-keys (comp (partial = "container") namespace))
        (mc/map-keys (comp keyword name))
        (update-env)))
+
+;;; Configuration handling
+
+(defmulti normalize-containers-config (comp :type :containers))
+
+(defmethod normalize-containers-config :default [conf]
+  conf)
+
+(defmethod c/normalize-key :containers [k conf]
+  (c/normalize-typed k conf normalize-containers-config))

--- a/app/src/monkey/ci/containers/oci.clj
+++ b/app/src/monkey/ci/containers/oci.clj
@@ -126,3 +126,6 @@
     (-> (oci/run-instance client ic)
         (md/chain (partial hash-map :exit))
         (deref))))
+
+(defmethod mcc/normalize-containers-config :oci [conf]
+  (oci/normalize-config conf :containers))

--- a/app/src/monkey/ci/context.clj
+++ b/app/src/monkey/ci/context.clj
@@ -146,10 +146,8 @@
   "Builds context used by the child script process"
   [env args]
   (-> default-script-config
-      (u/deep-merge (c/env->config env))
+      (c/normalize-config (c/strip-env-prefix env) args)
       (merge args)
-      (c/keywordize-all-types)
       (initialize-log-maker)
       (configure-cache)
-      (configure-artifacts)
-      (mc/update-existing-in [:build :sid] u/parse-sid)))
+      (configure-artifacts)))

--- a/app/src/monkey/ci/core.clj
+++ b/app/src/monkey/ci/core.clj
@@ -12,7 +12,8 @@
              [cli :as mcli]
              [components :as co]
              [config :as config]
-             [utils :as u]]))
+             [utils :as u]
+             [workspace]]))
 
 ;; The base system components.  Depending on the command that's being
 ;; executed, a subsystem will be created and initialized.

--- a/app/src/monkey/ci/core.clj
+++ b/app/src/monkey/ci/core.clj
@@ -9,11 +9,18 @@
             [com.stuartsierra.component :as sc]
             [config.core :refer [env]]
             [monkey.ci
+             [artifacts]
+             [cache]
              [cli :as mcli]
              [components :as co]
              [config :as config]
+             [logging]
              [utils :as u]
-             [workspace]]))
+             [workspace]]
+            [monkey.ci.storage
+             [cached]
+             [file]
+             [oci]]))
 
 ;; The base system components.  Depending on the command that's being
 ;; executed, a subsystem will be created and initialized.

--- a/app/src/monkey/ci/events/manifold.clj
+++ b/app/src/monkey/ci/events/manifold.clj
@@ -14,7 +14,7 @@
   (post-events [this e]
     (post stream e)
     this)
-  
+
   c/EventReceiver
   (add-listener [this l]
     (let [s (ms/stream 10)]

--- a/app/src/monkey/ci/logging.clj
+++ b/app/src/monkey/ci/logging.clj
@@ -6,7 +6,9 @@
             [clojure.string :as cs]
             [clojure.tools.logging :as log]
             [manifold.deferred :as md]
-            [monkey.ci.oci :as oci]
+            [monkey.ci
+             [config :as c]
+             [oci :as oci]]
             [monkey.ci.storage.oci :as st]
             [monkey.ci.utils :as u]
             [monkey.oci.os.core :as os]))
@@ -183,3 +185,6 @@
                      (oci/->oci-config))
         client (os/make-client oci-conf)]
     (->OciBucketLogRetriever client oci-conf)))
+
+(defmethod c/normalize-key :logging [_ conf]
+  (oci/group-credentials conf))

--- a/app/src/monkey/ci/logging.clj
+++ b/app/src/monkey/ci/logging.clj
@@ -186,5 +186,20 @@
         client (os/make-client oci-conf)]
     (->OciBucketLogRetriever client oci-conf)))
 
+;;; Configuration handling
+
+(defmulti normalize-logging-config (comp :type :logging))
+
+(defmethod normalize-logging-config :default [conf]
+  conf)
+
+(defmethod normalize-logging-config :file [conf]
+  (update-in conf [:logging :dir] #(or (u/abs-path %) (u/combine (c/abs-work-dir conf) "logs"))))
+
+(defmethod normalize-logging-config :oci [conf]
+  (oci/normalize-config conf :logging))
+
 (defmethod c/normalize-key :logging [_ conf]
-  (oci/group-credentials conf))
+  (-> conf
+      (update :logging c/keywordize-type)
+      (normalize-logging-config)))

--- a/app/src/monkey/ci/logging.clj
+++ b/app/src/monkey/ci/logging.clj
@@ -199,7 +199,5 @@
 (defmethod normalize-logging-config :oci [conf]
   (oci/normalize-config conf :logging))
 
-(defmethod c/normalize-key :logging [_ conf]
-  (-> conf
-      (update :logging c/keywordize-type)
-      (normalize-logging-config)))
+(defmethod c/normalize-key :logging [k conf]
+  (c/normalize-typed k conf normalize-logging-config))

--- a/app/src/monkey/ci/oci.clj
+++ b/app/src/monkey/ci/oci.clj
@@ -17,8 +17,17 @@
 (defn group-credentials
   "Assuming the conf is taken from env, groups all keys that start with `credentials-`
    into the `:credentials` submap."
-  [conf]
-  (c/group-keys :credentials conf))
+  [{orig :credentials :as conf}]
+  (let [u (c/group-keys :credentials conf)]
+    (update u :credentials (fn [c]
+                             (merge orig c)))))
+
+(defn normalize-config
+  "Normalizes the given OCI config key, by grouping the credentials both in the given key
+   and in the `oci` key, and merging them."
+  [conf k]
+  (assoc conf k (u/deep-merge (group-credentials (:oci conf))
+                              (group-credentials (k conf)))))
 
 (defn ->oci-config
   "Given a configuration map with credentials, turns it into a config map

--- a/app/src/monkey/ci/oci.clj
+++ b/app/src/monkey/ci/oci.clj
@@ -17,17 +17,17 @@
 (defn group-credentials
   "Assuming the conf is taken from env, groups all keys that start with `credentials-`
    into the `:credentials` submap."
-  [{orig :credentials :as conf}]
-  (let [u (c/group-keys :credentials conf)]
-    (update u :credentials (fn [c]
-                             (merge orig c)))))
+  [conf]
+  (c/group-and-merge conf :credentials))
 
 (defn normalize-config
   "Normalizes the given OCI config key, by grouping the credentials both in the given key
    and in the `oci` key, and merging them."
   [conf k]
-  (assoc conf k (u/deep-merge (group-credentials (:oci conf))
-                              (group-credentials (k conf)))))
+  (->> [(:oci (c/group-and-merge conf :oci)) (k conf)]
+       (map group-credentials)
+       (apply merge)
+       (assoc conf k)))
 
 (defn ->oci-config
   "Given a configuration map with credentials, turns it into a config map

--- a/app/src/monkey/ci/oci.clj
+++ b/app/src/monkey/ci/oci.clj
@@ -6,11 +6,19 @@
              [deferred :as md]
              [time :as mt]]
             [medley.core :as mc]
-            [monkey.ci.utils :as u]
+            [monkey.ci
+             [config :as c]
+             [utils :as u]]
             [monkey.oci.container-instance.core :as ci]
             [monkey.oci.os
              [martian :as os]
              [stream :as s]]))
+
+(defn group-credentials
+  "Assuming the conf is taken from env, groups all keys that start with `credentials-`
+   into the `:credentials` submap."
+  [conf]
+  (c/group-keys :credentials conf))
 
 (defn ->oci-config
   "Given a configuration map with credentials, turns it into a config map

--- a/app/src/monkey/ci/process.clj
+++ b/app/src/monkey/ci/process.clj
@@ -27,7 +27,7 @@
    with a nonzero value on failure."
   ([args env]
    (try 
-     (let [ctx (config/script-config env args)]
+     (let [ctx (ctx/script-context env args)]
        (log/debug "Executing script with context" ctx)
        (when (bc/failed? (script/exec-script! ctx))
          (System/exit 1)))

--- a/app/src/monkey/ci/runners.clj
+++ b/app/src/monkey/ci/runners.clj
@@ -135,16 +135,6 @@
   (log/warn "No runner configured, using fallback configuration")
   (constantly 2))
 
-(defmulti normalize-runner-config (comp :type :runner))
-
-(defmethod normalize-runner-config :default [conf]
-  conf)
-
-(defmethod config/normalize-key :runner [_ conf]
-  (-> conf
-      (update :runner config/keywordize-type)
-      (normalize-runner-config)))
-
 (defn- take-and-close
   "Takes the first value from channel `ch` and closes it.  Closing the channel
    is necessary to ensure cleanup."
@@ -178,3 +168,13 @@
                       :result :error
                       :exit 2
                       :exception ex}))))
+
+;;; Configuration handling
+
+(defmulti normalize-runner-config (comp :type :runner))
+
+(defmethod normalize-runner-config :default [conf]
+  conf)
+
+(defmethod config/normalize-key :runner [k conf]
+  (config/normalize-typed k conf normalize-runner-config))

--- a/app/src/monkey/ci/runners.clj
+++ b/app/src/monkey/ci/runners.clj
@@ -135,8 +135,15 @@
   (log/warn "No runner configured, using fallback configuration")
   (constantly 2))
 
-(defmethod config/normalize-key :runner [_ conf]
+(defmulti normalize-runner-config (comp :type :runner))
+
+(defmethod normalize-runner-config :default [conf]
   conf)
+
+(defmethod config/normalize-key :runner [_ conf]
+  (-> conf
+      (update :runner config/keywordize-type)
+      (normalize-runner-config)))
 
 (defn- take-and-close
   "Takes the first value from channel `ch` and closes it.  Closing the channel

--- a/app/src/monkey/ci/runners.clj
+++ b/app/src/monkey/ci/runners.clj
@@ -8,6 +8,7 @@
             [manifold.deferred :as md]
             [monkey.ci
              [blob :as b]
+             [config :as config]
              [context :as c]
              [events :as e]
              [process :as p]
@@ -133,6 +134,9 @@
   ;; Fallback
   (log/warn "No runner configured, using fallback configuration")
   (constantly 2))
+
+(defmethod config/normalize-key :runner [_ conf]
+  conf)
 
 (defn- take-and-close
   "Takes the first value from channel `ch` and closes it.  Closing the channel

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -68,3 +68,6 @@
                    (oci/->oci-config)
                    (ci/make-context))]
     (partial oci-runner client conf)))
+
+(defmethod r/normalize-runner-config :oci [conf]
+  (oci/normalize-config conf :runner))

--- a/app/src/monkey/ci/sidecar.clj
+++ b/app/src/monkey/ci/sidecar.clj
@@ -7,6 +7,7 @@
             [manifold.deferred :as md]
             [monkey.ci
              [blob :as blob]
+             [config :as c]
              [context :as ctx]
              [utils :as u]]))
 
@@ -66,3 +67,6 @@
       (restore-src)
       (mark-start)
       (poll-events)))
+
+(defmethod c/normalize-key :sidecar [_ conf]
+  conf)

--- a/app/src/monkey/ci/spec.clj
+++ b/app/src/monkey/ci/spec.clj
@@ -177,9 +177,9 @@
                                    :arg/git-url :arg/config-file :arg/events-file]))
 
 ;; Application configuration
-(s/def ::app-config (s/keys :req-un [:conf/http :conf/runner :conf/args :conf/logging
-                                     :conf/work-dir :conf/checkout-base-dir :conf/ssh-keys-dir]
-                            :opt-un [:conf/dev-mode :conf/containers :conf/log-dir :conf/jwk
+(s/def ::app-config (s/keys :req-un [:conf/http :conf/runner :conf/logging :conf/work-dir
+                                     :conf/checkout-base-dir :conf/ssh-keys-dir]
+                            :opt-un [:conf/dev-mode :conf/args :conf/containers :conf/log-dir :conf/jwk
                                      :conf/storage :conf/account :conf/sidecar :conf/workspace]))
 ;; Application context.  This is the result of processing the configuration and is passed
 ;; around internally.

--- a/app/src/monkey/ci/storage.clj
+++ b/app/src/monkey/ci/storage.clj
@@ -59,8 +59,13 @@
   (log/info "Using memory storage (only for dev purposes!)")
   (make-memory-storage))
 
-(defmethod c/normalize-key :storage [_ conf]
+(defmulti normalize-storage-config (comp :type :storage))
+
+(defmethod normalize-storage-config :default [conf]
   conf)
+
+(defmethod c/normalize-key :storage [k conf]
+  (c/normalize-typed k conf normalize-storage-config))
 
 ;;; Higher level functions
 

--- a/app/src/monkey/ci/storage.clj
+++ b/app/src/monkey/ci/storage.clj
@@ -5,7 +5,9 @@
             [clojure.string :as cs]
             [clojure.tools.logging :as log]
             [medley.core :as mc]
-            [monkey.ci.utils :as u])
+            [monkey.ci
+             [config :as c]
+             [utils :as u]])
   (:import [java.io File PushbackReader]))
 
 (defprotocol Storage
@@ -56,6 +58,9 @@
 (defmethod make-storage :memory [_]
   (log/info "Using memory storage (only for dev purposes!)")
   (make-memory-storage))
+
+(defmethod c/normalize-key :storage [_ conf]
+  conf)
 
 ;;; Higher level functions
 

--- a/app/src/monkey/ci/storage/cached.clj
+++ b/app/src/monkey/ci/storage/cached.clj
@@ -35,3 +35,4 @@
 (defn make-cached-storage [src]
   ;; FIXME Set a limit on the cache size
   (->CachedStorage src (st/make-memory-storage)))
+

--- a/app/src/monkey/ci/storage/file.clj
+++ b/app/src/monkey/ci/storage/file.clj
@@ -64,3 +64,4 @@
 (defmethod s/make-storage :file [{conf :storage}]
   (log/info "Using file storage with configuration:" conf)
   (make-file-storage (u/abs-path (:dir conf))))
+

--- a/app/src/monkey/ci/storage/file.clj
+++ b/app/src/monkey/ci/storage/file.clj
@@ -64,4 +64,3 @@
 (defmethod s/make-storage :file [{conf :storage}]
   (log/info "Using file storage with configuration:" conf)
   (make-file-storage (u/abs-path (:dir conf))))
-

--- a/app/src/monkey/ci/storage/oci.clj
+++ b/app/src/monkey/ci/storage/oci.clj
@@ -104,3 +104,6 @@
       (oci/ctx->oci-config :storage)
       (oci/->oci-config)
       (make-oci-storage)))
+
+(defmethod st/normalize-storage-config :oci [conf]
+  (oci/normalize-config conf :storage))

--- a/app/src/monkey/ci/storage/oci.clj
+++ b/app/src/monkey/ci/storage/oci.clj
@@ -100,6 +100,7 @@
   (->OciObjectStorage (os/make-client conf) conf))
 
 (defmethod st/make-storage :oci [conf]
+  (log/debug "Creating oci storage with config:" conf)
   (-> conf
       (oci/ctx->oci-config :storage)
       (oci/->oci-config)

--- a/app/src/monkey/ci/web/github.clj
+++ b/app/src/monkey/ci/web/github.clj
@@ -8,6 +8,7 @@
             [clojure.tools.logging :as log]
             [medley.core :as mc]
             [monkey.ci
+             [config :as config]
              [context :as ctx]
              [labels :as lbl]
              [storage :as s]
@@ -178,3 +179,6 @@
   "Lists public github configuration to use"
   [req]
   (rur/response {:client-id (c/from-context req (comp :client-id :github))}))
+
+(defmethod config/normalize-key :github [_ conf]
+  conf)

--- a/app/src/monkey/ci/workspace.clj
+++ b/app/src/monkey/ci/workspace.clj
@@ -1,0 +1,7 @@
+(ns monkey.ci.workspace
+  (:require [monkey.ci
+             [blob :as b]
+             [config :as c]]))
+
+(defmethod c/normalize-key :workspace [k conf]
+  (c/normalize-typed k conf (partial b/normalize-blob-config k)))

--- a/app/test/monkey/ci/config_test.clj
+++ b/app/test/monkey/ci/config_test.clj
@@ -6,6 +6,7 @@
             [monkey.ci
              [config :as sut]
              [context :as ctx]
+             [logging]
              [spec :as spec]]
             [monkey.ci.web.github]
             [monkey.ci.helpers :as h]))
@@ -120,9 +121,9 @@
 
   (testing "loads home config file"
     (with-home-config
-      {:log-dir "some-log-dir"}
+      {:work-dir "some-work-dir"}
       #(let [c (sut/app-config {} {})]
-         (is (cs/ends-with? (:log-dir c) "some-log-dir")))))
+         (is (cs/ends-with? (:work-dir c) "some-work-dir")))))
 
   (testing "global `work-dir`"
     (testing "uses current as default"
@@ -167,11 +168,11 @@
 
   (testing "takes account settings from args"
     (is (= {:customer-id "test-customer"
-            :project-id "arg-project"}
+            :repo-id "arg-repo"}
            (-> (sut/app-config {:monkeyci-account-customer-id "test-customer"}
-                               {:project-id "arg-project"})
+                               {:repo-id "arg-repo"})
                :account
-               (select-keys [:customer-id :project-id])))))
+               (select-keys [:customer-id :repo-id])))))
 
   (testing "uses `server` arg as account url"
     (is (= "http://test"
@@ -182,7 +183,8 @@
   (testing "oci"
     (testing "provides credentials from env"
       (is (= "env-fingerprint"
-             (-> {:monkeyci-logging-credentials-key-fingerprint "env-fingerprint"}
+             (-> {:monkeyci-logging-credentials-key-fingerprint "env-fingerprint"
+                  :monkeyci-logging-type "oci"}
                  (sut/app-config {})
                  :logging
                  :credentials
@@ -191,10 +193,10 @@
     (testing "keeps credentials from config file"
       (with-home-config
         {:logging
-         {:credentials
+         {:type :oci
+          :credentials
           {:key-fingerprint "conf-fingerprint"}}}
-        #(is (= "conf-fingerprint" (->> {}
-                                        (sut/app-config {})
+        #(is (= "conf-fingerprint" (->> (sut/app-config {} {})
                                         :logging
                                         :credentials
                                         :key-fingerprint)))))))

--- a/app/test/monkey/ci/containers/oci_test.clj
+++ b/app/test/monkey/ci/containers/oci_test.clj
@@ -3,6 +3,7 @@
             [manifold.deferred :as md]
             [medley.core :as mc]
             [monkey.ci
+             [config :as c]
              [containers :as mcc]
              [oci :as oci]
              [utils :as u]]
@@ -119,3 +120,13 @@
     (with-redefs [oci/run-instance (constantly (md/success-deferred 123))]
       (is (= 123 (-> (mcc/run-container {:containers {:type :oci}})
                      :exit))))))
+
+(deftest normalize-key
+  (testing "merges with oci"
+    (is (= {:type :oci
+            :key "value"
+            :credentials {}}
+           (->> {:containers {:type :oci}
+                 :oci {:key "value"}}
+                (c/normalize-key :containers)
+                :containers)))))

--- a/app/test/monkey/ci/containers/oci_test.clj
+++ b/app/test/monkey/ci/containers/oci_test.clj
@@ -124,8 +124,7 @@
 (deftest normalize-key
   (testing "merges with oci"
     (is (= {:type :oci
-            :key "value"
-            :credentials {}}
+            :key "value"}
            (->> {:containers {:type :oci}
                  :oci {:key "value"}}
                 (c/normalize-key :containers)

--- a/app/test/monkey/ci/containers_test.clj
+++ b/app/test/monkey/ci/containers_test.clj
@@ -1,7 +1,15 @@
 (ns monkey.ci.containers-test
   (:require [clojure.test :refer [deftest testing is]]
-            [monkey.ci.containers :as sut]))
+            [monkey.ci
+             [config :as c]
+             [containers :as sut]]))
 
 (deftest ctx->container-config
   (testing "extracts all keys with `container` namespace"
     (is (= {:key "value"} (sut/ctx->container-config {:step {:container/key "value"}})))))
+
+(deftest normalize-key
+  (testing "handles string type"
+    (is (= :podman (-> (c/normalize-key :containers {:containers {:type "podman"}})
+                       :containers
+                       :type)))))

--- a/app/test/monkey/ci/context_test.clj
+++ b/app/test/monkey/ci/context_test.clj
@@ -1,6 +1,9 @@
 (ns monkey.ci.context-test
   (:require [clojure.test :refer [deftest testing is]]
-            [monkey.ci.context :as sut]))
+            [clojure.spec.alpha :as s]
+            [monkey.ci
+             [context :as sut]
+             [spec :as spec]]))
 
 (deftest get-sid
   (testing "returns build sid"
@@ -34,3 +37,69 @@
                 :pipeline {:index 0}
                 :step {:index 1}}
                (sut/get-step-id))))))
+
+(deftest script-context
+  (testing "sets containers type"
+    (is (= :test-type
+           (-> {:monkeyci-containers-type "test-type"}
+               (sut/script-context {})
+               :containers
+               :type))))
+
+  (testing "sets logging config"
+    (is (= :file
+           (-> {:monkeyci-logging-type "file"}
+               (sut/script-context {})
+               :logging
+               :type))))
+
+  (testing "initializes logging maker"
+    (is (fn? (-> {:monkeyci-logging-type "file"}
+                 (sut/script-context {})
+                 :logging
+                 :maker))))
+
+  (testing "initializes cache store"
+    (is (some? (-> {:monkeyci-cache-type "disk"}
+                   (sut/script-context {})
+                   :cache
+                   :store))))
+
+  (testing "initializes artifacts store"
+    (is (some? (-> {:monkeyci-artifacts-type "disk"}
+                   (sut/script-context {})
+                   :artifacts
+                   :store))))
+
+  (testing "groups api settings"
+    (is (= "test-socket"
+           (-> {:monkeyci-api-socket "test-socket"}
+               (sut/script-context {})
+               :api
+               :socket))))
+
+  (testing "matches spec"
+    (is (true? (s/valid? ::spec/script-config (sut/script-context {} {})))))
+
+  (testing "provides oci credentials from env"
+    (is (= "test-fingerprint"
+           (-> {:monkeyci-logging-credentials-key-fingerprint "test-fingerprint"}
+               (sut/script-context {})
+               :logging
+               :credentials
+               :key-fingerprint))))
+
+  (testing "parses sid"
+    (is (= ["a" "b" "c"]
+           (-> {:monkeyci-build-sid "a/b/c"}
+               (sut/script-context {})
+               :build
+               :sid))))
+
+  (testing "groups git subkeys"
+    (is (= "test-ref"
+           (-> {:monkeyci-build-git-ref "test-ref"}
+               (sut/script-context {})
+               :build
+               :git
+               :ref)))))

--- a/app/test/monkey/ci/context_test.clj
+++ b/app/test/monkey/ci/context_test.clj
@@ -2,7 +2,9 @@
   (:require [clojure.test :refer [deftest testing is]]
             [clojure.spec.alpha :as s]
             [monkey.ci
+             [blob]
              [context :as sut]
+             [logging]
              [spec :as spec]]))
 
 (deftest get-sid
@@ -83,7 +85,8 @@
 
   (testing "provides oci credentials from env"
     (is (= "test-fingerprint"
-           (-> {:monkeyci-logging-credentials-key-fingerprint "test-fingerprint"}
+           (-> {:monkeyci-logging-credentials-key-fingerprint "test-fingerprint"
+                :monkeyci-logging-type "oci"}
                (sut/script-context {})
                :logging
                :credentials
@@ -102,4 +105,9 @@
                (sut/script-context {})
                :build
                :git
-               :ref)))))
+               :ref))))
+
+  (testing "merges args"
+    (is (= "test-arg"
+           (-> (sut/script-context {} {:key "test-arg"})
+               :key)))))

--- a/app/test/monkey/ci/oci_test.clj
+++ b/app/test/monkey/ci/oci_test.clj
@@ -28,6 +28,17 @@
     (is (= {:credentials {:fingerprint "test"}}
            (sut/group-credentials {:credentials {:fingerprint "test"}})))))
 
+(deftest normalize-config
+  (testing "combines oci and specific config from conf"
+    (is (= {:region "eu-frankfurt-1"
+            :bucket-name "test-bucket"}
+           (-> (sut/normalize-config
+                {:oci {:region "eu-frankfurt-1"}
+                 :storage {:bucket-name "test-bucket"}}
+                :storage)
+               :storage
+               (select-keys [:region :bucket-name]))))))
+
 (deftest stream-to-bucket
   (testing "pipes input stream to multipart"
     (with-redefs [os/input-stream->multipart (fn [ctx opts]

--- a/app/test/monkey/ci/process_test.clj
+++ b/app/test/monkey/ci/process_test.clj
@@ -23,8 +23,9 @@
                                           (reset! captured-args args)
                                           bc/success)]
         (is (nil? (sut/run {:key :test-args})))
-        (is (= {:key :test-args} (-> @captured-args
-                                     (select-keys [:key])))))))
+        (is (= {:key :test-args}
+               (-> @captured-args
+                   :args))))))
 
   (testing "merges args with env vars"
     (let [captured-args (atom nil)]

--- a/app/test/monkey/ci/storage_test.clj
+++ b/app/test/monkey/ci/storage_test.clj
@@ -1,7 +1,9 @@
 (ns monkey.ci.storage-test
   (:require [clojure.test :refer [deftest testing is]]
             [clojure.string :as cs]
-            [monkey.ci.storage :as sut]
+            [monkey.ci
+             [config :as c]
+             [storage :as sut]]
             [monkey.ci.helpers :as h]))
 
 (deftest webhook-details
@@ -99,3 +101,17 @@
                :email "test@monkeyci.com"}]
         (is (sut/sid? (sut/save-user st u)))
         (is (= u (sut/find-user st [:github 1234])) "can retrieve user by github id")))))
+
+(deftest normalize-key
+  (testing "normalizes string type"
+    (is (= :memory (-> (c/normalize-key :storage {:storage {:type "memory"}})
+                       :storage
+                       :type))))
+
+  (testing "normalizes oci credentials"
+    (is (map? (-> (c/normalize-key :storage {:storage
+                                             {:type :oci}
+                                             :oci
+                                             {:credentials {:fingerprint "test-fingerprint"}}})
+                  :storage
+                  :credentials)))))


### PR DESCRIPTION
Refactoring of the config and context code.  This is now sprinkled all over the codebase, with a lot of ad-hoc functionality in the config and context namespaces.  The aim of this refactoring is to put all config/context code with the modules that actually know how it should be handled.  I'm using multimethods for this.  The downside is a bit more complexity when preparing the config, the upside is that is handled much more generically and it should be easier to track down where configuration is handled (i.e. in the namespace that holds the actual functionality).