### PR TITLE
Feature: test results timings

### DIFF
--- a/.monkeyci/build.clj
+++ b/.monkeyci/build.clj
@@ -174,6 +174,7 @@
      {:id "publish-gui-img"
       :context "gui"
       :image gui-img
+      :memory 3 ;GB
       ;; Restore artifacts but modify the path because work dir is not the same
       :opts {:restore-artifacts [(update gui-release-artifact :path (partial str "gui/"))
                                  image-creds-artifact]

--- a/gui/src/monkey/ci/gui/charts.cljs
+++ b/gui/src/monkey/ci/gui/charts.cljs
@@ -1,0 +1,42 @@
+(ns monkey.ci.gui.charts
+  "Chart.js wrapper component"
+  (:require [monkey.ci.gui.logging :as log]
+            [re-frame.core :as rf]
+            ;; TODO Finetune loaded modules
+            ["chart.js/auto" :refer [Chart]]))
+
+(defn- set-chart-config [db id conf]
+  (assoc-in db [::chart-config id] conf))
+
+(defn- chart-config [db id]
+  (get-in db [::chart-config id]))
+
+(defn- configure-chart! [id chart config]
+  ;; FIXME No matter what, the chart always re-renders, so the change check doesn't work.
+  (when (or (nil? chart)
+            ;; Only update when the chart data has changed
+            (not= (js->clj (.-data chart)) (:data config)))
+    (when chart
+      (.destroy chart))
+    (log/debug "Configuring chart on element:" (name id))
+    (if-let [el (.getElementById js/document (name id))]
+      (Chart. el (clj->js config))
+      (log/warn "Element" (name id) "not found in document"))))
+
+(rf/reg-cofx
+ :chart/configurator
+ (fn [cofx _]
+   (assoc cofx :chart/configurator configure-chart!)))
+
+(rf/reg-event-fx
+ :chart/update
+ [(rf/inject-cofx :chart/configurator)]
+ (fn [{:keys [db :chart/configurator]} [_ chart-id new-config]]
+   (let [old-config (chart-config db chart-id)]
+     {:db (set-chart-config db chart-id (configurator chart-id old-config new-config))})))
+
+(defn chart-component
+  "Renders a canvas with the given id.  Use the `:chart/update` event to
+   actually initialize and render the chart."
+  [id]
+  [:canvas {:id id}])

--- a/gui/src/monkey/ci/gui/test_results.cljc
+++ b/gui/src/monkey/ci/gui/test_results.cljc
@@ -1,6 +1,10 @@
 (ns monkey.ci.gui.test-results
   "Displays test results"
-  (:require [monkey.ci.gui.components :as co]))
+  (:require [monkey.ci.gui.charts :as charts]
+            [monkey.ci.gui.components :as co]
+            [monkey.ci.gui.logging :as log]
+            [monkey.ci.gui.utils :as u]
+            [re-frame.core :as rf]))
 
 (def success? (comp (partial every? empty?) (juxt :errors :failures)))
 
@@ -23,3 +27,90 @@
    (->> suites
         (mapcat suite-rows)
         (into [:tbody]))])
