### PR TITLE
Events instead of polling

### DIFF
--- a/.monkeyci/build.clj
+++ b/.monkeyci/build.clj
@@ -10,7 +10,7 @@
 
 ;; Version assigned when building main branch
 ;; TODO Determine automatically
-(def snapshot-version "0.4.0-SNAPSHOT")
+(def snapshot-version "0.4.1-SNAPSHOT")
 
 (defn git-ref [ctx]
   (get-in ctx [:build :git :ref]))

--- a/app/env/dev/events.clj
+++ b/app/env/dev/events.clj
@@ -1,0 +1,32 @@
+(ns events
+  (:require [clojure.tools.logging :as log]
+            [com.stuartsierra.component :as co]
+            [manifold.stream :as ms]
+            [monkey.ci.events.core :as ec]))
+
+(defn trace-events
+  "Connects to zmq events endpoint and puts all events on a stream."
+  [addr]
+  (let [stream (ms/stream 100)
+        events (-> (ec/make-events {:events
+                                    {:type :zmq
+                                     :client {:address addr}}})
+                   (co/start))]
+    (ec/add-listener events nil (partial ms/put! stream))
+    (ms/on-closed stream
+                  (fn []
+                    (println "Stream closed, closing client")
+                    (co/stop events)))
+    (println "Started capturing all events")
+    stream))
+
+(defn log-events
+  "Consumes event stream and logs the events.  A human readable description
+   is printed to repl, the full event to log."
+  [stream]
+  (letfn [(log-evt [evt]
+            (println "Event:" (:type evt)
+                     "-" (some-> evt :time (java.time.Instant/ofEpochMilli))
+                     "-" (:message evt))
+            (log/info "Event:" evt))]
+    (ms/consume log-evt stream)))

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>com.monkeyci</groupId>
   <artifactId>app</artifactId>
-  <version>0.4.0-SNAPSHOT</version>
+  <version>0.4.1-SNAPSHOT</version>
   <name>app</name>
   <repositories>
     <repository>
@@ -41,6 +41,11 @@
       <groupId>org.clojure</groupId>
       <artifactId>tools.logging</artifactId>
       <version>1.2.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.zeromq</groupId>
+      <artifactId>jeromq</artifactId>
+      <version>0.5.4</version>
     </dependency>
     <dependency>
       <groupId>cli-matic</groupId>
@@ -157,6 +162,17 @@
         <exclusion>
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcutil-jdk15on</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.monkeyprojects</groupId>
+      <artifactId>zmq</artifactId>
+      <version>0.2.0-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.zeromq</groupId>
+          <artifactId>jzmq</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/app/resources/job.sh
+++ b/app/resources/job.sh
@@ -66,14 +66,14 @@ run_command()
 
 echo "Starting job script with working directory $MONKEYCI_WORK_DIR"
 mkdir -p $MONKEYCI_LOG_DIR
-post_event "{:type :job/wait}"
+post_event "{:type :container/pending}"
 wait_for_start
 if [ "$ABORT" == "yes" ]; then
     echo "Aborted."
     exit 1
 fi
 
-post_event "{:type :job/start}"
+post_event "{:type :container/start}"
 cd $MONKEYCI_WORK_DIR
 # Execute all arguments as script commands
 for v in $*
@@ -83,9 +83,9 @@ do
     if [ $r -ne 0 ]; then
 	echo "Got error at step $v: $r"
 	# Nonzero return value means error, so don't proceed
-	post_event "{:type :job/failed :done? true :exit $r :step \"$v\"}"
+	post_event "{:type :container/end :status :error :done? true :exit $r :step \"$v\"}"
 	exit $r
     fi
 done
-post_event "{:type :job/success :done? true}"
+post_event "{:type :container/end :status :success :done? true}"
 echo "All done."

--- a/app/src/monkey/ci/build.clj
+++ b/app/src/monkey/ci/build.clj
@@ -29,7 +29,8 @@
   (or (get-in rt [:build :build-id]) "unknown-build"))
 
 (def get-job-sid
-  "Creates a unique step id using the build id and job id"
+  "Creates a job sid using the build id and job id.  Note that this does
+   not include the customer and repo ids, so this is only unique within the repo."
   (comp (partial mapv str)
         (juxt get-build-id
               (comp bc/job-id :job))))
@@ -37,6 +38,8 @@
 (def get-job-id
   "Creates a string representation of the job sid"
   (comp (partial cs/join "-") get-job-sid))
