### PR TITLE
Feature/events rework

### DIFF
--- a/app/src/monkey/ci/containers/oci.clj
+++ b/app/src/monkey/ci/containers/oci.clj
@@ -369,17 +369,12 @@
    :job (j/job->event job)})
 
 (defn- fire-job-initializing [job build-sid events]
-  (let [job (assoc job
-                   :status :initializing
-                   :init-time (t/now)
-                   :credit-multiplier (credit-multiplier job))]
-    (ec/post-events events [(j/job-initializing-evt job build-sid)])
-    job))
+  (ec/post-events events [(j/job-initializing-evt job build-sid (credit-multiplier job))])
+  job)
 
 (defn- fire-job-end [job build-sid result events]
-  (let [job (assoc job
-                   :status (b/exit-code->status (:exit result))
-                   :end-time (t/now))]
+  (let [result (-> result
+                   (assoc :status (b/exit-code->status (:exit result))))]
     (ec/post-events events [(j/job-end-evt job build-sid result)])))
 
 (defn run-container [{:keys [events job build] :as conf}]

--- a/app/src/monkey/ci/extensions.clj
+++ b/app/src/monkey/ci/extensions.clj
@@ -67,12 +67,7 @@
 (defrecord ExtensionWrappingJob [target registered-ext]
   j/Job
   (execute! [job rt]
-    (let [rt (assoc rt :job target)
-          post-update (fn [rt]
-                        (rt/post-events rt {:type :job/updated
-                                            :sid (b/get-sid rt)
-                                            :job (j/job->event (:job rt))})
-                        rt)]
+    (let [rt (assoc rt :job target)]
       ;; FIXME This is fairly dirty: jobs don't return the runtime, but extensions use it,
       ;; so maybe we need to think about reworking this.
       (-> rt
@@ -81,9 +76,6 @@
           (md/chain
            ;; Add the result to the job in runtime
            (partial assoc-in rt [:job :result])
-           ;; Dispatch an update event already.  Some extensions may require information
-           ;; from the api that has not been sent yet, so we do it here.
-           post-update
            ;; Let any extensions work on it
            #(apply-extensions-after % registered-ext)
            ;; Return the job result (possibly modified by extensions)

--- a/app/src/monkey/ci/process.clj
+++ b/app/src/monkey/ci/process.clj
@@ -149,6 +149,7 @@
              "-X:monkeyci/build"
              (pr-str {:config-file (config->edn (child-config build (:api-config rt)))})]]
     (log/debug "Running in script dir:" script-dir ", this command:" cmd)
+    (rt/post-events rt [(script/script-init-evt build script-dir)])
     ;; TODO Run as another unprivileged user for security (we'd need `su -c` for that)
     (-> (bp/process
          {:dir script-dir

--- a/app/src/monkey/ci/spec/build.clj
+++ b/app/src/monkey/ci/spec/build.clj
@@ -68,7 +68,7 @@
 
 (s/def :build/id id?)
 (s/def :build/build-id id?)
-(s/def :build/sid vector?)
+(s/def :build/sid (s/coll-of id? :count 3))
 (s/def :build/cleanup? boolean?)
 (s/def :build/webhook-id id?)
 (s/def :build/customer-id id?)

--- a/app/src/monkey/ci/spec/build.clj
+++ b/app/src/monkey/ci/spec/build.clj
@@ -44,9 +44,9 @@
 (s/def :job/script (s/coll-of :job/command))
 
 (s/def :script/job
-  (-> (s/keys :req-un [:job/id :job/type]
-              :opt-un [:job/dependencies :job/caches :job/save-artifacts :job/restore-artifacts :job/script
-                       :job/memory :job/cpus :job/arch :job/status
+  (-> (s/keys :req-un [:job/id]
+              :opt-un [:job/type :job/dependencies :job/caches :job/save-artifacts :job/restore-artifacts
+                       :job/script :job/memory :job/cpus :job/arch :job/status
                        :job/credit-multiplier])))
 
 (s/def :script/jobs (s/coll-of :script/job))

--- a/app/src/monkey/ci/spec/build.clj
+++ b/app/src/monkey/ci/spec/build.clj
@@ -47,8 +47,7 @@
   (-> (s/keys :req-un [:job/id :job/type]
               :opt-un [:job/dependencies :job/caches :job/save-artifacts :job/restore-artifacts :job/script
                        :job/memory :job/cpus :job/arch :job/status
-                       :job/credit-multiplier])
-      (s/merge ::generic-entity)))
+                       :job/credit-multiplier])))
 
 (s/def :script/jobs (s/coll-of :script/job))
 

--- a/app/src/monkey/ci/spec/events.clj
+++ b/app/src/monkey/ci/spec/events.clj
@@ -1,11 +1,31 @@
 (ns monkey.ci.spec.events
   "Spec definitions for events"
-  (:require [clojure.spec.alpha :as s]))
+  (:require [clojure.spec.alpha :as s]
+            [monkey.ci.spec.build]))
 
 (s/def ::type keyword?)
 (s/def ::message string?)
 (s/def ::time int?)
 (s/def ::src keyword?)
 
-(s/def ::event (s/keys :req-un [::type ::time]
-                       :opt-un [::message ::src]))
+(s/def ::event-base (s/keys :req-un [::type ::time]
+                            :opt-un [::message ::src]))
+
+(defmulti event-type :type)
+
+(s/def ::build map?) ; TODO Specify
+(s/def ::credit-multiplier int?)
+
+(defmethod event-type :build/initializing [_]
+  (->> (s/keys :req-un [:build/sid ::build])
+       (s/merge ::event-base)))
+
+(defmethod event-type :build/start [_]
+  (->> (s/keys :req-un [:build/sid ::credit-multiplier])
+       (s/merge ::event-base)))
+
+(defmethod event-type :build/end [_]
+  (->> (s/keys :req-un [:build/sid :build/status])
+       (s/merge ::event-base)))
+
+(s/def ::event (s/multi-spec event-type :type))

--- a/app/src/monkey/ci/spec/events.clj
+++ b/app/src/monkey/ci/spec/events.clj
@@ -16,6 +16,7 @@
 (s/def ::build map?) ; TODO Specify
 (s/def ::credit-multiplier int?)
 (s/def ::job-id c/id?)
+(s/def ::result map?)
 
 (s/def ::build-event
   (->> (s/keys :req-un [:build/sid])
@@ -52,14 +53,15 @@
        (s/merge ::build-event)))
 
 (defmethod event-type :job/initializing [_]
-  (->> (s/keys :req-un [:build/sid ::job-id :script/job])
-       (s/merge ::event-base)))
+  (->> (s/keys :req-un [:script/job ::credit-multiplier])
+       (s/merge ::job-event)))
 
 (defmethod event-type :job/start [_]
   ::job-event)
 
 (defmethod event-type :job/end [_]
-  (->> (s/keys :req-un [:job/status])
+  (->> (s/keys :req-un [:job/status]
+               :opt-un [::result])
        (s/merge ::job-event)))
 
 (s/def ::event (s/multi-spec event-type :type))

--- a/app/src/monkey/ci/spec/events.clj
+++ b/app/src/monkey/ci/spec/events.clj
@@ -1,7 +1,9 @@
 (ns monkey.ci.spec.events
   "Spec definitions for events"
   (:require [clojure.spec.alpha :as s]
-            [monkey.ci.spec.build]))
+            [monkey.ci.spec
+             [build]
+             [common :as c]]))
 
 (s/def ::type keyword?)
 (s/def ::message string?)
@@ -11,21 +13,53 @@
 (s/def ::event-base (s/keys :req-un [::type ::time]
                             :opt-un [::message ::src]))
 
-(defmulti event-type :type)
-
 (s/def ::build map?) ; TODO Specify
 (s/def ::credit-multiplier int?)
+(s/def ::job-id c/id?)
+
+(s/def ::build-event
+  (->> (s/keys :req-un [:build/sid])
+       (s/merge ::event-base)))
+
+(s/def ::job-event
+  (->> (s/keys :req-un [::job-id])
+       (s/merge ::build-event)))
+
+(defmulti event-type :type)
 
 (defmethod event-type :build/initializing [_]
-  (->> (s/keys :req-un [:build/sid ::build])
-       (s/merge ::event-base)))
+  (->> (s/keys :req-un [::build])
+       (s/merge ::build-event)))
 
 (defmethod event-type :build/start [_]
-  (->> (s/keys :req-un [:build/sid ::credit-multiplier])
-       (s/merge ::event-base)))
+  (->> (s/keys :req-un [::credit-multiplier])
+       (s/merge ::build-event)))
 
 (defmethod event-type :build/end [_]
-  (->> (s/keys :req-un [:build/sid :build/status])
+  (->> (s/keys :req-un [:build/status])
+       (s/merge ::build-event)))
+
+(defmethod event-type :script/initializing [_]
+  (->> (s/keys :req-un [:script/script-dir])
+       (s/merge ::build-event)))
+
+(defmethod event-type :script/start [_]
+  (->> (s/keys :req-un [:script/jobs])
+       (s/merge ::build-event)))
+
+(defmethod event-type :script/end [_]
+  (->> (s/keys :req-un [:script/status])
+       (s/merge ::build-event)))
+
+(defmethod event-type :job/initializing [_]
+  (->> (s/keys :req-un [:build/sid ::job-id :script/job])
        (s/merge ::event-base)))
+
+(defmethod event-type :job/start [_]
+  ::job-event)
+
+(defmethod event-type :job/end [_]
+  (->> (s/keys :req-un [:job/status])
+       (s/merge ::job-event)))
 
 (s/def ::event (s/multi-spec event-type :type))

--- a/app/test/unit/monkey/ci/containers/oci_test.clj
+++ b/app/test/unit/monkey/ci/containers/oci_test.clj
@@ -19,7 +19,9 @@
             [monkey.ci.config.sidecar :as cs]
             [monkey.ci.containers.oci :as sut]
             [monkey.ci.events.core :as ec]
-            [monkey.ci.spec.sidecar :as ss]
+            [monkey.ci.spec
+             [events :as se]
+             [sidecar :as ss]]
             [monkey.ci.helpers :as h]
             [monkey.ci.test.runtime :as trt]))
 
@@ -564,19 +566,19 @@
           (let [evt (->> (h/received-events events)
                          (h/first-event-by-type :job/initializing))]
             (is (some? evt))
+            (is (spec/valid? ::se/event evt))
             (is (= sid (:sid evt)))
-            (is (= :initializing (get-in evt [:job :status])))
-            (is (number? (get-in evt [:job :credit-multiplier])))))
+            (is (number? (:credit-multiplier evt)))))
 
         (testing "fires `job/end` event"
           (let [{:keys [job] :as evt} (->> (h/received-events events)
                                            (h/first-event-by-type :job/end))]
             (is (some? evt))
+            (is (spec/valid? ::se/event evt)
+                (spec/explain-str ::se/event evt))
             (is (= sid (:sid evt)))
             (is (some? job))
-            (is (= {:exit 0} (:result job)))
-            (is (number? (:end-time job)))
-            (is (number? (get-in evt [:job :credit-multiplier]))))))
+            (is (= {:exit 0} (:result job))))))
 
       (testing "fires event in case of oci error"
         (h/reset-events events)

--- a/app/test/unit/monkey/ci/extensions_test.clj
+++ b/app/test/unit/monkey/ci/extensions_test.clj
@@ -110,11 +110,4 @@
       (is (true? (::before? @(j/execute! wrapped rt)))))
     
     (testing "invokes `after` extension"
-      (is (true? (::after? @(j/execute! wrapped rt)))))
-
-    (testing "dispatches `job/updated` event before invoking extensions"
-      (let [evt (h/received-events events)]
-        (is (pos? (count evt)))
-        (is (= :job/updated
-               (-> (h/first-event-by-type :job/updated evt)
-                   :type)))))))
+      (is (true? (::after? @(j/execute! wrapped rt)))))))

