### PR TITLE
Feature/telemere

### DIFF
--- a/app/deps.edn
+++ b/app/deps.edn
@@ -34,9 +34,10 @@
         com.stuartsierra/component {:mvn/version "1.1.0"}
         com.taoensso/telemere {:mvn/version "1.0.0-beta25"}
         commons-io/commons-io {:mvn/version "2.16.1"}
-        io.micrometer/micrometer-registry-prometheus {:mvn/version "1.12.8"}
-        io.micrometer/micrometer-core {:mvn/version "1.12.8"}
-        io.prometheus/prometheus-metrics-exporter-pushgateway {:mvn/version "1.3.0"}
+        io.micrometer/micrometer-registry-prometheus {:mvn/version "1.13.6"}
+        io.micrometer/micrometer-core {:mvn/version "1.13.6"}
+        io.prometheus/prometheus-metrics-exporter-pushgateway {:mvn/version "1.3.1"}
+        io.prometheus/prometheus-metrics-tracer-initializer {:mvn/version "1.3.1"}
         io.resonant/micrometer-clj {:mvn/version "0.0.4"}
         medley/medley {:mvn/version "1.4.0"}
         metosin/reitit-middleware {:mvn/version "0.7.1"}

--- a/app/deps.edn
+++ b/app/deps.edn
@@ -32,6 +32,7 @@
                                 ;; slower however, so maybe later we can change this.
                                 :exclusions [org.zeromq/jzmq]}
         com.stuartsierra/component {:mvn/version "1.1.0"}
+        com.taoensso/telemere {:mvn/version "1.0.0-beta25"}
         commons-io/commons-io {:mvn/version "2.16.1"}
         io.micrometer/micrometer-registry-prometheus {:mvn/version "1.12.8"}
         io.micrometer/micrometer-core {:mvn/version "1.12.8"}

--- a/app/deps.edn
+++ b/app/deps.edn
@@ -36,6 +36,7 @@
         commons-io/commons-io {:mvn/version "2.16.1"}
         io.micrometer/micrometer-registry-prometheus {:mvn/version "1.12.8"}
         io.micrometer/micrometer-core {:mvn/version "1.12.8"}
+        io.prometheus/prometheus-metrics-exporter-pushgateway {:mvn/version "1.3.0"}
         io.resonant/micrometer-clj {:mvn/version "0.0.4"}
         medley/medley {:mvn/version "1.4.0"}
         metosin/reitit-middleware {:mvn/version "0.7.1"}

--- a/app/deps.edn
+++ b/app/deps.edn
@@ -36,6 +36,7 @@
         commons-io/commons-io {:mvn/version "2.16.1"}
         io.prometheus/prometheus-metrics-core {:mvn/version "1.3.1"}
         io.prometheus/prometheus-metrics-exporter-pushgateway {:mvn/version "1.3.1"}
+        io.prometheus/prometheus-metrics-instrumentation-jvm {:mvn/version "1.3.1"}
         io.prometheus/prometheus-metrics-tracer-initializer {:mvn/version "1.3.1"}
         medley/medley {:mvn/version "1.4.0"}
         metosin/reitit-middleware {:mvn/version "0.7.1"}

--- a/app/deps.edn
+++ b/app/deps.edn
@@ -34,11 +34,8 @@
         com.stuartsierra/component {:mvn/version "1.1.0"}
         com.taoensso/telemere {:mvn/version "1.0.0-beta25"}
         commons-io/commons-io {:mvn/version "2.16.1"}
-        io.micrometer/micrometer-registry-prometheus {:mvn/version "1.13.6"}
-        io.micrometer/micrometer-core {:mvn/version "1.13.6"}
         io.prometheus/prometheus-metrics-exporter-pushgateway {:mvn/version "1.3.1"}
         io.prometheus/prometheus-metrics-tracer-initializer {:mvn/version "1.3.1"}
-        io.resonant/micrometer-clj {:mvn/version "0.0.4"}
         medley/medley {:mvn/version "1.4.0"}
         metosin/reitit-middleware {:mvn/version "0.7.1"}
         metosin/reitit-ring {:mvn/version "0.7.1"}