+
+(def rt->job-id (comp bc/job-id :job))
 
 (defn- maybe-set-git-opts [build rt]
   (let [{:keys [git-url branch commit-id dir]} (rt/args rt)]

--- a/app/src/monkey/ci/commands.clj
+++ b/app/src/monkey/ci/commands.clj
@@ -3,6 +3,7 @@
   (:require [clojure.tools.logging :as log]
             [monkey.ci
              [build :as b]
+             [jobs :as jobs]
              [runtime :as rt]
              [sidecar :as sidecar]
              [utils :as u]]
@@ -136,13 +137,17 @@
    which are then picked up by the sidecar to dispatch or store.  
 
    The sidecar loop will stop when the events file is deleted."
-  [rt]
+  [{:keys [job] :as rt}]
   (let [sid (b/get-sid rt)]
     (try
-      (rt/post-events rt {:type :sidecar/start :sid sid})
+      (rt/post-events rt {:type :sidecar/start
+                          :sid sid
+                          :job (jobs/job->event job)})
       (-> (sidecar/run rt)
           (deref)
           :exit-code)
       (finally
         (log/info "Sidecar terminated")
-        (rt/post-events rt {:type :sidecar/end :sid sid})))))
+        (rt/post-events rt {:type :sidecar/end
+                            :sid sid
+                            :job (jobs/job->event job)})))))

--- a/app/src/monkey/ci/commands.clj
+++ b/app/src/monkey/ci/commands.clj
@@ -137,9 +137,12 @@
 
    The sidecar loop will stop when the events file is deleted."
   [rt]
-  (try
-    (-> (sidecar/run rt)
-        (deref)
-        :exit-code)
-    (finally
-      (log/info "Sidecar terminated"))))
+  (let [sid (b/get-sid rt)]
+    (try
+      (rt/post-events rt {:type :sidecar/start :sid sid})
+      (-> (sidecar/run rt)
+          (deref)
+          :exit-code)
+      (finally
+        (log/info "Sidecar terminated")
+        (rt/post-events rt {:type :sidecar/end :sid sid})))))

--- a/app/src/monkey/ci/containers/oci.clj
+++ b/app/src/monkey/ci/containers/oci.clj
@@ -186,18 +186,10 @@
   "Checks the incoming events to see if a sidecar end event has been received.
    Returns a deferred that will contain the sidecar end event."
   [events sid job-id]
