### PR TITLE
Feature/remove script api

### DIFF
--- a/.monkeyci/build.clj
+++ b/.monkeyci/build.clj
@@ -10,7 +10,7 @@
 
 ;; Version assigned when building main branch
 ;; TODO Determine automatically
-(def snapshot-version "0.4.3-SNAPSHOT")
+(def snapshot-version "0.4.4-SNAPSHOT")
 
 (defn git-ref [ctx]
   (get-in ctx [:build :git :ref]))

--- a/app/deps.edn
+++ b/app/deps.edn
@@ -20,7 +20,7 @@
         com.monkeyprojects/oci-sign {:mvn/version "0.1.3"}
         com.monkeyprojects/oci-container-instance {:mvn/version "0.1.0"}
         com.monkeyprojects/oci-os {:mvn/version "0.2.2"}
-        com.monkeyprojects/zmq {:mvn/version "0.3.1-SNAPSHOT"
+        com.monkeyprojects/zmq {:mvn/version "0.3.1"
                                 ;; Use jeromq, so we don't need native lib.  This is a bit
                                 ;; slower however, so maybe later we can change this.
                                 :exclusions [org.zeromq/jzmq]}

--- a/app/env/dev/instances.clj
+++ b/app/env/dev/instances.clj
@@ -140,6 +140,11 @@
 (defn list-instances []
   (instance-call ci/list-container-instances #(select-keys % [:compartment-id]) :items))
 
+(defn list-active []
+  (md/chain
+   (list-instances)
+   (partial filter (comp (partial = "ACTIVE") :lifecycle-state))))
+
 (defn get-instance [id]
   (instance-call ci/get-container-instance (constantly {:instance-id id})))
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>com.monkeyci</groupId>
   <artifactId>app</artifactId>
-  <version>0.4.3-SNAPSHOT</version>
+  <version>0.4.4-SNAPSHOT</version>
   <name>app</name>
   <repositories>
     <repository>
@@ -183,7 +183,7 @@
     <dependency>
       <groupId>com.monkeyprojects</groupId>
       <artifactId>zmq</artifactId>
-      <version>0.3.1-SNAPSHOT</version>
+      <version>0.3.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.zeromq</groupId>

--- a/app/src/monkey/ci/build/api.clj
+++ b/app/src/monkey/ci/build/api.clj
@@ -1,27 +1,19 @@
 (ns monkey.ci.build.api
   "Functions for invoking the script API."
-  (:require [martian.core :as martian]))
+  (:require [clojure.tools.logging :as log]
+            [martian.core :as martian]
+            [monkey.ci.build :as b]))
 
-(def ctx->api-client (comp :client :api))
+(def rt->api-client (comp :client :api))
+
+(defn- fetch-params* [rt]
+  (let [client (rt->api-client rt)
+        [cust-id repo-id] (b/get-sid rt)]
+    (log/debug "Fetching repo params for" cust-id repo-id)
+    (->> @(client {:url (format "/customer/%s/repo/%s/param" cust-id repo-id)
+                   :method :get})
+         (map (juxt :name :value))
+         (into {}))))
 
 ;; Use memoize because we'll only want to fetch them once
-(def ^:private fetch-params (memoize (comp deref #(martian/response-for % :get-params {}))))
-
-(defn- error? [s]
-  (>= s 400))
-
-(defn- body-or-throw
-  "If the response is successful, returns the body, otherwise throws an exception."
-  [{:keys [status body] :as r}]
-  (if (error? status)
-    (throw (ex-info "Failed to invoke API call" r))
-    body))
-
-(defn build-params
-  "Retrieves the parameters configured for this build. Returns a map
-   of string/string."
-  [ctx]
-  (-> ctx
-      ctx->api-client
-      fetch-params
-      body-or-throw))
+(def build-params (memoize fetch-params*))

--- a/app/src/monkey/ci/containers/oci.clj
+++ b/app/src/monkey/ci/containers/oci.clj
@@ -191,6 +191,7 @@
                                     ;; TODO When a start event has not been received after
                                     ;; a sufficient period of time, start polling anyway.
                                     ;; For now, we add a max timeout.
+                                    ;; FIXME Seems like the timeout not always works.
                                     (md/timeout!
                                      (wait-for-sidecar-end-event (:events rt)
                                                                  (b/get-sid rt)

--- a/app/src/monkey/ci/process.clj
+++ b/app/src/monkey/ci/process.clj
@@ -111,7 +111,7 @@
   [rt]
   (-> (rt/rt->env rt)
       ;; Generate an API token and add it to the config
-      (assoc-in [:api :token] (auth/generate-jwt-from-rt rt (auth/build-token (b/get-sid rt))))
+      (update :api mc/assoc-some :token (auth/generate-jwt-from-rt rt (auth/build-token (b/get-sid rt))))
       (config/config->env)
       (merge default-envs)))
 

--- a/app/src/monkey/ci/process.clj
+++ b/app/src/monkey/ci/process.clj
@@ -25,7 +25,9 @@
             [monkey.ci.events.core]
             [monkey.ci.storage.file]
             [monkey.ci.storage.oci]
-            [monkey.ci.web.script-api :as script-api]
+            [monkey.ci.web
+             [auth :as auth]
+             [script-api :as script-api]]
             [monkey.socket-async.uds :as uds]))
 
 (def default-script-config
@@ -101,27 +103,15 @@
        (into [])
        (flatten)))
 
-(defn- make-socket-path [build-id]
-  (utils/tmp-file (str "events-" build-id ".sock")))
-
-(defn- start-script-api
-  "Starts a script API http server that listens at a domain socket 
-   location.  Returns both the server and the socket path."
-  [rt]
-  (let [build-id (get-in rt [:build :build-id])
-        path (make-socket-path build-id)]
-    {:socket-path path
-     :server (script-api/listen-at-socket path rt)}))
-
 (def default-envs
   {:lc-ctype "UTF-8"})
 
 (defn process-env
   "Build the environment to be passed to the child process."
-  [rt socket-path]
+  [rt]
   (-> (rt/rt->env rt)
-      (assoc :api
-             {:socket socket-path})
+      ;; Generate an API token and add it to the config
+      (assoc-in [:api :token] (auth/generate-jwt-from-rt rt {:sub (str "build/" (b/get-build-id rt))}))
       (config/config->env)
       (merge default-envs)))
 
@@ -139,8 +129,6 @@
   [{{:keys [checkout-dir build-id] :as build} :build :as rt}]
   (log/info "Executing build process for" build-id "in" checkout-dir)
   (let [script-dir (b/rt->script-dir rt)
-        ;; TODO Replace the script api with regular api client and token
-        {:keys [socket-path server]} (start-script-api rt)
         [out err :as loggers] (map (partial make-logger rt) [:out :err])
         result (md/deferred)
         cmd (-> ["clojure"
@@ -155,15 +143,10 @@
           :out (l/log-output out)
           :err (l/log-output err)
           :cmd cmd
-          :extra-env (process-env rt socket-path)
+          :extra-env (process-env rt)
           :exit-fn (fn [{:keys [proc] :as p}]
                      (let [exit (or (some-> proc (.exitValue)) 0)]
                        (log/debug "Script process exited with code" exit ", cleaning up")
-                       (when server
-                         (script-api/stop-server server))
-                       (when socket-path 
-                         (uds/delete-address socket-path))
-                       (log/debug "Reporting build completed to deferred")
                        (md/success! result {:process p
                                             :exit exit})))})
         ;; Depending on settings, some process streams need handling

--- a/app/src/monkey/ci/process.clj
+++ b/app/src/monkey/ci/process.clj
@@ -111,7 +111,7 @@
   [rt]
   (-> (rt/rt->env rt)
       ;; Generate an API token and add it to the config
-      (assoc-in [:api :token] (auth/generate-jwt-from-rt rt {:sub (str "build/" (b/get-build-id rt))}))
+      (assoc-in [:api :token] (auth/generate-jwt-from-rt rt (auth/build-token (b/get-sid rt))))
       (config/config->env)
       (merge default-envs)))
 

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -41,7 +41,7 @@
 
 (defn- ->env [rt]
   (->> (-> (rt/rt->env rt)
-           (dissoc :app-mode :git :github :http :args :jwk :checkout-base-dir
+           (dissoc :app-mode :git :github :http :args :jwk :checkout-base-dir :storage
                    :ssh-keys-dir :work-dir :oci)
            (update :build dissoc :cleanup? :status)
            (update-in [:build :git] dissoc :ssh-keys))

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -12,6 +12,7 @@
              [runtime :as rt]
              [utils :as u]]
             [monkey.ci.events.core :as ec]
+            [monkey.ci.web.auth :as auth]
             [monkey.oci.container-instance.core :as ci]))
 
 (def build-container "build")
@@ -39,6 +40,12 @@
   (cond-> conf
     (log-config rt) (assoc-in [:runner :log-config] (str log-config-dir "/" log-config-file))))
 
+(defn- add-api-token
+  "Generates a new API token that can be used by the build runner to invoke
+   certain API calls."
+  [rt conf]
+  (assoc-in conf [:api :token] (auth/generate-jwt-from-rt rt (auth/build-token (b/get-sid rt)))))
+
 (defn- ->env [rt]
   (->> (-> (rt/rt->env rt)
            (dissoc :app-mode :git :github :http :args :jwk :checkout-base-dir :storage
@@ -48,6 +55,7 @@
        (prepare-config-for-oci)
        (add-ssh-keys-dir rt)
        (add-log-config-path rt)
+       (add-api-token rt)
        (config/config->env)
        (mc/map-keys name)
        (mc/remove-vals empty?)))
@@ -161,11 +169,8 @@
                                        (oci/get-full-instance-details client id))))})
       (md/chain
        (fn [r]
-         (or (-> r :body :containers first :exit-code) 1))
-       (fn [r]
-         ;; FIXME We have a duplicate build/end event here because the remote script also posts it
-         (rt/post-events rt (b/build-end-evt (rt/build rt) r))
-         r))
+         (or (-> r :body :containers first :exit-code) 1)))
+      ;; Do not launch build/end event, that is already done by the script container.
       (md/catch
           (fn [ex]
             (log/error "Got error from container instance:" ex)

--- a/app/src/monkey/ci/script.clj
+++ b/app/src/monkey/ci/script.clj
@@ -25,26 +25,6 @@
   (:import java.nio.channels.SocketChannel
            [java.net UnixDomainSocketAddress StandardProtocolFamily]))
 
-;; (defn- script-evt [evt rt]
-;;   (assoc evt
-;;          :src :script
-;;          :sid (get-in rt [:build :sid])
-;;          :time (u/now)))
-
-;; (defn- post-event [rt evt]
-;;   (log/trace "Posting event:" evt)
-;;   (if-let [c (get-in rt [:api :client])]
-;;     ;; TODO Check if this converts keys to keywords automatically
-;;     (let [{:keys [status] :as r} @(martian/response-for c :post-event (script-evt evt rt))]
-;;       (when-not (= 202 status)
-;;         (log/warn "Failed to post event, got status" status)
-;;         (log/debug "Full response:" r)))
-;;     (log/warn "Unable to post event, no client configured")))
-
-;; (defn- post-events [rt events]
-;;   (doseq [e events]
-;;     (post-event rt e)))
-
 (defn- wrapped
   "Sets the event poster in the runtime."
   [f before after]
@@ -163,6 +143,7 @@
                           {:client client})))
 
 (defn- connect-to-host [url]
+  ;; TODO Use provided token
   (mh/bootstrap-openapi (str url swagger-path)))
 
 (defn make-client

--- a/app/src/monkey/ci/script.clj
+++ b/app/src/monkey/ci/script.clj
@@ -142,7 +142,7 @@
                           {:interceptors interceptors}
                           {:client client})))
 
