### PR TITLE
Job logs

### DIFF
--- a/.monkeyci/build.clj
+++ b/.monkeyci/build.clj
@@ -15,7 +15,7 @@
 
 ;; Version assigned when building main branch
 ;; TODO Determine automatically
-(def snapshot-version "0.7.5-SNAPSHOT")
+(def snapshot-version "0.7.6-SNAPSHOT")
 
 (def tag-regex #"^refs/tags/(\d+\.\d+\.\d+(\.\d+)?$)")
 

--- a/app/examples/many-parallel-jobs/build.clj
+++ b/app/examples/many-parallel-jobs/build.clj
@@ -1,0 +1,11 @@
+(require '[monkey.ci.build.core :as bc])
+
+(def n-jobs 20)
+
+(defn make-job [idx]
+  (bc/action-job (str "job-" (inc idx))
+                 (-> bc/success
+                     (bc/with-message (str "Job executed: " (inc idx))))))
+
+(->> (range n-jobs)
+     (mapv make-job))

--- a/app/examples/many-sequential-jobs/build.clj
+++ b/app/examples/many-sequential-jobs/build.clj
@@ -1,0 +1,13 @@
+(require '[monkey.ci.build.core :as bc])
+
+(def n-jobs 20)
+
+(defn make-job [idx]
+  (cond-> (bc/action-job (str "job-" (inc idx))
+                         (-> bc/success
+                             (bc/with-message (str "Job executed: " (inc idx)))))
+    ;; Make each job dependent on the previous one
+    (pos? idx) (bc/depends-on [(str "job-" idx)])))
+
+(->> (range n-jobs)
+     (mapv make-job))

--- a/app/src/monkey/ci/listeners.clj
+++ b/app/src/monkey/ci/listeners.clj
@@ -40,7 +40,7 @@
                 (-> (merge existing (if (fn? patch)
                                       (patch existing)
                                       patch))))
-    (log/warn "Unable to patch build" sid ", record not found in db (initialize event missed?)")))
+    (log/warn "Unable to patch build" sid ", record not found in db (initialize or pending event missed?)")))
 
 (defn start-build [storage {:keys [sid time credit-multiplier]}]
   (patch-build storage sid {:start-time time
@@ -51,6 +51,7 @@
   (patch-build storage sid (fn [build]
                              {:end-time time
                               :status status
+                              ;; TODO Calculate credits on each job update
                               :credits (b/calc-credits build)
                               :message message})))
 

--- a/app/src/monkey/ci/script.clj
+++ b/app/src/monkey/ci/script.clj
@@ -100,7 +100,7 @@
 ;;; Script loading
 
 (defn- load-script
-  "Loads the pipelines from the build script, by reading the script files 
+  "Loads the jobs from the build script, by reading the script files 
    dynamically.  If the build script does not define its own namespace,
    one will be randomly generated to avoid collisions."
   [dir build-id]
@@ -112,7 +112,7 @@
     (try
       (let [path (io/file dir "build.clj")]
         (log/debug "Loading script:" path)
-        ;; This should return pipelines to run
+        ;; This should return jobs to run
         (load-file (str path)))
       (finally
         ;; Return

--- a/app/test/unit/monkey/ci/script_test.clj
+++ b/app/test/unit/monkey/ci/script_test.clj
@@ -84,7 +84,13 @@
           (is (bc/failed? r)))
 
         (testing "returns compiler error"
-          (is (= "Unable to resolve symbol: This in this context" (:message r))))))))
+          (is (= "Unable to resolve symbol: This in this context" (:message r))))))
+
+    (testing "executes many parallel jobs"
+      (is (bc/success? (exec-in-dir "many-parallel-jobs"))))
+
+    (testing "executes many sequential jobs"
+      (is (bc/success? (exec-in-dir "many-sequential-jobs"))))))
 
 (deftest run-all-jobs
   (let [rt {:events (h/fake-events)

--- a/gui/src/monkey/ci/gui/components.cljc
+++ b/gui/src/monkey/ci/gui/components.cljc
@@ -66,7 +66,9 @@
                      :error        [:text-danger :x-circle]
                      :running      [:text-info :play-circle]
                      :pending      [:text-warning :pause-circle]
-                     :initializing [:text-warning :play-circle]}
+                     :initializing [:text-warning :play-circle]
+                     :canceled     [:text-warning :x-circle]
+}
                     status
                     [:text-default :question-circle])]
     [:div (cond-> {:style {:font-size size}
@@ -146,7 +148,8 @@
 (defn log-contents [raw]
   (->> raw
        (map ->html)
-       (into [:p.bg-dark.text-white.font-monospace.overflow-auto.text-nowrap.h-100.p-1])))
+       (into [:p.bg-dark.text-white.font-monospace.overflow-auto.text-nowrap.p-1
+              {:style {:min-height "20em"}}])))
 
 (defn build-elapsed [b]
   (let [e (u/build-elapsed b)]

--- a/gui/src/monkey/ci/gui/components.cljc
+++ b/gui/src/monkey/ci/gui/components.cljc
@@ -148,6 +148,9 @@
      {:dangerouslySetInnerHTML {:__html (ansi->html l)}}]
     l))
 
