### PR TITLE
Introduced protocols ns, moved storage proto to it

### DIFF
--- a/app/env/dev/storage.clj
+++ b/app/env/dev/storage.clj
@@ -1,6 +1,8 @@
 (ns storage
   (:require [config :as c]
-            [monkey.ci.storage :as s]
+            [monkey.ci
+             [protocols :as p]
+             [storage :as s]]
             [monkey.ci.storage.oci]))
 
 (defn make-storage
@@ -37,6 +39,6 @@
 (defn delete-build [id]
   (let [b (make-storage)
         sid (vec (concat (c/account->sid) [id]))
-        d (juxt (comp (partial s/delete-obj b) s/build-metadata-sid)
-                (comp (partial s/delete-obj b) s/build-results-sid))]
+        d (juxt (comp (partial p/delete-obj b) s/build-metadata-sid)
+                (comp (partial p/delete-obj b) s/build-results-sid))]
     (d sid)))

--- a/app/src/monkey/ci/protocols.clj
+++ b/app/src/monkey/ci/protocols.clj
@@ -1,0 +1,14 @@
+(ns monkey.ci.protocols
+  "Contains all (or most of) the protocols used in the app.  This is useful
+   to avoid circular dependencies.")
+
+(defprotocol Storage
+  "Low level storage protocol, that basically allows to store and retrieve
+   information by location (aka storage id or sid)."
+  (read-obj [this sid] "Read object at given location")
+  (write-obj [this sid obj] "Writes object to location")
+  (delete-obj [this sid] "Deletes object at location")
+  (obj-exists? [this sid] "Checks if object at location exists")
+  (list-obj [this sid] "Lists objects at given location"))
+
+;; TODO Add others

--- a/app/src/monkey/ci/storage/file.clj
+++ b/app/src/monkey/ci/storage/file.clj
@@ -7,6 +7,7 @@
             [clojure.java.io :as io]
             [clojure.tools.logging :as log]
             [monkey.ci
+             [protocols :as p]
              [storage :as s]
              [utils :as u]])
   (:import [java.io File PushbackReader]))
@@ -33,7 +34,7 @@
 
 ;; Must be a type, not a record, otherwise it gets lost in reitit data processing
 (deftype FileStorage [dir]
-  s/Storage
+  p/Storage
   (read-obj [_ loc]
     (let [f (->file dir loc)]
       (log/trace "Checking for file at" f)

--- a/app/src/monkey/ci/storage/oci.clj
+++ b/app/src/monkey/ci/storage/oci.clj
@@ -7,6 +7,7 @@
             [manifold.deferred :as md]
             [monkey.ci
              [oci :as oci]
+             [protocols :as p]
              [storage :as st]]
             [monkey.oci.os.core :as os]))
 
@@ -47,7 +48,7 @@
   (subs s (count prefix)))
 
 (deftype OciObjectStorage [client conf]
-  st/Storage
+  p/Storage
   (read-obj [this sid]
     (let [args (object-args client conf sid)]
       @(md/chain

--- a/app/test/monkey/ci/storage/cached_test.clj
+++ b/app/test/monkey/ci/storage/cached_test.clj
@@ -1,41 +1,44 @@
 (ns monkey.ci.storage.cached-test
   (:require [clojure.test :refer [deftest testing is]]
-            [monkey.ci.storage :as st]
+            [monkey.ci
+             [protocols :as p]
+             [storage :as st]]
             [monkey.ci.storage.cached :as sut]))
 
 (defrecord CountingStorage [src counts]
-  st/Storage
+  p/Storage
   (read-obj [_ sid]
     (swap! counts update :reads (fnil inc 0))
-    (st/read-obj src sid))
+    (p/read-obj src sid))
 
   (write-obj [_ sid obj]
     (swap! counts update :writes (fnil inc 0))
-    (st/write-obj src sid obj))
+    (p/write-obj src sid obj))
 
   (obj-exists? [_ sid]
     (swap! counts update :exists (fnil inc 0))
-    (st/obj-exists? src sid))
+    (p/obj-exists? src sid))
 
   (list-obj [_ sid]
     (swap! counts update :lists (fnil inc 0))
-    (st/list-obj src sid)))
+    (p/list-obj src sid)))
 
 (deftest cached-storage
   (testing "can write and read object"
     (let [cust {:id (random-uuid)
                 :name "test customer"}
           src (st/make-memory-storage)
-          st (sut/make-cached-storage src)]
+          st (sut/->CachedStorage src (st/make-memory-storage))]
       (is (st/sid? (st/save-customer st cust)))
       (is (= cust (st/find-customer st (:id cust))))))
 
   (testing "does not read from src if cached"
     (let [c (atom {:reads 0})
-          cs (sut/make-cached-storage
+          cs (sut/->CachedStorage
               (->CountingStorage
                (st/make-memory-storage)
-               c))
+               c)
+              (st/make-memory-storage))
           id (random-uuid)]
       (is (st/sid? (st/save-customer cs {:id id
                                          :name "test customer"})))
@@ -53,9 +56,9 @@
           cust {:id id
                 :name "test customer"}
           src (st/make-memory-storage)
-          st (sut/make-cached-storage src)]
+          st (sut/->CachedStorage src (st/make-memory-storage))]
       (is (st/sid? (st/save-customer st cust)))