-(defn- connect-to-host [url]
+(defn- connect-to-host [url token]
   ;; TODO Use provided token
   (mh/bootstrap-openapi (str url swagger-path)))
 
@@ -150,10 +150,10 @@
   "Initializes a Martian client using the configuration given.  It can either
    connect to a domain socket, or a host.  The client is then added to the
    context, where it can be accessed by the build scripts."
-  [{{:keys [url socket]} :api}]
+  [{{:keys [url socket token]} :api}]
   (log/debug "Connecting to API at" (or url socket))
   (cond
-    url (connect-to-host url)
+    url (connect-to-host url token)
     socket (connect-to-uds socket)))
 
 (def valid-config? (some-fn :socket :url))
@@ -248,7 +248,7 @@
     (try 
       (let [jobs (-> (load-script script-dir build-id)
                      (resolve-jobs rt))]
-        (log/debug "Jobs:" jobs)
+        (log/trace "Jobs:" jobs)
         (log/debug "Loaded" (count jobs) "jobs:" (map bc/job-id jobs))
         (run-all-jobs* rt jobs))
       (catch Exception ex

--- a/app/src/monkey/ci/web/auth.clj
+++ b/app/src/monkey/ci/web/auth.clj
@@ -38,13 +38,20 @@
          :iss "https://app.monkeyci.com"
          :aud ["https://api.monkeyci.com"]))
 
