### PR TITLE
Events security

### DIFF
--- a/.monkeyci/build.clj
+++ b/.monkeyci/build.clj
@@ -114,16 +114,17 @@
   "Creates a step that builds and uploads an image using kaniko"
   [{:keys [id dockerfile context image tag opts]}]
   (fn [ctx]
-    (let [wd (cond-> (shell/container-work-dir ctx)
-               context (str "/" context))]
+    (let [wd (shell/container-work-dir ctx)
+          ctx-dir (cond-> wd 
+                    context (str "/" context))]
       (core/container-job
        id
        (merge
         {:image "docker.io/monkeyci/kaniko:1.21.0"
          :script [(format "/kaniko/executor --dockerfile %s --destination %s --context dir://%s"
-                          (str wd "/" (or dockerfile "Dockerfile"))
+                          (str ctx-dir "/" (or dockerfile "Dockerfile"))
                           (str image ":" (or tag (image-version ctx)))
-                          wd)]
+                          ctx-dir)]
          ;; Set docker config credentials location
          :container/env {"DOCKER_CONFIG" (str wd "/.docker")}
          :restore-artifacts [image-creds-artifact]

--- a/app/src/monkey/ci/web/api.clj
+++ b/app/src/monkey/ci/web/api.clj
@@ -363,6 +363,7 @@
 (defn event-stream
   "Sets up an event stream for the specified filter."
   [req]
+  ;; TODO Only send events for the customer specified in the url
   (let [recv (c/from-rt req rt/events-receiver)
         stream (ms/stream)
         make-reply (fn [evt]

--- a/app/src/monkey/ci/web/handler.clj
+++ b/app/src/monkey/ci/web/handler.clj
@@ -172,6 +172,9 @@
                     repo-ssh-keys-routes
                     build-routes]})])
 
+(def event-stream-routes
+  ["/events" {:get {:handler api/event-stream}}])
+
 (def customer-routes
   ["/customer"
    {:middleware [:customer-check]}
@@ -184,10 +187,8 @@
      :id-key :customer-id
      :child-routes [repo-routes
                     customer-parameter-routes
-                    customer-ssh-keys-routes]})])
-
-(def event-stream-routes
-  ["/events" {:get {:handler api/event-stream}}])
+                    customer-ssh-keys-routes
+                    event-stream-routes]})])
 
 (def github-routes
   ["/github" [["/login" {:post
@@ -222,7 +223,6 @@
    ["/version" {:get version}]
    webhook-routes
    customer-routes
-   event-stream-routes
    github-routes
    auth-routes
    user-routes])

--- a/app/test/monkey/ci/web/handler_test.clj
+++ b/app/test/monkey/ci/web/handler_test.clj
@@ -560,9 +560,9 @@
                 (is (= 404 (:status l)))))))))))
 
 (deftest event-stream
-  (testing "'GET /events' exists"
+  (testing "'GET /customer/:customer-id/events' exists"
     (is (not= 404
-              (-> (mock/request :get "/events")
+              (-> (mock/request :get "/customer/test-cust/events")
                   (test-app)
                   :status)))))
 

--- a/gui/src/monkey/ci/gui/build/events.cljc
+++ b/gui/src/monkey/ci/gui/build/events.cljc
@@ -8,12 +8,12 @@
 
 (rf/reg-event-fx
  :build/init
- (fn [_ _]
+ (fn [{:keys [db]} _]
    {:dispatch-n [[:build/load]
                  ;; Make sure we stop listening to events when we leave this page
                  [:route/on-page-leave [:event-stream/stop stream-id]]
                  ;; TODO Only start reading events when the build has not finished yet
-                 [:event-stream/start stream-id [:build/handle-event]]]}))
+                 [:event-stream/start stream-id (r/customer-id db) [:build/handle-event]]]}))
 
 (defn load-logs-req [db]
   [:secure-request

--- a/gui/src/monkey/ci/gui/core.cljs
+++ b/gui/src/monkey/ci/gui/core.cljs
@@ -19,8 +19,8 @@
 
 (defn ^:dev/after-load reload []
   ;; Creating the root multiple times gives a react warning on reload.  However, if we
-  ;; keep track of the existing root instead, re-frame subs give problems, so we're
-  ;; damned if we do, damned if we don't.
+  ;; keep track of the existing root instead, re-frame subs give problems, that's why
+  ;; the pages ns is on "always reload".
   (let [root (get-app-root!)]
     (rf/clear-subscription-cache!)
     (rd/render root [p/render])))

--- a/gui/src/monkey/ci/gui/repo/events.cljc
+++ b/gui/src/monkey/ci/gui/repo/events.cljc
@@ -10,11 +10,11 @@
 (rf/reg-event-fx
  :repo/init
  (fn [{:keys [db]} _]
-   (let [cust-id (get-in (r/current db) [:parameters :path :customer-id])]
+   (let [cust-id (r/customer-id db)]
      {:dispatch-n [[:repo/load cust-id]
                    ;; Make sure we stop listening to events when we leave this page
                    [:route/on-page-leave [:event-stream/stop stream-id]]
-                   [:event-stream/start stream-id [:repo/handle-event]]]})))
+                   [:event-stream/start stream-id cust-id [:repo/handle-event]]]})))
 
 (rf/reg-event-fx
  :repo/load

--- a/gui/src/monkey/ci/gui/routing.cljs
+++ b/gui/src/monkey/ci/gui/routing.cljs
@@ -3,7 +3,13 @@
             [reitit.frontend :as f]
             [reitit.frontend.easy :as rfe]))
 
-(def current :route/current)
+(def current
+  "Retrieve current route from app db"
+  :route/current)
+
+(def customer-id
+  "Retrieve current customer id from app db"
+  (comp :customer-id :path :parameters current))
 
 (rf/reg-sub
  :route/current

--- a/gui/test/monkey/ci/gui/test/server_events_test.cljs
+++ b/gui/test/monkey/ci/gui/test/server_events_test.cljs
@@ -12,7 +12,7 @@
   (testing "connects and adds to db using id"
     (rf/reg-cofx :event-stream/connector (fn [cofx _]
                                            (assoc cofx ::sut/connector (constantly ::test-connector))))
-    (is (nil? (rf/dispatch-sync [:event-stream/start ::test-id [::test-evt]])))
+    (is (nil? (rf/dispatch-sync [:event-stream/start ::test-id "test-customer" [::test-evt]])))
     (is (= {:handler-evt [::test-evt]
             :source ::test-connector}
            (sut/stream-config @app-db ::test-id)))))


### PR DESCRIPTION
- Moved events endpoint under customer
- Add separate events endpoint because we don't want to use api gateway for this.
- Fix gui image build

Still todo: only dispatch events for that customer and pass the token as query param.