--- a/app/test/unit/monkey/ci/helpers.clj
+++ b/app/test/unit/monkey/ci/helpers.clj
@@ -13,6 +13,7 @@
             [monkey.ci
              [blob :as blob]
              [containers :as containers]
+             [cuid :as cuid]
              [protocols :as p]
              [storage :as s]
              [utils :as u]]
@@ -301,3 +302,5 @@
 ;; (defn fake-build-container-runner []
 ;;   (->FakeBuildContainerRunner (atom [])))
 
+(defn gen-build-sid []
+  (repeatedly 3 cuid/random-cuid))

--- a/app/test/unit/monkey/ci/listeners_test.clj
+++ b/app/test/unit/monkey/ci/listeners_test.clj
@@ -4,7 +4,8 @@
             [monkey.ci
              [listeners :as sut]
              [runtime :as rt]
-             [storage :as st]]
+             [storage :as st]
+             [time :as t]]
             [monkey.ci.helpers :as h]))
 
 (defn- random-sid []
@@ -18,238 +19,153 @@
   ([]
    (test-build (random-sid))))
 
-(deftest update-build
-  (testing "updates build entity"
-    (h/with-memory-store st
-      (let [sid (random-sid)
-            evt {:type :build/end
-                 :build (-> (test-build sid)
-                            (assoc :status :success))
-                 :sid sid
-                 :exit 0
-                 :result :success}]
-        (is (map? (sut/update-build st evt)))
-        (is (true? (st/build-exists? st sid)))
-        (is (= :success
-               (:status (st/find-build st sid)))))))
-
-  (testing "removes unwanted fields"
-    (h/with-memory-store st
-      (let [sid (random-sid)
-            evt {:type :build/end
-                 :build (-> (test-build sid)
-                            (assoc :status :success
-                                   :cleanup? true))
-                 :sid sid
-                 :exit 0
-                 :result :success}]
-        (is (map? (sut/update-build st evt)))
-        (let [match (st/find-build st sid)]
-          (is (not (contains? match :sid)))
-          (is (not (contains? match :cleanup?)))))))
-
-  (testing "does not remove existing script info"
-    (h/with-memory-store st
-      (let [sid (random-sid)
-            script {:jobs {"test-job" {:status :success}}}
-            build (-> (test-build sid)
-                      (assoc :status :success
-                             :script script))
-            evt {:type :build/end
-                 :build (dissoc build :script)
-                 :sid sid
-                 :exit 0
-                 :result :success}]
-        (is (st/sid? (st/save-build st build)))
-        (is (map? (sut/update-build st evt)))
-        (let [match (st/find-build st sid)]
-          (is (= script (:script match)))))))
-
-  (testing "`build/end` calculates consumed credits"
-    (h/with-memory-store st
-      (let [sid (random-sid)
-            build (-> (test-build sid)
-                      (assoc-in [:script :jobs] {:job-1 {:id "job-1"
-                                                         :start-time 100
-                                                         :end-time 200
-                                                         :credit-multiplier 1}}))
-            handler (sut/build-update-handler st (h/fake-events))]
-        (is (some? (st/save-build st build)))
-        (is (some? (sut/update-build st {:type :build/end
-                                         :build build})))
-        (is (number? (-> (st/find-build st sid)
-                         :credits)))))))
-
-(deftest update-script
-  (testing "updates script in build"
-    (h/with-memory-store st
-      (let [{:keys [sid] :as build} (test-build)
-            stored-build (dissoc build :sid)
-            script {:start-time 100
-                    :status :running
-                    :jobs {"test-job" {}}}
-            evt {:type :script/start
-                 :sid sid
-                 :script script}]
-        (is (st/sid? (st/save-build st stored-build)))
-        (is (= sid (:sid (sut/update-script st evt))))
-        (let [match (st/find-build st sid)]
-          (is (= script (:script match)))))))
-
-  (testing "returns `nil` when build not found"
-    (h/with-memory-store st
-      (let [{:keys [sid] :as build} (test-build)
-            script {:start-time 100
-                    :status :running
-                    :jobs {"test-job" {}}}
-            evt {:type :script/start
-                 :sid sid
-                 :script script}]
-        (is (nil? (sut/update-script st evt))))))
-
-  (testing "merges job info with existing"
-    (h/with-memory-store st
-      (let [{:keys [sid] :as build} (-> (test-build)
-                                        (assoc :script
-                                               {:start-time 100
-                                                :status :running
-                                                :jobs {"test-job" {:start-time 100
-                                                                   :status :pending}}}))
-            script {:start-time 100
-                    :status :running
-                    :jobs {"test-job" {:status :skipped
-                                       :end-time 200}}}
-            evt {:type :script/start
-                 :sid sid
-                 :script script}]
-        (is (st/sid? (st/save-build st build)))
-        (is (map? (sut/update-script st evt)))
-        (let [match (st/find-build st sid)
-              job (get-in match [:script :jobs "test-job"])]
-          (is (some? job))
-          (is (= :skipped (:status job)))
-          (is (= 100 (:start-time job)))
-          (is (= 200 (:end-time job)))))))
-
-  (testing "does not add dependencies twice"
-    (h/with-memory-store st
-      (let [{:keys [sid] :as build} (-> (test-build)
-                                        (assoc :script
-                                               {:jobs {"test-job" {:dependencies ["other-job"]}}}))
-            script {:jobs {"test-job" {:dependencies ["other-job"]}}}
-            evt {:type :script/start
-                 :sid sid
-                 :script script}]
-        (is (st/sid? (st/save-build st build)))
-        (is (map? (sut/update-script st evt)))
-        (let [match (st/find-build st sid)
-              job (get-in match [:script :jobs "test-job"])]
-          (is (some? job))
-          (is (= ["other-job"] (:dependencies job))))))))
-
-(deftest update-job
+(deftest handle-event
   (h/with-memory-store st
-    (let [{:keys [sid] :as build} (test-build)
-          stored-build (dissoc build :sid)]
+    (let [events (h/fake-events)
+          sid (random-sid)
+          build (test-build sid)
+          time (t/now)
+          handle (fn [part-evt]
+                   (sut/handle-event
+                    (merge {:sid sid :time time} part-evt)
+                    st events))]
       
-      (is (st/sid? (st/save-build st stored-build)))
-      
-      (testing "patches build script with job info"
-        (let [job {:id "test-job"
-                   :start-time 120
-                   :status :success}
-              evt {:type :job/start
-                   :sid sid
-                   :job job
-                   :message "Starting job"}]
-          (is (= sid (:sid (sut/update-job st evt))))
-          (is (= job
-                 (-> (st/find-build st sid)
-                     (get-in [:script :jobs "test-job"]))))))
+      (testing "`build/initializing` creates build"
+        (is (some? (handle {:type :build/initializing
+                            :build build})))
+        (is (= :initializing (-> (st/find-build st sid)
+                                 :status))))
 
-      (testing "marks running when no status"
-        (let [evt {:type :job/start
-                   :sid sid
-                   :job {:id "running-job"
-                         :start-time 120}
-                   :message "Starting job"}]
-          (is (= sid (:sid (sut/update-job st evt))))
-          (is (= :running
+      (testing "`build/start` sets start time and credit multiplier"
+        (is (some? (handle {:type :build/start
+                            :credit-multiplier 2})))
+        (is (= {:start-time time
+                :credit-multiplier 2
+                :status :running}
+               (-> (st/find-build st sid)
+                   (select-keys [:start-time :credit-multiplier :status])))))
+
+      (testing "`build/end`"
+        (is (some? (handle {:type :build/end
+                            :status :success})))
+        
+        (testing "sets end time and status"
+          (is (= {:end-time time
+                  :status :success}
                  (-> (st/find-build st sid)
-                     (get-in [:script :jobs "running-job"])
-                     :status))))))))
+                     (select-keys [:end-time :status])))))
+        
+        (testing "`build/end` calculates consumed credits"
+          (let [build (-> build
+                          (assoc-in [:script :jobs] {:job-1 {:id "job-1"
+                                                             :start-time 100
+                                                             :end-time 200
+                                                             :credit-multiplier 1}}))]
+            (is (some? (st/save-build st build)))
+            (is (some? (handle {:type :build/end})))
+            (is (number? (-> (st/find-build st sid)
+                             :credits))))))
+
+      (testing "`script/initializing` sets script dir in build"
+        (is (some? (handle {:type :script/initializing
+                            :script-dir "test/dir"})))
+        (is (= "test/dir"
+               (-> (st/find-build st sid)
+                   :script
+                   :script-dir))))
+
+
+      (let [job-id (str (random-uuid))]
+        (testing "`script/start` saves job configs"
+          (let [job {:id job-id
+                     :status :pending}]
+            (is (some? (handle {:type :script/start
+                                :jobs [job]})))
+            (is (= {job-id job}
+                   (-> (st/find-build st sid)
+                       :script
+                       :jobs)))))
+
+        (testing "`script/end` saves status"
+          (is (some? (handle {:type :script/end
+                              :status :success})))
+          (is (= :success
+                 (-> (st/find-build st sid)
+                     :script
+                     :status))))
+
+        (testing "`job/initializing`"
+          (is (some? (handle {:type :job/initializing
+                              :job-id job-id
+                              :credit-multiplier 2})))
+          (let [upd (-> (st/find-build st sid)
+                        :script
+                        :jobs
+                        (get job-id))]
+
+            (testing "updates job status"
+              (is (= :initializing (:status upd))))
+
+            (testing "sets credit multiplier"
+              (is (= 2 (:credit-multiplier upd))))))
+
+        (testing "`job/start`"
+          (is (some? (handle {:type :job/start
+                              :job-id job-id})))
+          (let [upd (-> (st/find-build st sid)
+                        (get-in [:script :jobs job-id]))]
+            
+            (testing "sets start time"
+              (is (= time (:start-time upd))))
+
+            (testing "sets status to `running`"
+              (is (= :running (:status upd))))))
+
+        (testing "`job/end`"
+          (is (some? (handle {:type :job/end
+                              :job-id job-id
+                              :status :success
+                              :result {:message "test result"}})))
+          (let [upd (-> (st/find-build st sid)
+                        (get-in [:script :jobs job-id]))]
+            
+            (testing "sets end time"
+              (is (= time (:end-time upd))))
+
+            (testing "sets status"
+              (is (= :success (:status upd))))
+
+            (testing "sets result"
+              (is (= {:message "test result"} (:result upd)))))))
+
+      (testing "dispatches `build/updated` event"
+        (let [evt (->> (h/received-events events)
+                       (h/first-event-by-type :build/updated))]
+          (is (some? evt))
+          (is (= sid (:sid evt))))))))
 
 (deftest build-update-handler
   (testing "creates a fn"
     (is (fn? (sut/build-update-handler {} nil))))
 
-  (letfn [(verify-build-event [evt-type]
-            (h/with-memory-store st
-              (let [sid (random-sid)
-                    build (test-build sid)
-                    handler (sut/build-update-handler st (h/fake-events))]
-                (handler {:type evt-type
-                          :build build})
-                (is (not= :timeout (h/wait-until #(st/build-exists? st sid) 1000))))))]
-    
-    (testing "handles `build/start`"
-      (verify-build-event :build/start))
-
-    (testing "handles `build/end`"
-      (verify-build-event :build/end)))
-
-  (letfn [(verify-script-event [evt-type]
-            (h/with-memory-store st
-              (let [sid (random-sid)
-                    build (test-build sid)
-                    _ (st/save-build st build)
-                    script {:jobs {"test-job" {:status :success}}}
-                    handler (sut/build-update-handler st (h/fake-events))]
-                (handler {:type evt-type
-                          :sid sid
-                          :script script})
-                (is (not= :timeout (h/wait-until (comp some? :script #(st/find-build st sid)) 1000))))))]
-    
-    (testing "handles `script/start`"
-      (verify-script-event :script/start))
-
-    (testing "handles `script/end`"
-      (verify-script-event :script/end)))
-
-  (letfn [(verify-job-event [evt-type]
-            (h/with-memory-store st
-              (let [sid (random-sid)
-                    build (test-build sid)
-                    job-id (random-uuid)
-                    _ (st/save-build st build)
-                    job {:id job-id
-                         :status :success}
-                    handler (sut/build-update-handler st (h/fake-events))]
-                (handler {:type evt-type
-                          :sid sid
-                          :job job})
-                (is (not= :timeout (h/wait-until (comp some?
-                                                       #(get-in % [:script :jobs job-id])
-                                                       #(st/find-build st sid)) 1000))))))]
-    
-    (testing "handles `job/start`"
-      (verify-job-event :job/start))
-
-    (testing "handles `job/updated`"
-      (verify-job-event :job/updated))
-
-    (testing "handles `job/end`"
-      (verify-job-event :job/end)))  
+  (testing "consumes and handles events async"
+    (h/with-memory-store st
+      (let [sid (random-sid)
+            build (test-build sid)
+            handler (sut/build-update-handler st (h/fake-events))]
+        (handler {:type :build/initializing
+                  :build build})
+        (is (not= :timeout (h/wait-until #(st/build-exists? st sid) 1000))))))
 
   (testing "dispatches events in sequence"
     (let [inv (atom {})
           handled (atom 0)
           handler (fn [_ {:keys [sid] :as evt}]
-                       (Thread/sleep 100)
-                       (if (= :job/start (:type evt))
-                         (swap! inv assoc sid [:started])
-                         (swap! inv update sid conj :completed))
-                       (swap! handled inc))]
+                    (Thread/sleep 100)
+                    (if (= :job/start (:type evt))
+                      (swap! inv assoc sid [:started])
+                      (swap! inv update sid conj :completed))
+                    (swap! handled inc))]
       (with-redefs [sut/update-handlers
                     {:job/start handler
                      :job/end handler}]
@@ -264,41 +180,7 @@
               :sid [::second]})
           (is (not= :timeout (h/wait-until #(= 4 @handled) 1000)))
           (doseq [[k r] @inv]
-            (is (= [:started :completed] r) (str "for id " k)))))))
-
-  (testing "dispatches `build/updated` event"
-    (h/with-memory-store st
-      (let [sid (random-sid)
-            events (h/fake-events)
-            build (test-build sid)
-            _ (st/save-build st build)
-            script {:jobs {"test-job" {:status :success}}}
-            handler (sut/build-update-handler st events)]
-        (handler {:type :script/start
-                  :sid sid
-                  :script script})
-        (is (not= :timeout (h/wait-until (comp some? :script #(st/find-build st sid)) 1000)))
-        (let [[e] @(:recv events)]
-          (is (some? e))
-          (is (= :build/updated (:type e)))
-          (is (= sid (:sid e)))
-          (is (= script (get-in e [:build :script])))))))
-
-  (testing "`build/updated` event has sid from `build/end`"
-    (h/with-memory-store st
-      (let [sid (random-sid)
-            events (h/fake-events)
-            build (test-build sid)
-            _ (st/save-build st build)
-            handler (sut/build-update-handler st events)]
-        (handler {:type :build/end
-                  :sid sid
-                  :build (assoc build :end-time 200)})
-        (is (not= :timeout (h/wait-until (comp some? :end-time #(st/find-build st sid)) 1000)))
-        (let [[e] @(:recv events)]
-          (is (some? e))
-          (is (= :build/updated (:type e)))
-          (is (= sid (:sid e))))))))
+            (is (= [:started :completed] r) (str "for id " k))))))))
 
 (deftest setup-runtime
   (testing "`nil` if no events configured"

--- a/app/test/unit/monkey/ci/sidecar_test.clj
+++ b/app/test/unit/monkey/ci/sidecar_test.clj
@@ -257,13 +257,13 @@
     
     (testing "restores artifacts if configured"
       (h/with-tmp-dir dir
-        (let [stored (atom {"test-cust/test-build/test-artifact.tgz" "/tmp/checkout"})
+        (let [stored (atom {"test-cust/test-repo/test-build/test-artifact.tgz" "/tmp/checkout"})
               build {:build-id "test-build"
-                     :sid ["test-cust" "test-build"]
+                     :sid ["test-cust" "test-repo" "test-build"]
                      :checkout-dir "/tmp/checkout"
                      :workspace "test-ws"}
               repo (art/make-blob-repository (h/fake-blob-store stored) build)
-              r (sut/run
+              tr (sut/run
                   (trs/make-test-rt
                    {:containers {:type :podman}
                     :build build
@@ -284,7 +284,7 @@
               path "test-artifact"
               _ (fs/create-file (fs/path dir path))
               build {:build-id "test-build"
-                     :sid ["test-cust" "test-build"]
+                     :sid ["test-cust" "test-repo" "test-build"]
                      :checkout-dir dir
                      :workspace "test-ws"}
               repo (art/make-blob-repository (h/fake-blob-store stored) build)

--- a/app/test/unit/monkey/ci/spec/events_test.clj
+++ b/app/test/unit/monkey/ci/spec/events_test.clj
@@ -85,7 +85,8 @@
                    :sid (h/gen-build-sid)
                    :job-id "test-job"
                    :job {:id "test-job"
-                         :type :container}})))
+                         :type :container}
+                   :credit-multiplier 1})))
   
   (testing "validates `:job/start` event"
     (is (not (s/valid? ::sut/event

--- a/app/test/unit/monkey/ci/spec/events_test.clj
+++ b/app/test/unit/monkey/ci/spec/events_test.clj
@@ -1,0 +1,44 @@
+(ns monkey.ci.spec.events-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure.spec.alpha :as s]
+            [monkey.ci.spec.events :as sut]
+            [monkey.ci
+             [cuid :as cuid]
+             [time :as t]]))
+
+(defn build-sid []
+  (repeatedly 3 cuid/random-cuid))
+
+(deftest event-spec
+  (testing "validates `:build/initializing` event"
+    (is (not (s/valid? ::sut/event
+                       {:type :build/initializing
+                        :time (t/now)
+                        :sid (build-sid)})))
+    (is (s/valid? ::sut/event
+                  {:type :build/initializing
+                   :time (t/now)
+                   :sid (build-sid)
+                   :build {:build-id "test-build"}})))
+
+  (testing "validates `:build/start` event"
+    (is (not (s/valid? ::sut/event
+                       {:type :build/start
+                        :time (t/now)
+                        :sid (build-sid)})))
+    (is (s/valid? ::sut/event
+                  {:type :build/start
+                   :time (t/now)
+                   :sid (build-sid)
+                   :credit-multiplier 2})))
+
+  (testing "validates `:build/end` event"
+    (is (not (s/valid? ::sut/event
+                       {:type :build/end
+                        :time (t/now)
+                        :sid (build-sid)})))
+    (is (s/valid? ::sut/event
+                  {:type :build/end
+                   :time (t/now)
+                   :sid (build-sid)
+                   :status :success}))))

--- a/app/test/unit/monkey/ci/spec/events_test.clj
+++ b/app/test/unit/monkey/ci/spec/events_test.clj
@@ -2,67 +2,63 @@
   (:require [clojure.test :refer [deftest testing is]]
             [clojure.spec.alpha :as s]
             [monkey.ci.spec.events :as sut]
-            [monkey.ci
-             [cuid :as cuid]
-             [time :as t]]))
-
-(defn build-sid []
-  (repeatedly 3 cuid/random-cuid))
+            [monkey.ci.time :as t]
+            [monkey.ci.helpers :as h]))
 
 (deftest event-spec
   (testing "validates `:build/initializing` event"
     (is (not (s/valid? ::sut/event
                        {:type :build/initializing
                         :time (t/now)
-                        :sid (build-sid)})))
+                        :sid (h/gen-build-sid)})))
     (is (s/valid? ::sut/event
                   {:type :build/initializing
                    :time (t/now)
-                   :sid (build-sid)
+                   :sid (h/gen-build-sid)
                    :build {:build-id "test-build"}})))
 
   (testing "validates `:build/start` event"
     (is (not (s/valid? ::sut/event
                        {:type :build/start
                         :time (t/now)
-                        :sid (build-sid)})))
+                        :sid (h/gen-build-sid)})))
     (is (s/valid? ::sut/event
                   {:type :build/start
                    :time (t/now)
-                   :sid (build-sid)
+                   :sid (h/gen-build-sid)
                    :credit-multiplier 2})))
 
   (testing "validates `:build/end` event"
     (is (not (s/valid? ::sut/event
                        {:type :build/end
                         :time (t/now)
-                        :sid (build-sid)})))
+                        :sid (h/gen-build-sid)})))
     (is (s/valid? ::sut/event
                   {:type :build/end
                    :time (t/now)
-                   :sid (build-sid)
+                   :sid (h/gen-build-sid)
                    :status :success})))
 
   (testing "validates `:script/initializing` event"
     (is (not (s/valid? ::sut/event
                        {:type :script/initializing
                         :time (t/now)
-                        :sid (build-sid)})))
+                        :sid (h/gen-build-sid)})))
     (is (s/valid? ::sut/event
                   {:type :script/initializing
                    :time (t/now)
-                   :sid (build-sid)
+                   :sid (h/gen-build-sid)
                    :script-dir "test/dir"})))
 
   (testing "validates `:script/start` event"
     (is (not (s/valid? ::sut/event
                        {:type :script/start
                         :time (t/now)
-                        :sid (build-sid)})))
+                        :sid (h/gen-build-sid)})))
     (is (s/valid? ::sut/event
                   {:type :script/start
                    :time (t/now)
-                   :sid (build-sid)
+                   :sid (h/gen-build-sid)
                    :jobs [{:id "test-job"
                            :type :container}]})))
 
@@ -70,23 +66,23 @@
     (is (not (s/valid? ::sut/event
                        {:type :script/end
                         :time (t/now)
-                        :sid (build-sid)})))
+                        :sid (h/gen-build-sid)})))
     (is (s/valid? ::sut/event
                   {:type :script/end
                    :time (t/now)
-                   :sid (build-sid)
+                   :sid (h/gen-build-sid)
                    :status :success})))
 
   (testing "validates `:job/initializing` event"
     (is (not (s/valid? ::sut/event
                        {:type :job/initializing
                         :time (t/now)
-                        :sid (build-sid)
+                        :sid (h/gen-build-sid)
                         :job-id "test-job"})))
     (is (s/valid? ::sut/event
                   {:type :job/initializing
                    :time (t/now)
-                   :sid (build-sid)
+                   :sid (h/gen-build-sid)
                    :job-id "test-job"
                    :job {:id "test-job"
                          :type :container}})))
@@ -95,21 +91,21 @@
     (is (not (s/valid? ::sut/event
                        {:type :job/start
                         :time (t/now)
-                        :sid (build-sid)})))
+                        :sid (h/gen-build-sid)})))
     (is (s/valid? ::sut/event
                   {:type :job/start
                    :time (t/now)
-                   :sid (build-sid)
+                   :sid (h/gen-build-sid)
                    :job-id "test-job"})))
 
   (testing "validates `:job/end` event"
     (is (not (s/valid? ::sut/event
                        {:type :job/end
                         :time (t/now)
-                        :sid (build-sid)})))
+                        :sid (h/gen-build-sid)})))
     (is (s/valid? ::sut/event
                   {:type :job/end
                    :time (t/now)
-                   :sid (build-sid)
+                   :sid (h/gen-build-sid)
                    :job-id "test-job"
                    :status :success}))))