--- a/app/deps.edn
+++ b/app/deps.edn
@@ -34,6 +34,7 @@
         com.stuartsierra/component {:mvn/version "1.1.0"}
         com.taoensso/telemere {:mvn/version "1.0.0-beta25"}
         commons-io/commons-io {:mvn/version "2.16.1"}
+        io.prometheus/prometheus-metrics-core {:mvn/version "1.3.1"}
         io.prometheus/prometheus-metrics-exporter-pushgateway {:mvn/version "1.3.1"}
         io.prometheus/prometheus-metrics-tracer-initializer {:mvn/version "1.3.1"}
         medley/medley {:mvn/version "1.4.0"}

--- a/app/env/dev/user.clj
+++ b/app/env/dev/user.clj
@@ -3,7 +3,7 @@
             [logging :as l]
             [server :as server]
             [storage :as s]
-            [clojure.tools.namespace.repl :refer [refresh]]))
+            [clojure.tools.namespace.repl :as nr]))
 
 (defn global-config []
   @c/global-config)
@@ -22,3 +22,7 @@
   (c/load-config! "github/staging.edn")
   (c/load-config! "bitbucket/staging.edn")
   (server/start-server))
+
+(defn refresh []
+  (server/stop-server)
+  (nr/refresh))

--- a/app/src/monkey/ci/blob.clj
+++ b/app/src/monkey/ci/blob.clj
@@ -213,7 +213,8 @@
 
 (defmethod make-blob-store :oci [conf k]
   (let [oci-conf (get conf k)
-        client (os/make-client oci-conf)]
+        client (-> (os/make-client oci-conf)
+                   (oci/add-inv-interceptor :blob))]
     (->OciBlobStore client oci-conf)))
 
 ;;; Configuration functionality

--- a/app/src/monkey/ci/containers/oci.clj
+++ b/app/src/monkey/ci/containers/oci.clj
@@ -383,7 +383,8 @@
 (defn run-container [{:keys [events job build] :as conf}]
   (log/debug "Running job as OCI instance:" job)
   (log/debug "Build details:" build)
-  (let [client (ci/make-context (:oci conf))
+  (let [client (-> (ci/make-context (:oci conf))
+                   (oci/add-inv-interceptor :containers))
         ic     (instance-config conf)]
     (fire-job-initializing job (b/sid build) events)
     (when (validate-job! conf)

--- a/app/src/monkey/ci/core.clj
+++ b/app/src/monkey/ci/core.clj
@@ -16,7 +16,6 @@
              [git]
              [listeners]
              [logging]
-             [metrics]
              [runtime :as rt]
              [runners]
              [sidecar]

--- a/app/src/monkey/ci/logging.clj
+++ b/app/src/monkey/ci/logging.clj
@@ -207,7 +207,8 @@
 
 (defmethod make-log-retriever :oci [conf]
   (let [oci-conf (:logging conf)
-        client (os/make-client oci-conf)]
+        client (-> (os/make-client oci-conf)
+                   (oci/add-inv-interceptor :logging))]
     (->OciBucketLogRetriever client oci-conf)))
 
 ;;; Configuration handling

--- a/app/src/monkey/ci/metrics.clj
+++ b/app/src/monkey/ci/metrics.clj
@@ -24,18 +24,20 @@
        (distinct)
        (count)))
 
+;; TODO Reactivate
+
 #_(defn add-events-metrics [r events]
-  (when-let [ss (get-in events [:server :state-stream])]
-    (let [state (atom nil)]
-      ;; Constantly store the latest state, so it can be used by the gauges
-      (ms/consume (partial reset! state) ss)
-      (mm/get-gauge r "monkey_event_filters" {}
-                    {:description "Number of different registered event filters"}
-                    #(count (keys (:listeners @state))))
-      (mm/get-gauge r "monkey_event_clients" {}
-                    {:description "Total number of registered clients"}
-                    #(count-listeners @state))))
-  r)
+    (when-let [ss (get-in events [:server :state-stream])]
+      (let [state (atom nil)]
+        ;; Constantly store the latest state, so it can be used by the gauges
+        (ms/consume (partial reset! state) ss)
+        (mm/get-gauge r "monkey_event_filters" {}
+                      {:description "Number of different registered event filters"}
+                      #(count (keys (:listeners @state))))
+        (mm/get-gauge r "monkey_event_clients" {}
+                      {:description "Total number of registered clients"}
+                      #(count-listeners @state))))
+    r)
 
 ;; TODO Instrument prometheus registry
 #_(extend-type io.resonant.micrometer.Registry

--- a/app/src/monkey/ci/metrics.clj
+++ b/app/src/monkey/ci/metrics.clj
@@ -80,6 +80,9 @@
                       :tx (filter (comp (partial = :oci/invocation) :id))})
     reg))
 
+(defn- remove-signal-handlers []
+  (t/remove-handler! ::oci-calls))
+
 (defrecord Metrics []
   co/Lifecycle
   (start [this]
@@ -87,6 +90,7 @@
                               (add-oci-metrics))))
 
   (stop [this]
+    (remove-signal-handlers)
     this))
 
 (def make-metrics ->Metrics)

--- a/app/src/monkey/ci/metrics.clj
+++ b/app/src/monkey/ci/metrics.clj
@@ -68,10 +68,23 @@
          ([])))
       counter)))
 