-      (is (true? (st/delete-obj st (st/customer-sid id))))
+      (is (true? (p/delete-obj st (st/customer-sid id))))
       (is (nil? (st/find-customer st id)))
       (is (nil? (st/find-customer (-> st .cache) id)))))
 
@@ -65,7 +68,7 @@
               (st/make-memory-storage)
               c)
           s (sut/->CachedStorage (st/make-memory-storage) cs)]
-      (is (false? (st/obj-exists? s ["test-id"])))
+      (is (false? (p/obj-exists? s ["test-id"])))
       (is (= 0 (:exists @c)))))
 
   (testing "lists from src"
@@ -76,6 +79,6 @@
           s (sut/->CachedStorage (st/make-memory-storage) cs)
           id (random-uuid)]
       (is (st/sid? (st/save-customer s {:id id :name "test customer"})))
-      (is (= [id] (st/list-obj s [st/global "customers"])) "list first time")
-      (is (= [id] (st/list-obj s [st/global "customers"])) "list again")
+      (is (= [id] (p/list-obj s [st/global "customers"])) "list first time")
+      (is (= [id] (p/list-obj s [st/global "customers"])) "list again")
       (is (= 0 (:lists @c)) "expected no listings from cache"))))

--- a/app/test/monkey/ci/storage/file_test.clj
+++ b/app/test/monkey/ci/storage/file_test.clj
@@ -1,7 +1,9 @@
 (ns monkey.ci.storage.file-test
   (:require [clojure.test :refer [deftest testing is]]
             [clojure.string :as cs]
-            [monkey.ci.storage :as st]
+            [monkey.ci
+             [protocols :as p]
+             [storage :as st]]
             [monkey.ci.storage.file :as sut]
             [monkey.ci.helpers :as h]))
 