--- a/app/test/unit/monkey/ci/spec/events_test.clj
+++ b/app/test/unit/monkey/ci/spec/events_test.clj
@@ -41,4 +41,75 @@
                   {:type :build/end
                    :time (t/now)
                    :sid (build-sid)
+                   :status :success})))
+
+  (testing "validates `:script/initializing` event"
+    (is (not (s/valid? ::sut/event
+                       {:type :script/initializing
+                        :time (t/now)
+                        :sid (build-sid)})))
+    (is (s/valid? ::sut/event
+                  {:type :script/initializing
+                   :time (t/now)
+                   :sid (build-sid)
+                   :script-dir "test/dir"})))
+
+  (testing "validates `:script/start` event"
+    (is (not (s/valid? ::sut/event
+                       {:type :script/start
+                        :time (t/now)
+                        :sid (build-sid)})))
+    (is (s/valid? ::sut/event
+                  {:type :script/start
+                   :time (t/now)
+                   :sid (build-sid)
+                   :jobs [{:id "test-job"
+                           :type :container}]})))
+
+  (testing "validates `:script/end` event"
+    (is (not (s/valid? ::sut/event
+                       {:type :script/end
+                        :time (t/now)
+                        :sid (build-sid)})))
+    (is (s/valid? ::sut/event
+                  {:type :script/end
+                   :time (t/now)
+                   :sid (build-sid)
+                   :status :success})))
+
+  (testing "validates `:job/initializing` event"
+    (is (not (s/valid? ::sut/event
+                       {:type :job/initializing
+                        :time (t/now)
+                        :sid (build-sid)
+                        :job-id "test-job"})))
+    (is (s/valid? ::sut/event
+                  {:type :job/initializing
+                   :time (t/now)
+                   :sid (build-sid)
+                   :job-id "test-job"
+                   :job {:id "test-job"
+                         :type :container}})))
+  
+  (testing "validates `:job/start` event"
+    (is (not (s/valid? ::sut/event
+                       {:type :job/start
+                        :time (t/now)
+                        :sid (build-sid)})))
+    (is (s/valid? ::sut/event
+                  {:type :job/start
+                   :time (t/now)
+                   :sid (build-sid)
+                   :job-id "test-job"})))
+
+  (testing "validates `:job/end` event"
+    (is (not (s/valid? ::sut/event
+                       {:type :job/end
+                        :time (t/now)
+                        :sid (build-sid)})))
+    (is (s/valid? ::sut/event
+                  {:type :job/end
+                   :time (t/now)
+                   :sid (build-sid)
+                   :job-id "test-job"
                    :status :success}))))


### PR DESCRIPTION
Reworked events to partial events.  They now only convey information that has changed, instead of entire builds or jobs, which were often incomplete or even incorrect.  This simplifies event handling in the listener.