+(defn- add-oci-metrics [reg]
+  (letfn [(tags
+            ([]
+             [:kind])
+            ([signal]
+             (name (get-in signal [:data :kind]))))]
+    (signal->counter ::oci-calls reg "monkey_oci_calls"
+                     {:description "Number of calls to OCI API endpoints"
+                      :tags tags
+                      :tx (filter (comp (partial = :oci/invocation) :id))})
+    reg))
+
 (defrecord Metrics []
   co/Lifecycle
   (start [this]
-    (assoc this :registry (make-registry)))
+    (assoc this :registry (-> (make-registry)
+                              (add-oci-metrics))))
 
   (stop [this]
     this))

--- a/app/src/monkey/ci/metrics.clj
+++ b/app/src/monkey/ci/metrics.clj
@@ -86,6 +86,7 @@
 (defrecord Metrics []
   co/Lifecycle
   (start [this]
+    ;; TODO Add build labels if present
     (assoc this :registry (-> (make-registry)
                               (add-oci-metrics))))
 

--- a/app/src/monkey/ci/prometheus.clj
+++ b/app/src/monkey/ci/prometheus.clj
@@ -4,7 +4,8 @@
    versions of the Prometheus libs.  Since we're fixed on Prometheus (for now), it's not
    necessary to maintain all the other formats, so the micrometer layer was essentially
    ballast.  This namespace accesses the Prometheus code directly."
-  (:require [medley.core :as mc])
+  (:require [clojure.tools.logging :as log]
+            [medley.core :as mc])
   (:import [io.prometheus.metrics.core.metrics Counter CounterWithCallback Gauge GaugeWithCallback]
            [io.prometheus.metrics.model.registry PrometheusRegistry]
            [io.prometheus.metrics.exporter.pushgateway PushGateway]
@@ -115,4 +116,5 @@
 (defn push
   "Pushes all registered datapoints to the push gateway"
   [gw]
+  (log/debug "Pushing metrics to push gateway")
   (.push gw))

--- a/app/src/monkey/ci/prometheus.clj
+++ b/app/src/monkey/ci/prometheus.clj
@@ -1,0 +1,80 @@
+(ns monkey.ci.prometheus
+  "Functionality to export metrics to prometheus format, or push them to a pushgateway.
+   Originally we used `micrometer-clj`, but it's really old and incompatible with recent
+   versions of the Prometheus libs.  Since we're fixed on Prometheus (for now), it's not
+   necessary to maintain all the other formats, so the micrometer layer was essentially
+   ballast.  This namespace accesses the Prometheus code directly."
+  (:import [io.prometheus.metrics.core.metrics Counter Gauge]
+           [io.prometheus.metrics.model.registry PrometheusRegistry]
+           [io.prometheus.metrics.exporter.pushgateway PushGateway]
+           [io.prometheus.metrics.expositionformats PrometheusTextFormatWriter]
+           [java.io ByteArrayOutputStream]
+           [java.nio.charset StandardCharsets]))
+
+(defn make-registry
+  "Creates a new prometheus registry"
+  []
+  (PrometheusRegistry.))
+
+(defn ^String scrape
+  "Returns metrics formatted to Prometheus scrape format as a string."
+  [reg]
+  (let [snapshots (.scrape reg)
+        writer (PrometheusTextFormatWriter. false)]
+    (with-open [os (ByteArrayOutputStream.)]
+      (.write writer os snapshots)
+      (String. (.toByteArray os) StandardCharsets/UTF_8))))
+
+(defn- ->arr [strs]
+  (into-array String strs))
+
+(defn- build-datapoint [dp name reg {:keys [description labels]}]
+  (cond-> (.name dp name)
+    description (.help description)
+    labels (.labelNames (->arr labels))
+    true (.register reg)))
+
+(defn make-gauge [name reg & [opts]]
+  (build-datapoint (Gauge/builder) name reg opts))
+
+(defn gauge-set [g v]
+  (.set g (double v))
+  g)
+
+(defn gauge-inc [g & [n]]
+  (.inc g (or (double n) 1.0))
+  g)
+
+(defn gauge-dec [g & [n]]
+  (.dec g (or (double n) 1.0))
+  g)
+
+(defn gauge-get [g]
+  (.get g))
+
+(defn make-counter [name reg & [opts]]
+  (build-datapoint (Counter/builder) name reg opts))
+
+(defn counter-inc [c v & [label-vals]]
+  (if label-vals
+    (.. c (labelValues (->arr label-vals)) (inc (double v)))
+    (.. c (inc (double v))))
+  c)
+
+(defn counter-get [c & [label-vals]]
+  (if label-vals
+    (.. c (labelValues (->arr label-vals)) (get))
+    (.get c)))
+
+(defn push-gw
+  "Creates a PushGateway object to push metrics to"
+  [host port reg job]
+  (.. (PushGateway/builder)
+      (address (str host ":" port))
+      (registry reg)
+      (job job)))
+
+(defn push
+  "Pushes all registered datapoints to the push gateway"
+  [gw]
+  (.push gw))

--- a/app/src/monkey/ci/runners.clj
+++ b/app/src/monkey/ci/runners.clj
@@ -26,6 +26,7 @@
      :message msg}))
 
 (defn- post-build-end [rt build {:keys [exit message] :as res}]
+  (log/debug "Posting :build/end event for exit code" exit)
   (md/chain
    (rt/post-events rt (build/build-end-evt
                        (cond-> build

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -216,6 +216,7 @@
 
 (defmethod r/make-runner :oci [rt]
   (let [conf (:runner rt)
-        client (ci/make-context conf)]
+        client (-> (ci/make-context conf)
+                   (oci/add-inv-interceptor :runners))]
     (partial oci-runner client conf)))
 

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -58,7 +58,7 @@
 (defn- rt->config [build rt]
   (-> (rt/rt->config rt)
       ;; TODO Move the config needed by the runner under the runner config itself
-      (select-keys [:containers :logging :workspace :cache :artifacts :sidecar :promtail :api])
+      (select-keys [:containers :logging :workspace :cache :artifacts :sidecar :promtail :api :push-gw])
       (assoc :checkout-base-dir oci/work-dir
              :build (dissoc build :ssh-keys :cleanup? :status)
              ;; TODO Use aero tags in the config, instead of doing this manually here

--- a/app/src/monkey/ci/runtime/app.clj
+++ b/app/src/monkey/ci/runtime/app.clj
@@ -147,7 +147,7 @@
       (not-empty config) (assoc :gw (prom/push-gw (:host config)
                                                   (:port config)
                                                   (:registry metrics)
-                                                  "test_job"))))
+                                                  "monkeyci_build"))))
 
   (stop [this]
     (when-let [gw (:gw this)]

--- a/app/src/monkey/ci/runtime/app.clj
+++ b/app/src/monkey/ci/runtime/app.clj
@@ -192,7 +192,9 @@
 (defrecord ServerRuntime [config]
   co/Lifecycle
   (start [this]
-    (assoc this :jwk (get-in this [:jwk :jwk])))
+    (assoc this
+           :jwk (get-in this [:jwk :jwk])
+           :metrics (get-in this [:metrics :registry])))
 
   (stop [this]
     this))
@@ -201,7 +203,7 @@
   (->ServerRuntime conf))
 
 (defn- new-metrics []
-  (m/make-registry))
+  {:registry (m/make-registry)})
 
 (defn make-server-system
   "Creates a component system that can be used to start an application server."

--- a/app/src/monkey/ci/runtime/app.clj
+++ b/app/src/monkey/ci/runtime/app.clj
@@ -203,7 +203,7 @@
   (->ServerRuntime conf))
 
 (defn- new-metrics []
-  {:registry (m/make-registry)})
+  (m/make-metrics))
 
 (defn make-server-system
   "Creates a component system that can be used to start an application server."

--- a/app/src/monkey/ci/runtime/app.clj
+++ b/app/src/monkey/ci/runtime/app.clj
@@ -10,6 +10,7 @@
              [listeners :as li]
              [logging :as l]
              [metrics :as m]
+             [prometheus :as prom]
              [protocols :as p]
              [reporting :as rep]
              [runners :as r]
@@ -136,6 +137,26 @@
    :port (or (get-in config [:runner :api-port])
              (random-port))})
 