-(defn generate-jwt
-  "Signs a JWT using the keypair from the request context."
-  [req payload]
-  (let [pk (c/from-rt req (comp :priv :jwk))]
+(defn generate-jwt-from-rt
+  "Generates a JWT from the private key in the runtime"
+  [rt payload]
+  (when-let [pk (get-in rt [:jwk :priv])]
     (-> payload
         (augment-payload)
         (sign-jwt pk))))
+
+(defn generate-jwt
+  "Signs a JWT using the keypair from the request context."
+  [req payload]
+  (-> req
+      (c/req->rt)
+      (generate-jwt-from-rt payload)))
 
 (defn generate-keypair
   "Generates a new RSA keypair"

--- a/app/src/monkey/ci/web/auth.clj
+++ b/app/src/monkey/ci/web/auth.clj
@@ -129,6 +129,10 @@
                             (st/find-build storage))]
     (assoc build :customers #{(:customer-id build)})))
 
+(defmethod resolve-token :default [rt token]
+  ;; Fallback, for backwards compatibility
+  nil)
+
 (defn- query-auth-to-bearer
   "Middleware that puts the authorization token query param in the authorization header
    if no auth header is provided."

--- a/app/src/monkey/ci/web/auth.clj
+++ b/app/src/monkey/ci/web/auth.clj
@@ -13,12 +13,27 @@
             [java-time.api :as jt]
             [monkey.ci
              [runtime :as rt]
-             [storage :as st]]
+             [storage :as st]
+             [utils :as u]]
             [monkey.ci.web.common :as c]
             [ring.middleware.params :as rmp]
             [ring.util.response :as rur]))
 
 (def kid "master")