@@ -11,32 +13,32 @@
       (let [s (sut/make-file-storage dir)
             obj {:key "value"}
             loc ["test"]]
-        (is (= (st/write-obj s loc obj) loc))
-        (is (= obj (st/read-obj s loc))))))
+        (is (= (p/write-obj s loc obj) loc))
+        (is (= obj (p/read-obj s loc))))))
 
   (testing "writes object to file"
     (h/with-tmp-dir dir
       (let [s (sut/make-file-storage dir)
             obj {:key "value"}
             loc ["test"]]
-        (is (= (st/write-obj s loc obj) loc))
-        (is (true? (st/obj-exists? s loc))))))
+        (is (= (p/write-obj s loc obj) loc))
+        (is (true? (p/obj-exists? s loc))))))
 
   (testing "can write to subdirectories"
     (h/with-tmp-dir dir
       (let [s (sut/make-file-storage dir)
             obj {:key "value"}
             loc ["subdir" "test"]]
-        (is (= (st/write-obj s loc obj) loc))
-        (is (= obj (st/read-obj s loc))))))
+        (is (= (p/write-obj s loc obj) loc))
+        (is (= obj (p/read-obj s loc))))))
 
   (testing "`obj-exists?` returns false if file does not exist"
     (is (false? (-> (sut/make-file-storage "test-dir")
-                    (st/obj-exists? ["test-loc"])))))
+                    (p/obj-exists? ["test-loc"])))))
 
   (testing "read returns `nil` if object does not exist"
     (is (nil? (-> (sut/make-file-storage "nonexisting")
-                  (st/read-obj ["nonexisting-loc"])))))
+                  (p/read-obj ["nonexisting-loc"])))))
 
   (testing "delete-obj"
     (testing "can delete file"
@@ -44,14 +46,14 @@
         (let [s (sut/make-file-storage dir)
               obj {:key "value"}
               loc ["test.edn"]]
-          (is (= (st/write-obj s loc obj) loc))
-          (is (true? (st/delete-obj s loc)))
-          (is (false? (st/obj-exists? s loc))))))
+          (is (= (p/write-obj s loc obj) loc))
+          (is (true? (p/delete-obj s loc)))
+          (is (false? (p/obj-exists? s loc))))))
 
     (testing "false if file does not exist"
       (h/with-tmp-dir dir 
         (is (false? (-> (sut/make-file-storage dir)
-                        (st/delete-obj ["test-loc"])))))))
+                        (p/delete-obj ["test-loc"])))))))
 
   (testing "list-obj"
     (testing "lists directories at location"
@@ -59,13 +61,13 @@
         (let [s (sut/make-file-storage dir)
               sid ["root" "a" "b"]
               obj {:key "value"}]
-          (is (= sid (st/write-obj s sid obj)))
-          (is (= ["a"] (st/list-obj s ["root"]))))))
+          (is (= sid (p/write-obj s sid obj)))
+          (is (= ["a"] (p/list-obj s ["root"]))))))
     
     (testing "lists files at location without extension"
       (h/with-tmp-dir dir
         (let [s (sut/make-file-storage dir)
               sid ["root" "child"]
               obj {:key "value"}]
-          (is (= sid (st/write-obj s sid obj)))
-          (is (= ["child"] (st/list-obj s ["root"]))))))))
+          (is (= sid (p/write-obj s sid obj)))
+          (is (= ["child"] (p/list-obj s ["root"]))))))))

--- a/app/test/monkey/ci/storage/oci_test.clj
+++ b/app/test/monkey/ci/storage/oci_test.clj
@@ -6,6 +6,7 @@
             [clojure.spec.alpha :as spec]
             [manifold.deferred :as md]
             [monkey.ci
+             [protocols :as p]
              [spec :as s]
              [storage :as st]
              [utils :refer [load-privkey]]]