+(defn colored [s color]
+  (str "\033[" color "m" s "\033[0m"))
+
 (defn log-viewer [contents]
   (into [:p.bg-dark.text-white.font-monospace.overflow-auto.text-nowrap.p-1
          {:style {:min-height "20em"}}]

--- a/gui/src/monkey/ci/gui/components.cljc
+++ b/gui/src/monkey/ci/gui/components.cljc
@@ -145,11 +145,15 @@
      {:dangerouslySetInnerHTML {:__html (ansi->html l)}}]
     l))
 
+(defn log-viewer [contents]
+  (into [:p.bg-dark.text-white.font-monospace.overflow-auto.text-nowrap.p-1
+         {:style {:min-height "20em"}}]
+        contents))
+
 (defn log-contents [raw]
   (->> raw
        (map ->html)
-       (into [:p.bg-dark.text-white.font-monospace.overflow-auto.text-nowrap.p-1
-              {:style {:min-height "20em"}}])))
+       (log-viewer)))
 
 (defn build-elapsed [b]
   (let [e (u/build-elapsed b)]

--- a/gui/src/monkey/ci/gui/job/db.cljc
+++ b/gui/src/monkey/ci/gui/job/db.cljc
@@ -55,5 +55,8 @@
 (defn set-log-expanded [db idx exp?]
   (assoc-in db [::expanded idx] exp?))
 
-(defn log-expanded? [db idx]
-  (true? (get-in db [::expanded idx])))
+(defn log-expanded?
+  ([db idx]
+   (true? (get-in db [::expanded idx])))
+  ([db]
+   (::expanded db)))

--- a/gui/src/monkey/ci/gui/job/db.cljc
+++ b/gui/src/monkey/ci/gui/job/db.cljc
@@ -1,31 +1,48 @@
 (ns monkey.ci.gui.job.db
-  (:require [monkey.ci.gui.loader :as lo]))
+  (:require [monkey.ci.gui.loader :as lo]
+            [monkey.ci.gui.routing :as r]))
 
-(def alerts ::alerts)
+(def route->id (comp (juxt :customer-id :repo-id :build-id :job-id)
+                     r/path-params))
+(def db->job-id (comp route->id r/current))
+
+(def get-id db->job-id)
+
+(defn get-path-id [db path]
+  (conj (db->job-id db) path))
+
+(defn get-alerts
+  ([db path]
+   (lo/get-alerts db (get-path-id db path)))
+  ([db]
+   (lo/get-alerts db (db->job-id db))))
 
 (defn set-alerts
   ([db path a]
-   (assoc-in db [alerts path] a))
+   (lo/set-alerts db (get-path-id db path) a))
   ([db a]
-   (set-alerts db :global a)))
+   (lo/set-alerts db (db->job-id db) a)))
 
 (defn clear-alerts
   ([db path]
-   (update db alerts dissoc path))
+   (lo/reset-alerts db (get-path-id db path)))
   ([db]
-   (clear-alerts db :global)))
+   (lo/reset-alerts db (db->job-id db))))
 
 (defn path-alerts [db path]
-  (get-in db [alerts path]))
+  (get-alerts db path))
 
 (defn global-alerts [db]
-  (path-alerts db :global))
+  (get-alerts db))
 
