### PR TITLE
Extension fixes.

### DIFF
--- a/app/src/monkey/ci/build.clj
+++ b/app/src/monkey/ci/build.clj
@@ -183,13 +183,14 @@
   [rt p]
   (u/abs-path (job-work-dir rt) p))
 
+(def all-jobs "Retrieves all jobs known to the build"
+  (comp vals :jobs :script))
+
 (defn success-jobs
   "Returns all successful jobs in the build"
   [b]
   (->> b
-       :script
-       :jobs
-       vals
+       (all-jobs)
        (filter (comp (partial = :success) :status))))
 
 (defmethod rt/setup-runtime :build [conf _]

--- a/app/src/monkey/ci/build/core.clj
+++ b/app/src/monkey/ci/build/core.clj
@@ -183,4 +183,5 @@
    checks if any of the files match the regex.  If `p` is a function, it is applied
    as a predicate against the files, until one matches."
   ;; Wrap the args in a vector because some-fn only passes one argument
-  (comp (some-fn added? modified? removed?) vector))
+  #_(comp (some-fn added? modified? removed?) vector)
+  (constantly true))

--- a/app/src/monkey/ci/build/core.clj
+++ b/app/src/monkey/ci/build/core.clj
@@ -183,5 +183,4 @@
    checks if any of the files match the regex.  If `p` is a function, it is applied
    as a predicate against the files, until one matches."
   ;; Wrap the args in a vector because some-fn only passes one argument
-  #_(comp (some-fn added? modified? removed?) vector)
-  (constantly true))
+  (comp (some-fn added? modified? removed?) vector))

--- a/app/src/monkey/ci/containers/podman.clj
+++ b/app/src/monkey/ci/containers/podman.clj
@@ -56,11 +56,13 @@
         cn (b/get-job-id rt)
         wd (b/job-work-dir rt)
         cwd "/home/monkeyci"
-        base-cmd ["/usr/bin/podman" "run"
-                  "-t" "--rm"
-                  "--name" cn
-                  "-v" (str wd ":" cwd ":Z")
-                  "-w" cwd]]
+        base-cmd (cond-> ["/usr/bin/podman" "run"
+                          "-t"
+                          "--name" cn
+                          "-v" (str wd ":" cwd ":Z")
+                          "-w" cwd]
+                   ;; Do not delete container in dev mode
+                   (not (rt/dev-mode? rt)) (conj "--rm"))]
     (concat
      ;; TODO Allow for more options to be passed in
      base-cmd

--- a/app/src/monkey/ci/listeners.clj
+++ b/app/src/monkey/ci/listeners.clj
@@ -42,6 +42,7 @@
 
 (def update-handlers
   {:job/start    update-job
+   :job/updated  update-job
    :job/end      update-job
    :script/start update-script
    :script/end   update-script

--- a/app/src/monkey/ci/process.clj
+++ b/app/src/monkey/ci/process.clj
@@ -156,7 +156,7 @@
                        (log/debug "Script process exited with code" exit ", cleaning up")
                        (when out
                          (log/debug "Process output:" (out->str out)))
-                       (when err
+                       (when (and err (not= 0 exit))
                          (log/warn "Process error output:" (out->str err)))
                        (md/success! result {:process p
                                             :exit exit})))})