-  (let [r (md/deferred)
-        f {:types #{:sidecar/end}
-           :sid sid}
-        l (fn [evt]
-            (when (= job-id (get-in evt [:job :id]))
-              (md/success! r evt)))
-        unregister (fn [_]
-                     (ec/remove-listener events f l))]
-    ;; Make sure to unregister the listener in any case
-    (md/on-realized r unregister unregister)
-    (ec/add-listener events f l)
-    r))
+  (ec/wait-for-event events
+                     {:types #{:sidecar/end}
+                      :sid sid}
+                     #(= job-id (get-in % [:job :id]))))
 
 (defmethod mcc/run-container :oci [rt]
   (log/debug "Running job as OCI instance:" (:job rt))
@@ -205,18 +197,23 @@
         client (-> conf
                    (oci/->oci-config)
                    (ci/make-context))
-        ic (instance-config conf rt)]
+        ic (instance-config conf rt)
+        max-job-timeout (* 20 60 60 1000)]
     (md/chain
-     (oci/run-instance client ic {:delete? true
-                                  :exited? (fn [id]
-                                             (md/chain
-                                              ;; TODO When a start event has not been received after
-                                              ;; a sufficient period of time, start polling anyway.
-                                              (wait-for-sidecar-end-event (:events rt)
-                                                                          (b/get-sid rt)
-                                                                          (b/rt->job-id rt))
-                                              (fn [_]
-                                                (oci/get-full-instance-details client id))))})
+     (oci/run-instance client ic
+                       {:delete? true
+                        :exited? (fn [id]
+                                   (md/chain
+                                    ;; TODO When a start event has not been received after
+                                    ;; a sufficient period of time, start polling anyway.
+                                    ;; For now, we add a max timeout.
+                                    (md/timeout!
+                                     (wait-for-sidecar-end-event (:events rt)
+                                                                 (b/get-sid rt)
+                                                                 (b/rt->job-id rt))
+                                     max-job-timeout ::timeout)
+                                    (fn [_]
+                                      (oci/get-full-instance-details client id))))})
      (fn [r]
        (letfn [(maybe-log-output [{:keys [exit-code display-name logs] :as c}]
                  (when (not= 0 exit-code)

--- a/app/src/monkey/ci/events/core.clj
+++ b/app/src/monkey/ci/events/core.clj
@@ -1,5 +1,6 @@
 (ns monkey.ci.events.core
   (:require [monkey.ci
+             [config :as c]
              [protocols :as p]
              [runtime :as rt]]
             [monkey.ci.events
@@ -64,6 +65,11 @@
   (fn [evt]
     (f evt)
     nil))
+
+(defmethod c/normalize-key :events [k conf]
+  (update conf k (comp #(c/group-keys % :client)
+                       #(c/group-keys % :server)
+                       c/keywordize-type)))
 
 (defmulti make-events (comp :type :events))
 

--- a/app/src/monkey/ci/events/core.clj
+++ b/app/src/monkey/ci/events/core.clj
@@ -1,5 +1,6 @@
 (ns monkey.ci.events.core
-  (:require [monkey.ci
+  (:require [manifold.deferred :as md]
+            [monkey.ci
              [config :as c]
              [protocols :as p]
              [runtime :as rt]]
@@ -115,3 +116,20 @@
             (maybe-post error args ex)
             (throw ex)))
         (inv args)))))
+
+(defn wait-for-event
+  "Utility fn that registers using an event filter and invokes the handler when one has
+   been received.  Returns a deferred that realizes with the received event.  An additional
+   predicate can do extra filtering if it's not supported by the event filter."
+  [events ef & [pred]]
+  (let [r (md/deferred)
+        l (fn [evt]
+            (when (or (nil? pred) (pred evt))
+              (md/success! r evt)))
+        unregister (fn [_]
+                     (remove-listener events ef l))]
+    ;; Make sure to unregister the listener in any case
+    (md/on-realized r unregister unregister)
+    (add-listener events ef l)
+    r))
+

--- a/app/src/monkey/ci/jobs.clj
+++ b/app/src/monkey/ci/jobs.clj
@@ -318,3 +318,10 @@
        (filter resolvable?)
        (mapcat #(resolve-jobs % rt))
        (filter job?)))
+
+(defn job->event
+  "Converts job into something that can be put in an event"
+  [job]
+  (-> job
+      (select-keys [:status :start-time :end-time deps labels])
+      (assoc :id (bc/job-id job))))

--- a/app/src/monkey/ci/listeners.clj
+++ b/app/src/monkey/ci/listeners.clj
@@ -67,7 +67,7 @@
   co/Lifecycle
   (start [this]
     ;; Register listeners
-    (ec/add-listener events (build-update-handler storage) {:types (set (keys update-handlers))})
+    (ec/add-listener events {:types (set (keys update-handlers))} (build-update-handler storage))
     this)
   (stop [this]))
 

--- a/app/src/monkey/ci/oci.clj
+++ b/app/src/monkey/ci/oci.clj
@@ -138,6 +138,7 @@
           (start-polling [{:keys [id]}]
             (log/debug "Starting polling...")
             ;; TODO Replace this with OCI events as soon as they become available.
+            ;; FIXME Polling may result in a 429 from OCI so need to replace this with events.
             (wait-for-completion (-> {:instance-id id
                                       :get-details get-instance-details}
                                      (merge (select-keys opts [:poll-interval :post-event])))))

--- a/app/src/monkey/ci/process.clj
+++ b/app/src/monkey/ci/process.clj
@@ -45,7 +45,7 @@
    (try
      (when (-> (config/normalize-config default-script-config (config/strip-env-prefix env) args)
                (rt/with-runtime :script rt
-                 (log/debug "Executing script with runtime" rt)
+                 (log/debug "Executing script with config" (:config rt))
                  (log/debug "Script working directory:" (utils/cwd))
                  (script/exec-script! rt))
                (bc/failed?))

--- a/app/src/monkey/ci/process.clj
+++ b/app/src/monkey/ci/process.clj
@@ -22,6 +22,7 @@
             [monkey.ci.build.core :as bc]
             ;; Need to require these for the multimethod discovery
             [monkey.ci.containers.oci]
+            [monkey.ci.events.core]
             [monkey.ci.storage.file]
             [monkey.ci.storage.oci]
             [monkey.ci.web.script-api :as script-api]

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -54,12 +54,12 @@
        (fn [r]
          (or (-> r :body :containers first :exit-code) 1))
        (fn [r]
-         (rt/post-events rt (b/build-completed-evt (:build rt) r))
+         (rt/post-events rt (b/build-end-evt (:build rt) r))
          r))
       (md/catch
           (fn [ex]
             (log/error "Got error from container instance:" ex)
-            (rt/post-events rt (b/build-completed-evt (:build rt) 1))))))
+            (rt/post-events rt (b/build-end-evt (:build rt) 1))))))
 
 (defmethod r/make-runner :oci [rt]
   (let [conf (:runner rt)

--- a/app/src/monkey/ci/script.clj
+++ b/app/src/monkey/ci/script.clj
@@ -29,7 +29,7 @@
   (assoc evt
          :src :script
          :sid (get-in rt [:build :sid])
-         :time (System/currentTimeMillis)))
+         :time (u/now)))
 
 (defn- post-event [rt evt]
   (log/trace "Posting event:" evt)
@@ -40,6 +40,10 @@
         (log/warn "Failed to post event, got status" status)
         (log/debug "Full response:" r)))
     (log/warn "Unable to post event, no client configured")))