-(defn logs [db path]
-  (get-in db [::logs path]))
+(defn get-logs [db path]
+  (lo/get-value db (get-path-id db path)))
 
 (defn set-logs [db path l]
-  (assoc-in db [::logs path] l))
+  (lo/set-value db (get-path-id db path) l))
+
+(defn logs-loading? [db path]
+  (lo/loading? db (get-path-id db path)))
 
 (def log-files ::log-files)
 

--- a/gui/src/monkey/ci/gui/job/db.cljc
+++ b/gui/src/monkey/ci/gui/job/db.cljc
@@ -60,3 +60,6 @@
    (true? (get-in db [::expanded idx])))
   ([db]
    (::expanded db)))
+
+(defn clear-expanded [db]
+  (dissoc db ::expanded))

--- a/gui/src/monkey/ci/gui/job/db.cljc
+++ b/gui/src/monkey/ci/gui/job/db.cljc
@@ -51,3 +51,9 @@
 
 (defn clear-log-files [db]
   (dissoc db log-files))
+
+(defn set-log-expanded [db idx exp?]
+  (assoc-in db [::expanded idx] exp?))
+
+(defn log-expanded? [db idx]
+  (true? (get-in db [::expanded idx])))

--- a/gui/src/monkey/ci/gui/job/events.cljc
+++ b/gui/src/monkey/ci/gui/job/events.cljc
@@ -13,33 +13,38 @@
 
 (rf/reg-event-fx
  :job/init
- (fn [{:keys [db]} _]
-   {:dispatch-n [[:customer/maybe-load]
-                 [:build/maybe-load]
-                 [:tab/tab-changed details-tabs-id nil]]
-    :db (-> db
-            (db/clear-alerts)
-            (db/set-log-files nil)
-            (db/clear-log-files))}))
+ (fn [{:keys [db]} [_ uid]]
+   (lo/on-initialize db uid {:init-events
+                             [[:customer/maybe-load]
+                              [:build/maybe-load]
+                              [:tab/tab-changed details-tabs-id nil]]
+                             :leave-event
+                             [:job/leave uid]})))
+
+(rf/reg-event-db
+ :job/leave
+ (fn [db [_ uid]]
+   (lo/clear-all db uid)))
+
+(def route->id db/route->id)
 
 (def params->build-sid (juxt :customer-id :repo-id :build-id))
 
 (rf/reg-event-fx
  :job/load-log-files
- (fn [{:keys [db]} [_ job]]
-   (when job
-     (let [params (r/path-params (r/current db))
-           sid (params->build-sid params)]
-       {:dispatch [:secure-request
-                   :get-log-label-values
-                   (-> (loki/request-params sid job)
-                       (assoc :customer-id (:customer-id params)
-                              :label "filename"))
-                   [:job/load-log-files--success]
-                   [:job/load-log-files--failed]]
-        :db (db/set-alerts db
-                           [{:type :info
-                             :message "Seaching logs..."}])}))))
+ (fn [{:keys [db] :as ctx} [_ job :as evt]]
+   (let [[cust-id :as id] (db/db->job-id db)
+         loader (lo/loader-evt-handler
+                 id
+                 (fn [& _]
+                   [:secure-request
+                    :get-log-label-values
+                    (-> (loki/request-params id job)
+                        (assoc :customer-id cust-id
+                               :label "filename"))
+                    [:job/load-log-files--success]
+                    [:job/load-log-files--failed]]))]
+     (loader ctx evt))))
 
 (rf/reg-event-db
  :job/load-log-files--success
@@ -57,40 +62,35 @@
 
 (rf/reg-event-fx
  :job/load-logs
- (fn [{:keys [db]} [_ job path]]
-   (when job
-     (let [params (r/path-params (r/current db))
-           sid (params->build-sid params)]
-       ;; FIXME Loki limits the number of entries returned.  We should send an index stats
-       ;; request first and then fetch all entries.  This could lead to problems with large
-       ;; logs however, so we'll need to add some sort of pagination.
-       {:dispatch [:secure-request
-                   :download-log
-                   (-> (loki/request-params sid job)
-                       (assoc :customer-id (:customer-id params)
-                              :limit 1000
-                              :query (-> (loki/job-query sid (:id job))
-                                         (assoc "filename" path)
-                                         (loki/query->str))))
-                   [:job/load-logs--success path]
-                   [:job/load-logs--failed path]]
-        :db (db/set-alerts db
-                           path
-                           [{:type :info
-                             :message "Fetching logs..."}])}))))
+ (fn [{:keys [db] :as ctx} [_ job path :as evt]]
+   (let [[cust-id :as id] (db/get-path-id db path)
+         loader (lo/loader-evt-handler
+                 id
+                 (fn [& _]
+                   ;; FIXME Loki limits the number of entries returned.  We should send an index stats
+                   ;; request first and then fetch all entries.  This could lead to problems with large
+                   ;; logs however, so we'll need to add some sort of pagination.
+                   [:secure-request
+                    :download-log
+                    (-> (loki/request-params id job)
+                        (assoc :customer-id cust-id
+                               :limit 1000
+                               :query (-> (loki/job-query id (:id job))
+                                          (assoc "filename" path)
+                                          (loki/query->str))))
+                    [:job/load-logs--success path]
+                    [:job/load-logs--failed path]]))]
+     (loader ctx evt))))
 
 (rf/reg-event-db
  :job/load-logs--success
- (fn [db [_ path {logs :body}]]
+ (fn [db [_ path resp]]
    (-> db
-       (db/clear-alerts path)
-       (db/set-logs path logs))))
+       (lo/on-success (db/get-path-id db path) resp)
+       (db/clear-alerts path))))
 
 (rf/reg-event-db
  :job/load-logs--failed
  (fn [db [_ path err]]
-   (db/set-alerts db
-                  path
-                  [{:type :danger
-                    :message (str "Failed to fetch logs: " (u/error-msg err))}])))
+   (lo/on-failure db (db/get-path-id db path) "Failed to fetch logs: " err)))
 