+(defn- new-metrics []
+  (m/make-metrics))
+
+(defrecord PushGateway [config metrics]
+  co/Lifecycle
+  (start [this]
+    (cond-> this
+      (not-empty config) (assoc :gw (prom/push-gw (:host config)
+                                                  (:port config)
+                                                  (:registry metrics)
+                                                  "test_job"))))
+
+  (stop [this]
+    (when-let [gw (:gw this)]
+      (prom/push gw))
+    (dissoc this :gw)))
+
+(defn new-push-gw [config]
+  (map->PushGateway {:config (:push-gw config)}))
+
 (defn make-runner-system
   "Given a runner configuration object, creates component system.  When started,
    it contains a fully configured `runtime` component that can be used by the
@@ -166,7 +187,11 @@
                 [:events :artifacts :cache :containers :workspace :build :params :api-config])
    :params     (co/using
                 (new-params config)
-                [:build])))
+                [:build])
+   :metrics    (new-metrics)
+   :push-gw    (co/using
+                (new-push-gw config)
+                [:metrics])))
 
 (defn with-runner-system [config f]
   (rc/with-system (make-runner-system config) f))
@@ -201,9 +226,6 @@
 
 (defn- new-server-runtime [conf]
   (->ServerRuntime conf))
-
-(defn- new-metrics []
-  (m/make-metrics))
 
 (defn make-server-system
   "Creates a component system that can be used to start an application server."

--- a/app/src/monkey/ci/runtime/common.clj
+++ b/app/src/monkey/ci/runtime/common.clj
@@ -1,19 +1,23 @@
 (ns monkey.ci.runtime.common
-  (:require [com.stuartsierra.component :as co]
+  (:require [clojure.tools.logging :as log]
+            [com.stuartsierra.component :as co]
             [manifold.deferred :as md]))
 
 (defn with-system
   "Starts the system passes it to `f` and then shuts it down afterwards."
   [sys f]
-  (let [sys (co/start sys)]
+  (let [sys (co/start sys)
+        stop (fn []
+               (log/debug "Stopping system")
+               (co/stop sys))]
     (try
       (let [r (f sys)]
         ;; If `f` returns a deferred, only stop the system on realization
         (if (md/deferred? r)
-          (md/finally r #(co/stop sys))
+          (md/finally r stop)
           (do 
             ;; Otherwise stop now
-            (co/stop sys)
+            (stop)
             r)))
       (catch Exception ex
         (co/stop sys)

--- a/app/test/unit/monkey/ci/metrics_test.clj
+++ b/app/test/unit/monkey/ci/metrics_test.clj
@@ -64,3 +64,12 @@
         (is (= 1.0 (get-val))))
       (finally
         (t/remove-handler! ::lbl-handler)))))
+
+(deftest metrics-component
+  (testing "creates registry at start"
+    (let [co (-> (sut/make-metrics)
+                 (co/start))]
+      (is (some? (:registry co)))))
+
+  (testing "adds event metrics when events state stream exists"
+    ))

--- a/app/test/unit/monkey/ci/metrics_test.clj
+++ b/app/test/unit/monkey/ci/metrics_test.clj
@@ -1,7 +1,10 @@
 (ns monkey.ci.metrics-test
   (:require [clojure.test :refer [deftest testing is]]
             [com.stuartsierra.component :as co]
-            [monkey.ci.metrics :as sut]))
+            [io.resonant.micrometer :as mm]
+            [monkey.ci.metrics :as sut]
+            [monkey.ci.helpers :as h]
+            [taoensso.telemere :as t]))
 
 (deftest metrics
   (testing "can make metrics registry"
@@ -14,3 +17,18 @@
     (is (some? (-> (sut/make-registry)
                    (co/start)
                    (co/stop))))))
+
+(deftest signal->counter
+  (testing "creates a gauge that holds signal recv count"
+    (let [r (sut/make-registry)
+          c (sut/signal->counter ::test-signal r "test_counter" {} {:description "For testing"})
+          get-val (fn []
+                    (->> (mm/inspect-meter r "test_counter")
+                         :measurements
+                         (filter (comp (partial = "COUNT") :statistic))
+                         (first)
+                         :value))]
+      (is (some? c))
+      (is (true? (t/event! ::test-signal :info)))
+      (is (not= :timeout (h/wait-until #(number? (get-val)) 1000)))
+      (is (= 1.0 (get-val))))))

--- a/app/test/unit/monkey/ci/metrics_test.clj
+++ b/app/test/unit/monkey/ci/metrics_test.clj
@@ -69,4 +69,7 @@
   (testing "creates registry at start"
     (let [co (-> (sut/make-metrics)
                  (co/start))]
-      (is (some? (:registry co))))))
+      (try
+        (is (some? (:registry co)))
+        (finally
+          (co/stop co))))))

--- a/app/test/unit/monkey/ci/metrics_test.clj
+++ b/app/test/unit/monkey/ci/metrics_test.clj
@@ -20,15 +20,39 @@
 
 (deftest signal->counter
   (testing "creates a gauge that holds signal recv count"
-    (let [r (sut/make-registry)
-          c (sut/signal->counter ::test-signal r "test_counter" {} {:description "For testing"})
-          get-val (fn []
-                    (->> (mm/inspect-meter r "test_counter")
-                         :measurements
-                         (filter (comp (partial = "COUNT") :statistic))
-                         (first)
-                         :value))]
-      (is (some? c))
-      (is (true? (t/event! ::test-signal :info)))
-      (is (not= :timeout (h/wait-until #(number? (get-val)) 1000)))
-      (is (= 1.0 (get-val))))))
+    (try
+      (let [r (sut/make-registry)
+            c (sut/signal->counter ::test-handler r "test_counter"
+                                   {:opts {:description "For testing"}})
+            get-val (fn []
+                      (->> (mm/inspect-meter r "test_counter")
+                           :measurements
+                           (filter (comp (partial = "COUNT") :statistic))
+                           (first)
+                           :value))]
+        (is (some? c))
+        (is (true? (t/event! ::test-signal :info)))
+        (is (not= :timeout (h/wait-until #(number? (get-val)) 1000)))
+        (is (= 1.0 (get-val))))
+      (finally
+        (t/remove-handler! ::test-handler))))
+
+  (testing "applies transducer to signal"
+    (try
+      (let [r (sut/make-registry)
+            c (sut/signal->counter ::filter-handler r "filter_counter"
+                                   {:opts {:description "For testing"}
+                                    :tx (filter (comp (partial = ::ok-signal) :id))})
+            get-val (fn []
+                      (->> (mm/inspect-meter r "filter_counter")
+                           :measurements
+                           (filter (comp (partial = "COUNT") :statistic))
+                           (first)
+                           :value))]
+        (is (some? c))
+        (is (true? (t/event! ::ok-signal :info)))
+        (is (true? (t/event! ::other-signal :info)))
+        (is (not= :timeout (h/wait-until #(number? (get-val)) 1000)))
+        (is (= 1.0 (get-val))))
+      (finally
+        (t/remove-handler! ::filter-handler)))))

--- a/app/test/unit/monkey/ci/metrics_test.clj
+++ b/app/test/unit/monkey/ci/metrics_test.clj
@@ -69,7 +69,4 @@
   (testing "creates registry at start"
     (let [co (-> (sut/make-metrics)
                  (co/start))]
-      (is (some? (:registry co)))))
-
-  (testing "adds event metrics when events state stream exists"
-    ))
+      (is (some? (:registry co))))))

--- a/app/test/unit/monkey/ci/oci_test.clj
+++ b/app/test/unit/monkey/ci/oci_test.clj
@@ -6,7 +6,8 @@
             [monkey.ci.oci :as sut]
             [monkey.ci.helpers :as h]
             [monkey.oci.container-instance.core :as ci]
-            [monkey.oci.os.stream :as os])
+            [monkey.oci.os.stream :as os]
+            [taoensso.telemere :as t])
   (:import java.io.ByteArrayInputStream))
 
 (deftest stream-to-bucket
@@ -293,3 +294,12 @@
                     :is-read-only false
                     :volume-name "checkout"}
                    (first (get vol-mounts "checkout"))))))))))