+
+(defn- post-events [rt events]
+  (doseq [e events]
+    (post-event rt e)))
 
 (defn- wrapped
   "Sets the event poster in the runtime."
@@ -250,7 +254,7 @@
         script-dir (build/rt->script-dir rt)
         ;; Manually add events poster
         ;; This will be removed when events are reworked to be more generic
-        rt (assoc-in rt [:events :poster] (partial post-event rt))]
+        rt (assoc-in rt [:events :poster] (partial post-events rt))]
     (log/debug "Executing script for build" build-id "at:" script-dir)
     (log/debug "Script runtime:" rt)
     (try 

--- a/app/src/monkey/ci/script.clj
+++ b/app/src/monkey/ci/script.clj
@@ -197,7 +197,8 @@
 (defn- with-script-evt
   "Creates an skeleton event with the script and invokes `f` on it"
   [rt f]
-  (f {:script (-> rt rt/build build/script)}))
+  (f {:script (-> rt rt/build build/script)
+      :sid (build/get-sid rt)}))
 
 (defn- script-start-evt [rt _]
   (with-script-evt rt
@@ -266,6 +267,7 @@
         (let [msg ((some-fn (comp ex-message ex-cause)
                             ex-message) ex)]
           (post-event rt {:type :script/end
+                          :sid (build/get-sid rt)
                           :script (-> rt rt/build build/script)
                           :message msg})
           (assoc bc/failure

--- a/app/src/monkey/ci/sidecar.clj
+++ b/app/src/monkey/ci/sidecar.clj
@@ -77,7 +77,9 @@
       (upload-log logger l)
       (log/debug "File uploaded:" l))))
 
-(defn poll-events [rt]
+(defn poll-events
+  "Reads events from the job container events file and posts them to the event service."
+  [rt]
   (let [f (-> (get-config rt :events-file)
               (maybe-create-file))
         read-next (fn [r]
@@ -122,7 +124,6 @@
    containing the runtime with an `:exit-code` added."
   [rt]
   (log/info "Running sidecar with configuration:" (get-in rt [rt/config :sidecar]))
-  (log/debug "Max memory available to this VM:" (.maxMemory (Runtime/getRuntime)) "bytes")
   ;; Restore caches and artifacts before starting the job
   (let [h (-> (comp poll-events mark-start)
               (art/wrap-artifacts)

--- a/app/src/monkey/ci/utils.clj
+++ b/app/src/monkey/ci/utils.clj
@@ -151,3 +151,8 @@
 
 (defn now []
   (System/currentTimeMillis))
+
+(defn ->seq
+  "Converts `x` into a sequential"
+  [x]
+  (if (sequential? x) x [x]))

--- a/app/test/monkey/ci/commands_test.clj
+++ b/app/test/monkey/ci/commands_test.clj
@@ -117,4 +117,11 @@
 (deftest sidecar
   (testing "runs sidecar poll loop, returns exit code"
     (with-redefs [sc/run (constantly (md/success-deferred {:exit-code ::test-exit}))]
-      (is (= ::test-exit (sut/sidecar {}))))))
+      (is (= ::test-exit (sut/sidecar {})))))
+
+  (testing "posts start and end events"
+    (with-redefs [sc/run (constantly (md/success-deferred {:exit-code ::test-exit}))]
+      (let [{:keys [recv] :as e} (h/fake-events)]
+        (is (some? (sut/sidecar {:events e})))
+        (is (= [:sidecar/start :sidecar/end]
+               (map :type @recv)))))))

--- a/app/test/monkey/ci/events/core_test.clj
+++ b/app/test/monkey/ci/events/core_test.clj
@@ -1,5 +1,6 @@
 (ns monkey.ci.events.core-test
   (:require [clojure.test :refer [deftest testing is]]
+            [monkey.ci.config :as c]
             [monkey.ci.events
              [core :as sut]
              [async-tests :as ast]]))
@@ -120,3 +121,18 @@
                                   first
                                   :exception
                                   (.getMessage)))))))