--- a/gui/src/monkey/ci/gui/job/events.cljc
+++ b/gui/src/monkey/ci/gui/job/events.cljc
@@ -1,5 +1,6 @@
 (ns monkey.ci.gui.job.events
-  (:require [monkey.ci.gui.job.db :as db]
+  (:require [monkey.ci.gui.build.db :as bdb]
+            [monkey.ci.gui.job.db :as db]
             [monkey.ci.gui.loader :as lo]
             [monkey.ci.gui.login.db :as ldb]
             [monkey.ci.gui.loki :as loki]
@@ -94,3 +95,12 @@
  (fn [db [_ path err]]
    (lo/on-failure db (db/get-path-id db path) "Failed to fetch logs: " err)))
 
+(rf/reg-event-fx
+ :job/toggle-logs
+ (fn [{:keys [db]} [_ idx]]
+   (let [job-id (db/db->job-id db)
+         job (get-in (bdb/get-build db) [:script :jobs job-id])]
+     ;; TODO Only fetch logs if we know they exist
+     {:dispatch-n [[:job/load-logs job (str idx "_out.log")]
+                   [:job/load-logs job (str idx "_err.log")]]
+      :db (db/set-log-expanded db idx true)})))

--- a/gui/src/monkey/ci/gui/job/events.cljc
+++ b/gui/src/monkey/ci/gui/job/events.cljc
@@ -99,8 +99,10 @@
  :job/toggle-logs
  (fn [{:keys [db]} [_ idx]]
    (let [job-id (db/db->job-id db)
-         job (get-in (bdb/get-build db) [:script :jobs job-id])]
-     ;; TODO Only fetch logs if we know they exist
-     {:dispatch-n [[:job/load-logs job (str idx "_out.log")]
-                   [:job/load-logs job (str idx "_err.log")]]
-      :db (db/set-log-expanded db idx true)})))
+         job (get-in (bdb/get-build db) [:script :jobs job-id])
+         exp? (db/log-expanded? db idx)]
+     (cond-> {:db (db/set-log-expanded db idx (not exp?))}
+       (not exp?)
+       ;; TODO Only fetch logs if we know they exist
+       (assoc :dispatch-n [[:job/load-logs job (str idx "_out.log")]
+                           [:job/load-logs job (str idx "_err.log")]])))))