+
+(defn- timings->chart [results n]
+  (let [cases (->> results
+                   (mapcat :test-cases)
+                   (remove (comp nil? :time))
+                   (take n)
+                   (sort-by :time)
+                   (reverse))]
+    {:type "bar"
+     :data {:labels (map :test-case cases)
+            :datasets [{:label "Seconds"
+                        :data (map :time cases)}]}}))
+
+(def default-chart-form {:count 5})
+
+(defn- timing-chart-form [db id]
+  (get-in db [::timing-chart id] default-chart-form))
+
+(defn- timing-chart-results [db id]
+  (get-in db [::timing-chart-results id]))
+
+(rf/reg-sub
+ ::timing-chart-form
+ (fn [db [_ id]]
+   (timing-chart-form db id)))
+
+(rf/reg-sub
+ ::timing-chart-val
+ (fn [db [_ id prop]]
+   (prop (timing-chart-form db id))))
+
+(rf/reg-event-fx
+ ::timing-chart-init
+ (fn [{:keys [db]} [_ id results]]
+   {:db (assoc-in db [::timing-chart-results id] results)
+    :dispatch [:chart/update id (timings->chart results (:count (timing-chart-form db id)))]}))
+
+(rf/reg-event-fx
+ ::timing-chart-changed
+ (fn [{:keys [db]} [_ id prop v]]
+   (let [results (timing-chart-results db id)
+         db (assoc-in db [::timing-chart id prop] v)]
+     {:db db
+      :dispatch [:chart/update id (timings->chart results (:count (timing-chart-form db id)))]})))
+
+(defn suite-dropdown [suites id name]
+  (let [v (rf/subscribe [::timing-chart-val id :suite])]
+    (->> (concat [nil] suites)
+         (map (fn [{:keys [name]}]
+                [:option {:value name} (or name "All")]))
+         (into [:select.form-select
+                {:name name
+                 :aria-label "suite"
+                 :selected @v
+                 :on-change (u/form-evt-handler [::timing-chart-changed id :suite])}]))))
+
+(defn test-count-dropdown [id name]
+  (let [v (rf/subscribe [::timing-chart-val id :count])]
+    (->> [5 10 100]
+         (map (fn [n]
+                [:option {:value n} n]))
+         (into [:select.form-select
+                {:name name
+                 :selected @v
+                 :aria-label "test count"
+                 :on-change (u/form-evt-handler [::timing-chart-changed id :count]
+                                                (comp u/parse-int u/evt->value))}]))))
+
+(defn timing-chart
+  "Displays a bar chart that shows the times for the slowest tests.  By default this is for
+   all suites, the top 100, but the user can configure this."
+  [id results]
+  (let [suite-id (str (name id) "-suite-dropdown")
+        count-id (str (name id) "-count-dropdown")
+        form (rf/subscribe [::timing-chart-form id])]
+    [:div
+     [:h4 "Test Timings"]
+     [:form
+      [:div.row
+       [:label.form-label.col-2.col-form-label {:for suite-id} "Suite:"]
+       [:div.col-2
+        [suite-dropdown results id suite-id]]
+       [:label.form-label.col-2.col-form-label {:for count-id} "Show top:"]
+       [:div.col-2
+        [test-count-dropdown id count-id]]]]
+     (rf/dispatch [::timing-chart-init id results])
+     [charts/chart-component id]]))

--- a/gui/src/monkey/ci/gui/utils.cljc
+++ b/gui/src/monkey/ci/gui/utils.cljc
@@ -25,11 +25,11 @@
     #?(:cljs (.preventDefault e true))
     (rf/dispatch evt)))
 
-(defn- evt->value [e]
+(defn evt->value [e]
   #?(:cljs (-> e .-target .-value)
      :clj (:value e)))
 
-(defn- evt->checked [e]
+(defn evt->checked [e]
   #?(:cljs (-> e .-target .-checked)
      :clj (:value e)))
 
@@ -87,3 +87,9 @@
     (login-on-401
      {:db (f db evt)}
      (last evt))))
+
+(defn parse-int [x]
+  (if (string? x)
+    #?(:cljs (js/parseInt x)
+       :clj (Integer/parseInt x))
+    x))

--- a/gui/test/monkey/ci/gui/test/cards/unit_test_cards.cljs
+++ b/gui/test/monkey/ci/gui/test/cards/unit_test_cards.cljs
@@ -13,15 +13,36 @@
      :test-cases
      [{:test-case "monkey.ci.test/some-test"
        :class-name "monkey.ci.test"
-       :time "0.1735"}
+       :time 0.1735}
       {:test-case "monkey.ci.test/other-test"
        :class-name "monkey.ci.test"
-       :time "0.0414"}
+       :time 0.0414}
       {:test-case "monkey.ci.test/failing"
        :class-name "monkey.ci.test"
-       :time "0.069343"
+       :time 0.069343
        :failures
        [{:message "Test error"
          :type "assertion error: true?"
          :description "This is a longer description of the error"}]}]}]])
 
+(defn- gen-test-case [n]
+  {:test-case (str "test-" n)
+   :time (* (rand) 10)})
+
+(defcard-rg timing-chart-small-single-suite
+  "Timing chart for single suit with low number of tests"
+  [sut/timing-chart
+   :small-single-suite
+   [{:name "small"
+     :test-cases
+     (->> (range 3)
+          (map (comp gen-test-case inc)))}]])
+
+(defcard-rg timing-chart-large-single-suite
+  "Timing chart for single suit with high number of tests"
+  [sut/timing-chart
+   :large-single-suite
+   [{:name "large"
+     :test-cases
+     (->> (range 200)
+          (map (comp gen-test-case inc)))}]])

