### PR TITLE
Feature/edn config

### DIFF
--- a/app/src/monkey/ci/build/archive.clj
+++ b/app/src/monkey/ci/build/archive.clj
@@ -99,9 +99,11 @@
    argument, only the files that match the regex are extracted."
   [is dest & [re]]
   (with-open [ds (decompress is)]
-    (unarchive ds dest (if re
-                         (bc/->pred re)
-                         (constantly true)))))
+    (unarchive ds
+               (io/file dest)
+               (if re
+                 (bc/->pred re)
+                 (constantly true)))))
 
 (defn list-files
   "Lists files in the archive at given path"

--- a/app/src/monkey/ci/containers/oci.clj
+++ b/app/src/monkey/ci/containers/oci.clj
@@ -234,6 +234,8 @@
              max-timeout (ec/set-result
                           {:type t}
                           (ec/make-result :error 1 (str "Timeout after " max-timeout " msecs")))))]
+    ;; TODO As soon as a failure for the sidecar has been received, we should return
+    ;; because then container events won't be sent anymore anyway.
     (md/zip
      (wait-for :container/end)
      (wait-for :sidecar/end))))

--- a/app/src/monkey/ci/process.clj
+++ b/app/src/monkey/ci/process.clj
@@ -148,6 +148,7 @@
           :out (l/log-output out)
           :err (l/log-output err)
           :cmd cmd
+          ;; TODO Pass as edn instead of env vars.  We would have to write it to a tmp file.
           :extra-env (process-env rt)
           :exit-fn (fn [{:keys [proc] :as p}]
                      (let [exit (or (some-> proc (.exitValue)) 0)]

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -59,13 +59,6 @@
        (add-log-config-path rt)
        (add-api-token rt)))
 
-(defn- ->env [rt]
-  (->> rt
-       (rt->config)
-       (config/config->env)
-       (mc/map-keys name)
-       (mc/remove-vals empty?)))
-
 (defn- ->edn [rt]
   (-> (rt->config rt)
       (prn-str)))
@@ -138,8 +131,6 @@
                              ;; TODO Add support for tags as well
                              branch (concat ["-b" branch])
                              commit-id (concat ["--commit-id" commit-id]))
-                ;; TODO Pass config in a config file instead of env, cleaner and somewhat safer
-                ;;:environment-variables (->env rt)
                 ;; Run as root, because otherwise we can't write to the shared volumes
                 :security-context {:security-context-type "LINUX"
                                    :run-as-user 0})

--- a/app/src/monkey/ci/sidecar.clj
+++ b/app/src/monkey/ci/sidecar.clj
@@ -91,6 +91,7 @@
         read-next (fn [r]
                     (u/parse-edn r {:eof ::eof}))
         interval (get-in rt [rt/config :sidecar :poll-interval] 1000)
+        ;; TODO Remove explicit log uploads, the promtail container takes care of this now.
         log-maker (rt/log-maker rt)
         log-base (b/get-job-sid rt)
         logger (when log-maker (comp (partial log-maker rt)

--- a/gui/src/monkey/ci/gui/build/views.cljc
+++ b/gui/src/monkey/ci/gui/build/views.cljc
@@ -12,32 +12,6 @@
             [monkey.ci.gui.timer :as timer]
             [re-frame.core :as rf]))
 
-(def log-modal-id :log-dialog)
-
-(defn- modal-title []
-  (let [p (rf/subscribe [:build/log-path])]
-    [:h5 "Log for " @p]))
-
-(defn- show-downloading []
-  (let [d? (rf/subscribe [:build/downloading?])]
-    (when @d?
-      [co/render-alert {:type :info
-                        :message "Downloading log file, one moment..."}])))
-
-(defn- log-contents []
-  (let [c (rf/subscribe [:build/current-log])]
-    [co/log-contents @c]))
-
-(defn log-modal []
-  (let [a (rf/subscribe [:build/log-alerts])]
-    [co/modal
-     log-modal-id
-     [modal-title]
-     [:div {:style {:min-height "100px"}}
-      [co/alerts [:build/log-alerts]]
-      [show-downloading]
-      [log-contents]]]))
-
 (defn build-details
   "Displays the build details by looking it up in the list of repo builds."
   []
@@ -80,14 +54,6 @@
 (defn- calc-elapsed [{s :start-time e :end-time}]
   (when (and s e)
     (t/format-seconds (int (/ (- e s) 1000)))))
-
-#_(defn- render-log-link [{:keys [name size path]}]
-  [:span.me-1
-   [:a.me-1 {:href (u/->dom-id log-modal-id)
-             :data-bs-toggle "modal"
-             :on-click (u/link-evt-handler [:build/download-log path])}
-    name]
-   (str "(" size " bytes)")])
 
 (defn- elapsed-final [s]
   [:span (calc-elapsed s)])
@@ -186,6 +152,5 @@
         [build-details]
         [build-result]
         [build-jobs]
-        [log-modal]
         [:div
          [:a {:href (r/path-for :page/repo params)} "Back to repository"]]]])))


### PR DESCRIPTION
Instead of passing all properties as env vars, use an edn config file for OCI runners instead.  This makes it much easier to pass structured data (like lists).  In future PRs I will do the same for other processes like sidecar and child runner.