--- a/gui/src/monkey/ci/gui/job/subs.cljc
+++ b/gui/src/monkey/ci/gui/job/subs.cljc
@@ -34,7 +34,7 @@
 (rf/reg-sub
  :job/logs
  (fn [db [_ path]]
-   (->> (db/logs db path)
+   (->> (db/get-logs db path)
         :data
         :result
         first
@@ -51,3 +51,30 @@
         (mapcat :test-cases)
         (sort-by error-count)
         (reverse))))
+
+(def log-path-regex #"^.*([0-9]+)_(out|err).log$")
+
+(defn- path->line [path]
+  (when-let [[_ idx :as p] (re-matches log-path-regex path)]
+    (u/parse-int idx)))
+
+(defn- path->type [path]
+  (keyword (nth (re-matches log-path-regex path) 2)))
+
+(rf/reg-sub
+ :job/script-with-logs
+ :<- [:job/current]
+ :<- [:job/log-files]
+ (fn [[job files] _]
+   (let [file-per-line (group-by path->line files)]
+     (letfn [(as-types-map [paths]
+               (->> paths
+                    (map (fn [l]
+                           [(path->type l) l]))
+                    (into {})))
+             (->out [idx line]
+               (let [m (get file-per-line idx)]
+                 (cond-> {:cmd line}
+                   m (merge (as-types-map m)))))]
+       (->> (:script job)
+            (map-indexed ->out))))))

--- a/gui/src/monkey/ci/gui/job/subs.cljc
+++ b/gui/src/monkey/ci/gui/job/subs.cljc
@@ -74,6 +74,7 @@
                     (into {})))
              (->out [idx line]
                (let [m (get file-per-line idx)]
+                 ;; TODO Also add expanded status
                  (cond-> {:cmd line}
                    m (merge (as-types-map m)))))]
        (->> (:script job)

--- a/gui/src/monkey/ci/gui/job/views.cljs
+++ b/gui/src/monkey/ci/gui/job/views.cljs
@@ -67,6 +67,7 @@
           last))
 
 (defn- log-contents [job path]
+  ;; FIXME Stretch to full available height
   (let [log (rf/subscribe [:job/logs path])]
     ;; Reload log file
     (rf/dispatch [:job/load-logs job path])

--- a/gui/src/monkey/ci/gui/job/views.cljs
+++ b/gui/src/monkey/ci/gui/job/views.cljs
@@ -77,9 +77,16 @@
      (when (and @log (not-empty @log))
        [co/log-contents @log])]))
 
-(defn- script-line [idx l]
-  [:a {:on-click (u/link-evt-handler [:job/toggle-logs idx])}
-   [:span.me-1 [co/icon :chevron-right]] (co/->html (str "\033[92m$ " (:cmd l) "\033[0m"))])
+(defn- script-line [idx {:keys [expanded?] :as l}]
+  [:<>
+   [:a {:on-click (u/link-evt-handler [:job/toggle-logs idx])}
+    [:span.me-1
+     [co/icon (if expanded? :chevron-down :chevron-right)]]
+    (co/->html (str "\033[92m$ " (:cmd l) "\033[0m"))]
+   (when expanded?
+     ;; TODO Subscribe to logs per type
+     ;; TODO Show each log
+     )])
 
 (defn- job-logs [job]
   (rf/dispatch [:job/load-log-files job])

--- a/gui/src/monkey/ci/gui/loader.cljc
+++ b/gui/src/monkey/ci/gui/loader.cljc
@@ -129,8 +129,6 @@
       event-handler-event
       (update :dispatch-n (fnil conj []) [:event-stream/start id (r/customer-id db) event-handler-event]))))
 