@@ -30,7 +31,7 @@
           (let [writes (atom [])]
             (with-redefs [os/put-object (fn [_ args]
                                           (swap! writes conj args))]
-              (is (= sid (st/write-obj s sid {:key "value"})))
+              (is (= sid (p/write-obj s sid {:key "value"})))
               (is (= 1 (count @writes)))
               (let [w (first @writes)]
                 (is (= "test-ns" (:ns w)))
@@ -41,29 +42,29 @@
           (with-redefs [os/get-object (fn [_ args]
                                         "{:key \"value\"}")
                         os/head-object (constantly true)]
-            (is (= {:key "value"} (st/read-obj s sid)))))
+            (is (= {:key "value"} (p/read-obj s sid)))))
 
         (testing "returns `nil` when object does not exist on read"
           (with-redefs [os/get-object (fn [_ args]
                                         "{:key \"value\"}")
                         os/head-object (constantly false)]
-            (is (nil? (st/read-obj s sid))))))
+            (is (nil? (p/read-obj s sid))))))
 
       (testing "`obj-exists?` sends head request"
         (with-redefs [os/head-object (fn [_ {:keys [object-name]}]
                                        (future (= "test.edn" object-name)))]
-          (is (true? (st/obj-exists? s ["test"])))
-          (is (false? (st/obj-exists? s ["other"])))))
+          (is (true? (p/obj-exists? s ["test"])))
+          (is (false? (p/obj-exists? s ["other"])))))
 
       (testing "can delete object"
         (with-redefs [os/delete-object (fn [_ args]
                                          true)]
-          (is (true? (st/delete-obj s sid)))))
+          (is (true? (p/delete-obj s sid)))))
 
       (testing "false when delete fails"
         (with-redefs [os/delete-object (fn [_ args]
                                          (md/error-deferred (ex-info "Object not found" {})))]
-          (is (false? (st/delete-obj s sid)))))
+          (is (false? (p/delete-obj s sid)))))
 
       (testing "list objects"
         (testing "passes sid prefix"
@@ -73,20 +74,20 @@
                                             (md/success-deferred
                                              {:objects []
                                               :prefixes []}))]
-              (is (some? (st/list-obj s sid)))
+              (is (some? (p/list-obj s sid)))
               (is (= "path/to/object/" (:prefix @inv))))))
 
         (testing "returns files without extensions"
           (with-redefs [os/list-objects (constantly
                                          (md/success-deferred
                                           {:objects [{:name "prefix/test.edn"}]}))]
-            (is (= ["test"] (st/list-obj s ["prefix"])))))
+            (is (= ["test"] (p/list-obj s ["prefix"])))))
 
         (testing "returns dirs without prefix"
           (with-redefs [os/list-objects (constantly
                                          (md/success-deferred
                                           {:prefixes ["prefix/test/"]}))]
-            (is (= ["test"] (st/list-obj s ["prefix"])))))))))
+            (is (= ["test"] (p/list-obj s ["prefix"])))))))))
 
 (def private-key? (partial instance? java.security.PrivateKey))
 
@@ -138,4 +139,4 @@
         (is (nil? (st/find-customer s id)))
         (is (st/sid? (st/save-customer s cust)))
         (is (= cust (st/find-customer s id)))
-        (is (true? (st/delete-obj s (st/customer-sid id))))))))
+        (is (true? (p/delete-obj s (st/customer-sid id))))))))

--- a/app/test/monkey/ci/web/github_test.clj
+++ b/app/test/monkey/ci/web/github_test.clj
@@ -3,6 +3,7 @@
             [clojure.math :as cm]
             [buddy.sign.jwt :as jwt]
             [monkey.ci
+             [protocols :as p]
              [storage :as st]]
             [monkey.ci.web
              [auth :as auth]
@@ -67,10 +68,10 @@
                                   {:id (:id wh)
                                    :payload {}})]
           (is (some? r))
-          (is (st/obj-exists? s (-> wh
-                                    (select-keys [:customer-id :project-id :repo-id])
-                                    (assoc :build-id (:build-id r))
-                                    (st/build-metadata-sid))))))))
+          (is (p/obj-exists? s (-> wh
+                                   (select-keys [:customer-id :project-id :repo-id])
+                                   (assoc :build-id (:build-id r))
+                                   (st/build-metadata-sid))))))))
 
   (testing "metadata contains commit message"
     (h/with-memory-store s


### PR DESCRIPTION
In order to avoid circular dependencies between core and implementation namespaces, I have added a `protocols` ns and moved `Storage` to it.  Others may be moved later on as well.