### PR TITLE
Add support for jms events

### DIFF
--- a/app/deps.edn
+++ b/app/deps.edn
@@ -1,5 +1,6 @@
 {:deps {aleph/aleph {:mvn/version "0.7.0-alpha2"} ; For http SSE receiving
         babashka/process {:mvn/version "0.5.21"}
+        bowerick/bowerick {:mvn/version "2.9.8"}
         buddy/buddy-auth {:mvn/version "3.0.323"}
         buddy/buddy-core {:mvn/version "1.11.423"}
         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}

--- a/app/src/monkey/ci/events/core.clj
+++ b/app/src/monkey/ci/events/core.clj
@@ -6,6 +6,7 @@
              [protocols :as p]
              [runtime :as rt]]
             [monkey.ci.events
+             [jms :as jms]
              [manifold :as manifold]
              [zmq :as zmq]]))
 
@@ -77,6 +78,9 @@
 
 (defmethod make-events :sync [_]
   (make-sync-events matches-event?))
+
+(defmethod make-events :jms [config]
+  (jms/make-jms-events (:events config) matches-event?))
 
 (defmethod make-events :manifold [_]
   (manifold/make-manifold-events matches-event?))

--- a/app/src/monkey/ci/events/jms.clj
+++ b/app/src/monkey/ci/events/jms.clj
@@ -1,0 +1,104 @@
+(ns monkey.ci.events.jms
+  "Uses JMS (with bowerick) to connect to an event broker.  Can also
+   starts its own broker server, although this is mostly meant for
+   development and testing purposes."
+  (:require [bowerick.jms :as jms]
+            [clojure.java.io :as io]
+            [clojure.tools.logging :as log]
+            [com.stuartsierra.component :as co]
+            [medley.core :as mc]
+            [monkey.ci
+             [protocols :as p]
+             [utils :as u]]))
+
+(def jms-ns 'bowerick.jms)
+
+(defmacro with-logs [& body]
+  ;; Bowerick uses println to log, so we need to redirect it here.
+  ;; Don't use this with bodies that use regular logs because when
+  ;; that prints to stdout, it will stack overflow.
+  ;; Also, for some strange reason, it prints regular logs to stderr and
+  ;; errors to stdout *facepalm*...
+  `(log/with-logs [jms-ns :debug :debug] ~@body))
+
+(defn- maybe-start-broker [{:keys [enabled url]}]
+  (when enabled
+    (with-logs
+      (jms/start-broker url))))
+
+(defn- wrap-creds [{:keys [username password]} h]
+  (if (and username password)
+    (binding [jms/*user-name* username
+              jms/*user-password* password]
+      (h))
+    (h)))
+
+(defn- make-producer [{:keys [url dest] :as conf}]
+  ;; TODO Auto reconnect
+  (with-logs
+    (wrap-creds
+     conf
+     #(jms/create-producer url dest 1 (comp (memfn getBytes) pr-str)))))
+
+(defn filtering-listener [pred l]
+  (fn [evt]
+    (when (pred evt) (l evt))))
+
+(defn- remove-listener [listeners l]
+  (remove (comp (partial = l) :orig) listeners))
+
+(defn- event-handler
+  "Invoked when an event is received.  Dispatches event to all listeners."
+  [listeners]
+  (fn [evt]
+    (doseq [l @listeners]
+      ((:listener l) evt))))
+
+(defn- parse-edn [buf]
+  (with-open [r (io/reader buf)]
+    (u/parse-edn r)))
+
+(defn- make-consumer [{:keys [url dest] :as conf} listeners]
+  ;; TODO Auto reconnect
+  (with-logs
+    (wrap-creds
+     conf
+     #(jms/create-consumer url dest (event-handler listeners) 1 parse-edn))))
+
+(defrecord JmsEvents [config matches-event? listeners broker producer consumer]
+  p/EventPoster
+  (post-events [this events]
+    (let [events (if (sequential? events) events [events])]
+      (doseq [evt events]
+        (producer evt))
+      this))
+  
+  p/EventReceiver
+  (add-listener [this ef l]
+    (swap! listeners conj {:orig l
+                           :listener (filtering-listener #(matches-event? % ef) l)})
+    this)
+  
+  (remove-listener [this ef l]
+    (swap! listeners remove-listener l)
+    this)
+
+  co/Lifecycle
+  (start [this]
+    (-> this
+        (mc/assoc-some :broker (maybe-start-broker (:server config)))
+        (assoc :producer (make-producer (:client config))
+               :consumer (make-consumer (:client config) listeners))))
+
+  (stop [{:keys [broker producer consumer] :as this}]
+    (with-logs
+      (when producer
+        (jms/close producer))
+      (when consumer
+        (jms/close consumer))
+      (when broker
+        (jms/stop broker)))
+    (assoc this :broker nil :producer nil :consumer nil)))
+
+(defn make-jms-events [config matches-event?]
+  (->JmsEvents config matches-event? (atom []) nil nil nil))

--- a/app/test/monkey/ci/events/jms_test.clj
+++ b/app/test/monkey/ci/events/jms_test.clj
@@ -1,0 +1,17 @@
+(ns monkey.ci.events.jms-test
+  (:require [monkey.ci.events
+             [async-tests :as ast]
+             [core :as ec]
+             [jms :as sut]]
+            [clojure.test :refer [deftest testing is]]))
+
+(def default-config
+  {:server
+   {:enabled true
+    :url "tcp://0.0.0.0:4001"}
+   :client
+   {:url "tcp://localhost:4001"
+    :dest "/topic/test"}})
+
+(deftest jms-events
+  (ast/async-tests (partial sut/make-jms-events default-config)))


### PR DESCRIPTION
Using ZeroMQ turns out to give more headaches than expected.  So I'm adding support for JMS, which would allow us to either run our own broker (using bowerick) or connect to an external [Artemis](https://activemq.apache.org/components/artemis) instance.