+
+(deftest normalize-key
+  (testing "groups client subkey"
+    (is (= {:type :zmq
+            :client {:addr "test-addr"}}
+           (-> (c/normalize-key :events {:events {:type "zmq"
+                                                  :client-addr "test-addr"}})
+               :events))))
+
+  (testing "groups server subkey"
+    (is (= {:type :zmq
+            :server {:addr "test-addr"}}
+           (-> (c/normalize-key :events {:events {:type "zmq"
+                                                  :server-addr "test-addr"}})
+               :events)))))

--- a/app/test/monkey/ci/events/core_test.clj
+++ b/app/test/monkey/ci/events/core_test.clj
@@ -92,7 +92,7 @@
                      (swap! invocations conj (into [t] args))
                      {:event t}))
           poster (fn [evt]
-                   (swap! invocations conj [:event evt]))
+                   (swap! invocations conj [:event (first evt)]))
           w (sut/wrapped (test-f :during)
                          (test-f :before)
                          (test-f :after))]
@@ -100,10 +100,10 @@
              (w {:events {:poster poster}} "test-arg")))
       (is (= 5 (count @invocations)))
       (is (= :before (ffirst @invocations)))
-      (is (= [:event {:event :before}] (second @invocations)))
+      (is (= {:event :before} (-> (second @invocations) second (select-keys [:event]))))
       (is (= :during (first (nth @invocations 2))))
       (is (= :after (first (nth @invocations 3))))
-      (is (= [:event {:event :after}] (nth @invocations 4)))))
+      (is (= {:event :after} (-> (nth @invocations 4) second (select-keys [:event]))))))
 
   (testing "invokes `on-error` fn on exception"
     (let [inv (atom [])
@@ -118,7 +118,7 @@
       (is (thrown? Exception (w {:events {:poster poster}})))
       (is (= 1 (count @inv)))
       (is (= "test error" (some-> @inv
-                                  first
+                                  ffirst
                                   :exception
                                   (.getMessage)))))))
 