--- a/gui/test/monkey/ci/gui/test/test_results_test.cljc
+++ b/gui/test/monkey/ci/gui/test/test_results_test.cljc
@@ -1,6 +1,7 @@
 (ns monkey.ci.gui.test.test-results-test
   (:require #?(:cljs [cljs.test :refer-macros [deftest testing is use-fixtures]]
                :clj [clojure.test :refer [deftest testing is use-fixtures]])
+            [day8.re-frame.test :as rft]
             [monkey.ci.gui.test-results :as sut]
             [monkey.ci.gui.test.fixtures :as f]
             [monkey.ci.gui.test.helpers :as h]
@@ -32,9 +33,35 @@
         s (rf/subscribe [::sut/timing-chart-form id])]
     
     (testing "updates selected suite"
-      (rf/dispatch-sync [::sut/timing-chart-changed id :suite "test suite"])
+      (is (nil? (rf/dispatch-sync [::sut/timing-chart-changed id :suite "test suite"])))
       (is (= "test suite" (:suite @s))))
 
     (testing "updates selected count"
-      (rf/dispatch-sync [::sut/timing-chart-changed id :count 10])
-      (is (= 10 (:count @s))))))
+      (is (nil? (rf/dispatch-sync [::sut/timing-chart-changed id :count 10])))
+      (is (= 10 (:count @s))))
+
+    (rft/run-test-sync
+     (rf/reg-event-db
+      :chart/update
+      (fn [db evt]
+        (assoc db ::updates (rest evt))))
+
+     (is (nil? (rf/dispatch [::sut/timing-chart-init id
+                             [{:name "suite-1"
+                               :test-cases
+                               [{:test-case "test-1"
+                                 :time 1}]}
+                              {:name "suite-2"
+                               :test-cases
+                               [{:test-case "test-2"
+                                 :time 2}]}]])))
+     
+     (testing "updates chart for id"
+       (is (nil? (rf/dispatch [::sut/timing-chart-changed id :count 10])))
+       (is (= id (-> @app-db ::updates first))))
+
+     (testing "filters chart data by suite"
+       (is (nil? (rf/dispatch [::sut/timing-chart-changed id :suite "suite-2"])))
+       (let [data (-> @app-db ::updates second)]
+         (is (= 1 (-> data :data :datasets first :data count)))
+         (is (= "test-2" (-> data :data :labels first))))))))

--- a/gui/test/monkey/ci/gui/test/test_results_test.cljc
+++ b/gui/test/monkey/ci/gui/test/test_results_test.cljc
@@ -1,0 +1,40 @@
+(ns monkey.ci.gui.test.test-results-test
+  (:require #?(:cljs [cljs.test :refer-macros [deftest testing is use-fixtures]]
+               :clj [clojure.test :refer [deftest testing is use-fixtures]])
+            [monkey.ci.gui.test-results :as sut]
+            [monkey.ci.gui.test.fixtures :as f]
+            [monkey.ci.gui.test.helpers :as h]
+            [re-frame.core :as rf]
+            [re-frame.db :refer [app-db]]))
+
+(rf/clear-subscription-cache!)
+
+(use-fixtures :each f/reset-db)
+
+(deftest timing-chart-form-sub
+  (let [s (rf/subscribe [::sut/timing-chart-form ::test])]
+    (testing "exists"
+      (is (some? s)))
+
+    (testing "defaults to all suites and top 5"
+      (is (= {:count 5} @s)))))
+
+(deftest timing-chart-val-sub
+  (let [s (rf/subscribe [::sut/timing-chart-val ::test :count])]
+    (testing "exists"
+      (is (some? s)))
+
+    (testing "returns form value"
+      (is (= 5 @s)))))
+
+(deftest timing-chart-changed-evt
+  (let [id (random-uuid)
+        s (rf/subscribe [::sut/timing-chart-form id])]
+    
+    (testing "updates selected suite"
+      (rf/dispatch-sync [::sut/timing-chart-changed id :suite "test suite"])
+      (is (= "test suite" (:suite @s))))
+
+    (testing "updates selected count"
+      (rf/dispatch-sync [::sut/timing-chart-changed id :count 10])
+      (is (= 10 (:count @s))))))


### PR DESCRIPTION
Added a simple chart that displays the slowest tests in a bar chart.  User can also filter by suite or configure the number of slow tests to show in the chart.  Part of #132 