+(def role-user "user")
+(def role-build "build")
+
+(defn user-token
+  "Creates token contents for an authenticated user"
+  [user-sid]
+  {:role role-user
+   :sub (u/serialize-sid user-sid)})
+
+(defn build-token
+  "Creates token contents for a build, to be used by a build script."
+  [build-sid]
+  {:role role-build
+   :sub (u/serialize-sid build-sid)})
 
 (defn generate-secret-key
   "Generates a random secret key object"
@@ -98,14 +113,21 @@
     (rur/response {:keys [(make-jwk k)]})
     (rur/not-found {:message "No JWKS configured"})))
 
-(defn- lookup-user [{:keys [storage]} {:keys [sub]}]
+(defmulti resolve-token (fn [_ {:keys [role]}] role))
+
+(defmethod resolve-token role-user [{:keys [storage]} {:keys [sub]}]
   (when sub
-    (let [id (->> (seq (.split sub "/"))
-                  (take 2))]
+    (let [id (u/parse-sid sub)]
       (when (= 2 (count id))
         (log/debug "Looking up user with id" id)
         (some-> (st/find-user storage id)
                 (update :customers set))))))
+
+(defmethod resolve-token role-build [{:keys [storage]} {:keys [sub]}]
+  (when-let [build (some->> sub
+                            (u/parse-sid)
+                            (st/find-build storage))]
+    (assoc build :customers #{(:customer-id build)})))
 
 (defn- query-auth-to-bearer
   "Middleware that puts the authorization token query param in the authorization header
@@ -123,27 +145,30 @@
   "Wraps the ring handler so it verifies the JWT authorization header"
   [app rt]
   (let [pk (rt->pub-key rt)
-        ;; TODO Also check authorization query arg, because in some cases it's not possible
-        ;; to pass it as a header (e.g. server-sent events).
         backend (bb/jws {:secret pk
                          :token-name "Bearer"
                          :options {:alg :rs256}
-                         :authfn (partial lookup-user rt)})]
+                         :authfn (partial resolve-token rt)})]
     (-> app
         (bmw/wrap-authentication backend)
+        ;; Also check authorization query arg, because in some cases it's not possible
+        ;; to pass it as a header (e.g. server-sent events).
         (query-auth-to-bearer)
         (rmp/wrap-params))))
 
-(defn- check-authorization! [req]
+(defn- check-authorization!
+  "Checks if the request identity grants access to the customer specified in 
+   the parameters path."
+  [req]
   (when-let [cid (get-in req [:parameters :path :customer-id])]
     (when-not (and (ba/authenticated? req)
                    (contains? (get-in req [:identity :customers]) cid))
-      (throw (ex-info "User does not have access to this customer"
+      (throw (ex-info "Credentials do not grant access to this customer"
                       {:type :auth/unauthorized
                        :customer-id cid})))))
 
 (defn customer-authorization
-  "Middleware that verifies the identity token to check if the user has
+  "Middleware that verifies the identity token to check if the user or build has
    access to the given customer."
   [h]
   (fn [req]

--- a/app/src/monkey/ci/web/github.clj
+++ b/app/src/monkey/ci/web/github.clj
@@ -144,7 +144,7 @@
 (defn- generate-jwt [req user]
   ;; Perhaps we should use the internal user id instead?
   ;; TODO Add user permissions
-  (auth/generate-jwt req {:sub (str "github/" (:type-id user))}))
+  (auth/generate-jwt req (auth/user-token ["github" (:type-id user)])))
 
 (defn- add-jwt [user req]
   (assoc user :token (generate-jwt req user)))

--- a/app/test/monkey/ci/process_test.clj
+++ b/app/test/monkey/ci/process_test.clj
@@ -139,18 +139,16 @@
                                        (sut/execute!)
                                        (find-arg :pipeline)))))
 
-      (testing "starts script api server"
-        (is (some? (sut/execute! {})))
-        (is (true? @server-started?)))
-
-      (testing "passes socket path in env"
-        (is (string? (-> {:script {:script-dir "test-dir"}}
-                         (sut/execute!)
-                         (deref)
-                         :process
-                         :args
-                         :extra-env
-                         :monkeyci-api-socket)))))))
+      (testing "passes api url and token in env"
+        (let [env (-> {:script {:script-dir "test-dir"}
+                       :config {:api {:url "http://test-api"}}}
+                      (sut/execute!)
+                      (deref)
+                      :process
+                      :args
+                      :extra-env)]
+          (is (= "http://test-api" (:monkeyci-api-url env)))
+          (is (string? (:monkeyci-api-token env))))))))
 
 (deftest process-env
   (testing "passes build id"

--- a/app/test/monkey/ci/web/handler_test.clj
+++ b/app/test/monkey/ci/web/handler_test.clj
@@ -192,7 +192,9 @@
           cust-id (st/new-id)
           github-id 6453
           app (sut/make-app rt)
-          token (auth/sign-jwt {:sub (str "github/" github-id)} (.getPrivate kp))
+          token (auth/sign-jwt {:sub (str "github/" github-id)
+                                :role auth/role-user}
+                               (.getPrivate kp))
           _ (st/save-customer st {:id cust-id
                                   :name "test customer"})
           _ (st/save-user st {:type "github"


### PR DESCRIPTION
Simplified script api invocation by calling the main api directly.  This means adding a token to the config so the script runner can authenticate.  I also removed the UDS stuff, because no longer needed.