--- a/app/test/monkey/ci/examples_test.clj
+++ b/app/test/monkey/ci/examples_test.clj
@@ -15,7 +15,7 @@
           :dir path})))
 
 (defn success? [r]
-  (= 0 (deref r 30000 :timeout)))
+  (= 0 r #_(deref r 30000 :timeout)))
 
 (deftest ^:integration examples
   (letfn [(run-example-test [n]

--- a/app/test/monkey/ci/helpers.clj
+++ b/app/test/monkey/ci/helpers.clj
@@ -7,7 +7,9 @@
             [manifold.deferred :as md]
             [monkey.ci
              [blob :as blob]
-             [storage :as s]]
+             [protocols :as p]
+             [storage :as s]
+             [utils :as u]]
             [monkey.ci.web
              [common :as wc]
              [auth :as auth]]
@@ -133,3 +135,14 @@
 
 (defn generate-private-key []
   (.getPrivate (auth/generate-keypair)))
+
+(defrecord FakeEvents [recv]
+  p/EventPoster
+  (post-events [this evt]
+    (swap! recv (comp vec concat) (u/->seq evt))))
+
+(defn fake-events
+  "Set up fake events implementation.  It returns an event poster that can be
+   queried for received events."
+  []
+  (->FakeEvents (atom [])))

--- a/app/test/monkey/ci/runners/oci_test.clj
+++ b/app/test/monkey/ci/runners/oci_test.clj
@@ -31,10 +31,10 @@
     (with-redefs [ci/create-container-instance (fn [_ opts]
                                                  {:status 500})
                   ci/delete-container-instance (fn [_ r] r)]
-      (let [received (atom [])]
-        (is (some? (sut/oci-runner {} {} {:events {:poster (partial swap! received conj)}})))
-        (is (not-empty @received))
-        (is (= :build/end (-> @received first :type)))))))
+      (let [{:keys [recv] :as e} (h/fake-events)]
+        (is (some? (sut/oci-runner {} {} {:events e})))
+        (is (not-empty @recv))
+        (is (= :build/end (-> @recv first :type)))))))
 
 (deftest instance-config
   (let [priv-key (h/generate-private-key)

--- a/app/test/monkey/ci/runners_test.clj
+++ b/app/test/monkey/ci/runners_test.clj
@@ -26,14 +26,14 @@
                      (deref)))))
 
       (testing "fires `:build/end` event with error status"
-        (let [events (atom [])]
+        (let [{:keys [recv] :as e} (h/fake-events)]
           (is (some? (-> {:build
                           {:script {:script-dir "nonexisting"}}
-                          :events {:poster (partial swap! events conj)}}
-                         (sut/build-local)
+                          :events e} 
+                        (sut/build-local)
                          (deref))))
-          (is (not-empty @events))
-          (let [m (->> @events
+          (is (not-empty @recv))
+          (let [m (->> @recv
                        (filter (comp (partial = :build/end) :type))
                        (first))]
             (is (some? m))

--- a/app/test/monkey/ci/runtime_test.clj
+++ b/app/test/monkey/ci/runtime_test.clj
@@ -11,6 +11,7 @@
              [storage]
              [workspace]]
             [monkey.ci.events.core]
+            [monkey.ci.helpers :as h]
             [monkey.ci.web.handler]))
 
 (defn- verify-runtime [k extra-config checker]
@@ -100,3 +101,17 @@
                     (md/success-deferred (:test rt)))
                   ((juxt :started? :stopped?))
                   (map deref)))))))
+
+(deftest post-events
+  (letfn [(verify-time [evt checker]
+            (let [{:keys [recv] :as e} (h/fake-events)]
+              (is (some? (sut/post-events {:events e} evt)))
+              (is (checker (-> @recv
+                               first
+                               :time)))))]
+    
+    (testing "adds time"
+      (is (verify-time {:type :test-event} number?)))
+
+    (testing "keeps provided time"
+      (is (verify-time {:type :test-event :time 100} (partial = 100))))))