-;;(defn initializer-evt-handler [])
-
 (defn on-leave
   "Creates a context for an leave fx handler that clears the initialized flag
    and dispatches a stream stop event."

--- a/gui/src/monkey/ci/gui/test_results.cljc
+++ b/gui/src/monkey/ci/gui/test_results.cljc
@@ -121,12 +121,12 @@
     [:div
      [:h4 "Test Timings"]
      [:form
-      [:div.row
-       [:label.form-label.col-2.col-form-label {:for suite-id} "Suite:"]
-       [:div.col-2
+      [:div.d-flex.gap-2
+       [:label.form-label.col-form-label {:for suite-id} "Suite:"]
+       [:div
         [suite-dropdown results id suite-id]]
-       [:label.form-label.col-2.col-form-label {:for count-id} "Show top:"]
-       [:div.col-2
+       [:label.form-label.col-form-label {:for count-id} "Show top:"]
+       [:div
         [test-count-dropdown id count-id]]]]
      (rf/dispatch [::timing-chart-init id results])
      #_[charts/chart-component id]

--- a/gui/test/monkey/ci/gui/test/job/events_test.cljc
+++ b/gui/test/monkey/ci/gui/test/job/events_test.cljc
@@ -143,3 +143,32 @@
                          first
                          :type))))))
 
+(deftest job-toggle-logs
+  (testing "when collapsed"
+    (rft/run-test-sync
+     (h/initialize-martian {:download-log {:error-code :no-error
+                                           :body {}}})
+     
+     (let [e (h/catch-fx :martian.re-frame/request)]
+       (is (nil? (rf/dispatch [:job/toggle-logs 0])))
+
+       (testing "fetches out and err logs for given line from backend"
+         (is (= 2 (count @e)))
+         (is (-> @e
+                 first
+                 (nth 3)
+                 :query
+                 (cs/includes? "filename=\"0_out.log\"")))
+         (is (-> @e
+                 second
+                 (nth 3)
+                 :query
+                 (cs/includes? "filename=\"0_err.log\""))))
+
+       (testing "marks as expanded"
+         (is (db/log-expanded? @app-db 0)))))
+
+    (testing "does not re-fetch logs if job finished"))
+
+  (testing "when expanded"
+    (testing "marks as collapsed")))

--- a/gui/test/monkey/ci/gui/test/job/subs_test.cljc
+++ b/gui/test/monkey/ci/gui/test/job/subs_test.cljc
@@ -165,4 +165,9 @@
                :err "/var/log/0_err.log"}
               {:cmd "script line 2"
                :out "/var/log/1_out.log"}]
-             @l)))))
+             @l)))
+
+    (testing "includes expanded state"
+      (is (some? (swap! app-db (fn [db]
+                                 (db/set-log-expanded db 1 true)))))
+      (is (true? (-> @l second :expanded?))))))

--- a/gui/test/monkey/ci/gui/test/job/subs_test.cljc
+++ b/gui/test/monkey/ci/gui/test/job/subs_test.cljc
@@ -134,3 +134,35 @@
                 "failed"
                 "success"]
                (map :name @tc)))))))
+
+(deftest job-script-with-logs
+  (let [l (rf/subscribe [:job/script-with-logs])]
+    (testing "exists"
+      (is (some? l)))
+
+    (testing "returns script list with log paths"
+      (is (empty? @l))
+      (is (some? (reset! app-db
+                         (-> {}
+                             (db/set-log-files
+                              ["/var/log/0_out.log"
+                               "/var/log/0_err.log"
+                               "/var/log/1_out.log"])
+                             (r/set-current
+                              {:parameters
+                               {:path
+                                {:job-id "test-job"}}})
+                             (bdb/set-build
+                              {:id "test-build"
+                               :script
+                               {:jobs {"test-job"
+                                       {:id "test-job"
+                                        :script
+                                        ["script line 1"
+                                         "script line 2"]}}}})))))
+      (is (= [{:cmd "script line 1"
+               :out "/var/log/0_out.log"
+               :err "/var/log/0_err.log"}
+              {:cmd "script line 2"
+               :out "/var/log/1_out.log"}]
+             @l)))))


### PR DESCRIPTION
Reworked the way job logs are viewed.  Instead of a tab per file, I have combined them in a single "logs" tab, that links the script line to the stdout and stderr logs.