--- a/app/src/monkey/ci/runtime.clj
+++ b/app/src/monkey/ci/runtime.clj
@@ -126,6 +126,7 @@
   "Posts one or more events using the event poster in the runtime"
   [{:keys [events]} evt]
   (let [evt (prepare-events evt)]
+    (log/trace "Posting events:" evt)
     (cond
       (satisfies? p/EventPoster events)
       (p/post-events events evt)

--- a/app/src/monkey/ci/script.clj
+++ b/app/src/monkey/ci/script.clj
@@ -97,7 +97,7 @@
 (defn- with-fire-events
   "Wraps job so events are fired on start and end."
   [job]
-  (map->EventFiringJob (-> (select-keys job [j/job-id j/deps j/labels])
+  (map->EventFiringJob (-> (j/job->event job)
                            (assoc :target job))))
 
 (def with-extensions

--- a/app/src/monkey/ci/web/api.clj
+++ b/app/src/monkey/ci/web/api.clj
@@ -301,7 +301,6 @@
   (if-let [b (fetch-build-details (c/req->storage req)
                                   (build-sid req))]
     (do 
-      (log/debug "Build details:" b)
       (let [res (->> (b/all-jobs b)
                      (mapcat :save-artifacts)
                      (f))
@@ -320,7 +319,6 @@
   (with-artifacts req identity))
 
 (defn- artifact-by-id [id art]
-  (log/debug "Looking for artifact" id "in" art)
   (->> art
        (filter (comp (partial = id) :id))
        (first)))

--- a/app/test/unit/monkey/ci/listeners_test.clj
+++ b/app/test/unit/monkey/ci/listeners_test.clj
@@ -188,6 +188,9 @@
     (testing "handles `job/start`"
       (verify-job-event :job/start))
 
+    (testing "handles `job/updated`"
+      (verify-job-event :job/updated))
+
     (testing "handles `job/end`"
       (verify-job-event :job/end)))  
 

--- a/app/test/unit/monkey/ci/web/api_test.clj
+++ b/app/test/unit/monkey/ci/web/api_test.clj
@@ -430,7 +430,19 @@
                                                 :repo-id rid})
                  (sut/make-build-ctx "test-build")
                  :git
-                 :main-branch))))))
+                 :main-branch)))))
+
+  (testing "sets cleanup flag when not in dev mode"
+    (is (true? (:cleanup? (sut/make-build-ctx (-> (h/test-rt)
+                                                  (assoc-in [:config :dev-mode] false)
+                                                  (h/->req))
+                                              "test-build")))))
+
+  (testing "does not set cleanup flag when in dev mode"
+    (is (false? (:cleanup? (sut/make-build-ctx (-> (h/test-rt)
+                                                   (assoc-in [:config :dev-mode] true)
+                                                   (h/->req))
+                                               "test-build"))))))
 
 (deftest update-user
   (testing "updates user in storage"

--- a/app/test/unit/monkey/ci/web/handler_test.clj
+++ b/app/test/unit/monkey/ci/web/handler_test.clj
@@ -433,7 +433,7 @@
 (defn- with-repo [f & [rt]]
   (h/with-memory-store st
     (let [events (atom [])
-          app (sut/make-app (merge
+          app (sut/make-app (u/deep-merge
                              {:storage st
                               :events {:poster (partial swap! events conj)}
                               :config {:dev-mode true}
@@ -537,12 +537,6 @@
              (is (= (take 2 sid) (take 2 bsid)))
              (is (= (:build-id @runner-args)
                     (last bsid)))))))
-      
-      (testing "sets cleanup flag"
-        (verify-runner
-         "/trigger"
-         (fn [{:keys [sid runner-args]}]
-           (is (true? (:cleanup? @runner-args))))))
       
       (testing "creates build in storage"
         (verify-runner

--- a/gui/src/monkey/ci/gui/job/events.cljc
+++ b/gui/src/monkey/ci/gui/job/events.cljc
@@ -6,14 +6,14 @@
             [re-frame.core :as rf]))
 
 (def alerts ::alerts)
-(def log-tabs-id ::log-tabs)
+(def details-tabs-id ::details-tabs)
 
 (rf/reg-event-fx
  :job/init
  (fn [{:keys [db]} _]
    {:dispatch-n [[:customer/maybe-load]
                  [:build/maybe-load]
-                 [:tab/tab-changed log-tabs-id nil]]
+                 [:tab/tab-changed details-tabs-id nil]]
     :db (-> db
             (db/clear-alerts)
             (db/set-log-files nil)


### PR DESCRIPTION
Some fixes regarding extensions that require artifacts from the same job (like for test results).  The main issue here was that not all information was passed in the update events, and I have also added an extra job update event right before invoking the extensions, so that the job results are already available to the api.