--- a/app/test/monkey/ci/sidecar_test.clj
+++ b/app/test/monkey/ci/sidecar_test.clj
@@ -29,8 +29,8 @@
       (let [f (io/file dir "events.edn")
             evt {:type :test/event
                  :message "This is a test event"}
-            recv (atom [])
-            rt {:events {:poster (partial swap! recv conj)}
+            {:keys [recv] :as e} (h/fake-events)
+            rt {:events e
                 :config {:sidecar {:poll-interval 10
                                    :events-file f}}}
             _ (spit f (prn-str evt))
@@ -47,8 +47,8 @@
       (let [f (io/file dir "events.edn")
             evt {:type :test/event
                  :message "This is a test event"}
-            recv (atom [])
-            rt {:events {:poster (partial swap! recv conj)}
+            {:keys [recv] :as e} (h/fake-events)
+            rt {:events e
                 :config {:sidecar {:events-file f
                                    :poll-interval 10}}}
             c (sut/poll-events rt)]
@@ -66,8 +66,8 @@
             evt {:type :test/event
                  :message "This is a test event"
                  :done? true}
-            recv (atom [])
-            rt {:events {:poster (partial swap! recv conj)}
+            {:keys [recv] :as e} (h/fake-events)
+            rt {:events e
                 :config {:sidecar {:events-file f
                                    :poll-interval 10}}}
             c (sut/poll-events rt)]

--- a/app/test/monkey/ci/web/script_api_test.clj
+++ b/app/test/monkey/ci/web/script_api_test.clj
@@ -6,12 +6,12 @@
             [ring.mock.request :as mock]))
 
 (deftest routes
-  (let [events (atom [])
+  (let [{:keys [recv] :as e} (h/fake-events)
         test-app (sut/make-app {:public-api (fn [_]
                                               (fn [ep]
                                                 (when (= :get-params ep)
                                                   {"key" "value"})))
-                                :events {:poster (partial swap! events conj)}})]
+                                :events e})]
 
     (testing "unknown endpoint results in 404"
       (is (= 404 (-> (mock/request :get "/unknown")
@@ -38,7 +38,7 @@
                   (mock/header :content-type "application/edn")
                   (test-app))]
         (is (= 202 (:status r)))
-        (is (= evt (-> @events
+        (is (= evt (-> @recv
                        (first)
                        (select-keys (keys evt)))))))))
 

--- a/gui/src/monkey/ci/gui/build/db.cljc
+++ b/gui/src/monkey/ci/gui/build/db.cljc
@@ -72,8 +72,3 @@
 
 (defn set-auto-reload [db v]
   (assoc db auto-reload? v))
-
-(def last-reload-time ::last-reload-time)
-
-(defn set-last-reload-time [db t]
-  (assoc db last-reload-time t))

--- a/gui/src/monkey/ci/gui/build/events.cljc
+++ b/gui/src/monkey/ci/gui/build/events.cljc
@@ -97,9 +97,7 @@
  (fn [{:keys [db] :as cofx} _]
    {:dispatch-n [(load-build-req db)
                  (load-logs-req db)]
-    :db (-> db
-            (db/set-reloading)
-            (db/set-last-reload-time (:time/now cofx)))}))
+    :db (db/set-reloading db)}))
 
 (rf/reg-event-fx
  :build/download-log

--- a/gui/src/monkey/ci/gui/build/subs.cljc
+++ b/gui/src/monkey/ci/gui/build/subs.cljc
@@ -8,7 +8,6 @@
 (u/db-sub :build/current db/build)
 (u/db-sub :build/logs db/logs)
 (u/db-sub :build/reloading? (comp some? db/reloading?))
-(u/db-sub :build/last-reload-time db/last-reload-time)
 
 (u/db-sub :build/log-alerts db/log-alerts)
 (u/db-sub :build/downloading? (comp some? db/downloading?))

--- a/gui/src/monkey/ci/gui/build/views.cljc
+++ b/gui/src/monkey/ci/gui/build/views.cljc
@@ -96,8 +96,8 @@
   [:span (calc-elapsed s)])
 
 (defn- elapsed-running [s]
-  (let [t (rf/subscribe [:build/last-reload-time])]
-    [:span (calc-elapsed (assoc s :end-time @t))]))
+  (let [now (t/to-epoch (t/now))]
+    [:span (calc-elapsed (assoc s :end-time now))]))
 
 (defn- elapsed [x]
   (if (u/running? x)

--- a/gui/test/monkey/ci/gui/test/build/events_test.cljc
+++ b/gui/test/monkey/ci/gui/test/build/events_test.cljc
@@ -139,13 +139,7 @@
 
   (testing "marks reloading"
     (rf/dispatch-sync [:build/reload])
-    (is (some? (db/reloading? @app-db))))
-
-  (testing "sets reload time"
-    (rf/reg-cofx :time/now (fn [cofx]
-                             (assoc cofx :time/now 444)))
-    (rf/dispatch-sync [:build/reload])
-    (is (= 444 (db/last-reload-time @app-db)))))
+    (is (some? (db/reloading? @app-db)))))
 
 (deftest build-download-log
   (testing "sets downloading"

--- a/gui/test/monkey/ci/gui/test/build/subs_test.cljc
+++ b/gui/test/monkey/ci/gui/test/build/subs_test.cljc
@@ -109,15 +109,6 @@
       (is (map? (reset! app-db (db/set-log-path {} "test-path"))))
       (is (= "test-path" @c)))))
 
-(deftest last-reload-time
-  (let [t (rf/subscribe [:build/last-reload-time])]
-    (testing "exists"
-      (is (some? t)))
-
-    (testing "returns last reload time from db"
-      (is (map? (reset! app-db (db/set-last-reload-time {} 543))))
-      (is (= 543 @t)))))
-
 (deftest global-logs
   (let [g (rf/subscribe [:build/global-logs])]
     (testing "exists"


### PR DESCRIPTION
Replaced the poll loop for oci container instances with events.  Even though polling works, OCI tends to return 429 client errors whenever we do too much of it.  This is already noticeable when a more complicated build runs.  So I've replaced it with an event check.  The run fn waits for a sidecar end or script end event (either for container or runner) to arrive.  As an additional safety, a timeout is added as well.  In the future this should be expanded with an additional check if we've received a start event within a certain timeout.  If not, we can assume something is wrong and the instance has not even started.