+
+(deftest invocation-interceptor
+  (testing "dispatches invocation event for given kind"
+    (let [i (sut/invocation-interceptor ::test-module)
+          s (t/with-signal
+              (is (= ::test-ctx ((:enter i) ::test-ctx))))]
+      (is (= :event (:kind s)))
+      (is (= :oci/invocation (:id s)))
+      (is (= ::test-module (get-in s [:data :kind]))))))

--- a/app/test/unit/monkey/ci/prometheus_test.clj
+++ b/app/test/unit/monkey/ci/prometheus_test.clj
@@ -19,7 +19,20 @@
     (let [reg (sut/make-registry)
           c (sut/make-counter "test_counter" reg {:labels ["test" "labels"]})]
       (is (= c (sut/counter-inc c 10 ["val-1" "val-2"])))
-      (is (= 10.0 (sut/counter-get c ["val-1" "val-2"]))))))
+      (is (= 10.0 (sut/counter-get c ["val-1" "val-2"])))))
+
+  (testing "invokes callback if provided"
+    (let [reg (sut/make-registry)
+          c (sut/make-counter "lazy_counter" reg {:callback (constantly 7)})]
+      (is (= 7.0 (.. c (collect) (getDataPoints) (get 0) (getValue))))))
+
+  (testing "invokes callback with labels"
+    (let [reg (sut/make-registry)
+          c (sut/make-counter "lazy_counter" reg {:callback (constantly [7 "test-domain"])
+                                                  :labels ["domain"]})]
+      (is (= "test-domain" (.. c
+                               (collect) (getDataPoints) (get 0)
+                               (getLabels) (getValue 0)))))))
 
 (deftest push-gw
   (testing "creates push gateway"

--- a/app/test/unit/monkey/ci/prometheus_test.clj
+++ b/app/test/unit/monkey/ci/prometheus_test.clj
@@ -1,0 +1,26 @@
+(ns monkey.ci.prometheus-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure.string :as cs]
+            [monkey.ci.prometheus :as sut]))
+
+(deftest make-registry
+  (testing "creates a new Prometheus registry"
+    (is (instance? io.prometheus.metrics.model.registry.PrometheusRegistry (sut/make-registry)))))
+
+(deftest scrape
+  (testing "returns metrics as string format"
+    (let [reg (sut/make-registry)
+          gauge (-> (sut/make-gauge "test_val" reg)
+                    (sut/gauge-set 100))]
+      (is (cs/includes? (sut/scrape reg) "100")))))
+
+(deftest counter
+  (testing "can increase"
+    (let [reg (sut/make-registry)
+          c (sut/make-counter "test_counter" reg {:labels ["test" "labels"]})]
+      (is (= c (sut/counter-inc c 10 ["val-1" "val-2"])))
+      (is (= 10.0 (sut/counter-get c ["val-1" "val-2"]))))))
+
+(deftest push-gw
+  (testing "creates push gateway"
+    (is (some? (sut/push-gw "test-host" 9091 (sut/make-registry) "test_job")))))


### PR DESCRIPTION
 - Add telemere as a means to gather metrics in the application.
 - Removed Micrometer, using Prometheus api directly because the clj lib is outdated.
 - Added push gateway, to be used by OCI runners