### PR TITLE
Feat: Script verification

### DIFF
--- a/.monkeyci/build.clj
+++ b/.monkeyci/build.clj
@@ -1,12 +1,9 @@
 ;; Build script for Monkey-ci itself
-(ns monkeyci.build.script
-  (:require [babashka.fs :as fs]
-            [clojure.java.io :as io]
-            [clojure.string :as cs]
+(ns build
+  (:require [clojure.string :as cs]
             [monkey.ci.build
              [api :as api]
-             [core :as core]
-             [shell :as shell]]
+             [core :as core]]
             [monkey.ci.ext.junit]
             [monkey.ci.plugin
              [github :as gh]
@@ -84,11 +81,12 @@
   (or (tag-version ctx)
       snapshot-version))
 
-(defn clj-container [id dir & args]
+(defn clj-container 
   "Executes script in clojure container"
+  [id dir & args]
   (core/container-job
    id
-   {;; Alpine based images don't exist for arm, so use debian
+   { ;; Alpine based images don't exist for arm, so use debian
     :image "docker.io/clojure:temurin-21-tools-deps-bookworm-slim"
     :script [(str "cd " dir
                   " && "
@@ -170,8 +168,9 @@
        :dependencies ["release-gui"]}}
      ctx)))
 
-(defn publish [ctx id dir & [version]]
+(defn publish 
   "Executes script in clojure container that has clojars publish env vars"
+  [ctx id dir & [version]]
   (let [env (-> (api/build-params ctx)
                 (select-keys ["CLOJARS_USERNAME" "CLOJARS_PASSWORD"])
                 (assoc "MONKEYCI_VERSION" (or version (lib-version ctx))))]

--- a/app/deps.edn
+++ b/app/deps.edn
@@ -1,12 +1,12 @@
-{:deps {org.clojure/clojure {:mvn/version "1.11.4"}
+{:deps {org.clojure/clojure {:mvn/version "1.12.0"}
         aleph/aleph {:mvn/version "0.8.1"} ; For http SSE receiving
         babashka/process {:mvn/version "0.5.22"}
         buddy/buddy-auth {:mvn/version "3.0.323"}
         buddy/buddy-core {:mvn/version "1.12.0-430"}
         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
-        ch.qos.logback/logback-classic {:mvn/version "1.5.6"}
+        ch.qos.logback/logback-classic {:mvn/version "1.5.11"}
         clansi/clansi {:mvn/version "1.0.0"}
-        clj-commons/clj-yaml {:mvn/version "1.0.27"}
+        clj-commons/clj-yaml {:mvn/version "1.0.28"}
         cli-matic/cli-matic {:mvn/version "0.5.4"}
         clj-jgit/clj-jgit {:mvn/version "1.1.0"
                            ;; Exclude these because they conflict with buddy
@@ -17,7 +17,7 @@
         clj-kondo/clj-kondo {:mvn/version "2024.09.27"}
         clojure.java-time/clojure.java-time {:mvn/version "1.4.2"}
         com.github.loki4j/loki-logback-appender {:mvn/version "1.6.0-m1"}
-        com.github.seancorfield/honeysql {:mvn/version "2.6.1147"}
+        com.github.seancorfield/honeysql {:mvn/version "2.6.1196"}
         com.github.seancorfield/next.jdbc {:mvn/version "1.3.939"}
         com.monkeyprojects/aero-ext {:mvn/version "0.2.0"}
         com.monkeyprojects/clompress {:mvn/version "0.1.1"}
@@ -25,8 +25,8 @@
         com.monkeyprojects/oci-container-instance {:mvn/version "0.1.0"}
         com.monkeyprojects/oci-os {:mvn/version "0.3.2"}
         com.monkeyprojects/oci-sign {:mvn/version "0.1.3"}
-        com.mysql/mysql-connector-j {:mvn/version "9.0.0"}
-        com.zaxxer/HikariCP {:mvn/version "5.1.0"}
+        com.mysql/mysql-connector-j {:mvn/version "9.1.0"}
+        com.zaxxer/HikariCP {:mvn/version "6.0.0"}
         dev.weavejester/ragtime {:mvn/version "0.9.4"}
         com.monkeyprojects/zmq {:mvn/version "0.3.2"
                                 ;; Use jeromq, so we don't need native lib.  This is a bit
@@ -34,25 +34,24 @@
                                 :exclusions [org.zeromq/jzmq]}
         com.stuartsierra/component {:mvn/version "1.1.0"}
         com.taoensso/telemere {:mvn/version "1.0.0-beta25"}
-        commons-io/commons-io {:mvn/version "2.16.1"}
-        io.prometheus/prometheus-metrics-core {:mvn/version "1.3.1"}
-        io.prometheus/prometheus-metrics-exporter-pushgateway {:mvn/version "1.3.1"}
-        io.prometheus/prometheus-metrics-instrumentation-jvm {:mvn/version "1.3.1"}
-        io.prometheus/prometheus-metrics-tracer-initializer {:mvn/version "1.3.1"}
+        commons-io/commons-io {:mvn/version "2.17.0"}
+        io.prometheus/prometheus-metrics-core {:mvn/version "1.3.2"}
+        io.prometheus/prometheus-metrics-exporter-pushgateway {:mvn/version "1.3.2"}
+        io.prometheus/prometheus-metrics-instrumentation-jvm {:mvn/version "1.3.2"}
+        io.prometheus/prometheus-metrics-tracer-initializer {:mvn/version "1.3.2"}
         medley/medley {:mvn/version "1.4.0"}
-        metosin/reitit-middleware {:mvn/version "0.7.1"}
-        metosin/reitit-ring {:mvn/version "0.7.1"}
-        metosin/reitit-schema {:mvn/version "0.7.1"}
-        metosin/reitit-swagger {:mvn/version "0.7.1"}
-        org.apache.activemq/artemis-server {:mvn/version "2.36.0"}
-        org.apache.activemq/artemis-amqp-protocol {:mvn/version "2.36.0"}
-        org.clojars.lispyclouds/contajners {:mvn/version "1.0.5"}
+        metosin/reitit-middleware {:mvn/version "0.7.2"}
+        metosin/reitit-ring {:mvn/version "0.7.2"}
+        metosin/reitit-schema {:mvn/version "0.7.2"}
+        metosin/reitit-swagger {:mvn/version "0.7.2"}
+        org.apache.activemq/artemis-server {:mvn/version "2.37.0"}
+        org.apache.activemq/artemis-amqp-protocol {:mvn/version "2.37.0"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         org.clojure/tools.logging {:mvn/version "1.3.0"}
         org.zeromq/jeromq {:mvn/version "0.6.0"} ; Java implementation of zeromq
         prismatic/schema {:mvn/version "1.4.1"}
         ring-cors/ring-cors {:mvn/version "0.1.13"}
-        yogthos/config {:mvn/version "1.2.0"}}
+        yogthos/config {:mvn/version "1.2.1"}}
 
  ;; TODO Remove external path, replace with lib
  :paths ["src" "resources"]
@@ -68,7 +67,7 @@
   :test
   {:extra-paths [:test-paths]
    :extra-deps {com.monkeyprojects/build {:mvn/version "0.2.0"}
-                com.h2database/h2 {:mvn/version "2.3.230"}
+                com.h2database/h2 {:mvn/version "2.3.232"}
                 org.clojure/test.check {:mvn/version "1.1.1"}
                 ring/ring-mock {:mvn/version "0.4.0"}}
    :exec-fn monkey.test/all

--- a/app/deps.edn
+++ b/app/deps.edn
@@ -14,6 +14,7 @@
                                         org.bouncycastle/bcprov-jdk15on
                                         org.bouncycastle/bcpkix-jdk15on
                                         org.bouncycastle/bcutil-jdk15on]}
+        clj-kondo/clj-kondo {:mvn/version "2024.09.27"}
         clojure.java-time/clojure.java-time {:mvn/version "1.4.2"}
         com.github.loki4j/loki-logback-appender {:mvn/version "1.6.0-m1"}
         com.github.seancorfield/honeysql {:mvn/version "2.6.1147"}
@@ -58,7 +59,8 @@
  
  :aliases
  {:dev
-  {:extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}}
+  {:extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}
+                org.clojure/tools.namespace {:mvn/version "1.5.0"}}
    :extra-paths ["dev-resources" "env/dev"]}
 
   :test-paths ["test/unit" "test/integration"]

--- a/app/examples/basic-clj/build.clj
+++ b/app/examples/basic-clj/build.clj
@@ -1,13 +1,11 @@
 ;; Basic Clojure build script
 (require '[monkey.ci.build.core :as core])
 
-(core/defjob simple-step [_]
-  (println "This must be the simplest build script!")
-  (println "Running in namespace" (ns-name *ns*))
-  ;; Return success response
-  core/success)
-
-;; Pipeline with a single step that just prints a message to stdout
-(core/pipeline
- {:name "test pipeline"
-  :steps [simple-step]})
+(def simple-step
+  (core/action-job
+   "simple-step"
+   (fn [_]
+     (println "This must be the simplest build script!")
+     (println "Running in namespace" (ns-name *ns*))
+     ;; Return success response
+     core/success)))

--- a/app/examples/extra-deps/build.clj
+++ b/app/examples/extra-deps/build.clj
@@ -2,8 +2,8 @@
 ;; This dependency is included through the deps.edn file
 (require '[camel-snake-kebab.core :as csk])
 
-(c/pipeline
- {:name "Pipeline with extra dependencies"
-  :steps [(fn [_]
-            (assoc c/success :output (csk/->snake_case "SomeSimpleScript")))]})
+(c/action-job
+ "extra-deps"
+ (fn [_]
+   (assoc c/success :output (csk/->snake_case "SomeSimpleScript"))))
                

--- a/app/src/monkey/ci/cli.clj
+++ b/app/src/monkey/ci/cli.clj
@@ -47,7 +47,8 @@
    :description "Verifies local build script"
    :opts [script-location-opt]
    :runs {:command cmd/verify-build
-          :app-mode :cli}})
+          :app-mode :cli
+          :runtime? false}})
 
 (def list-build-cmd
   {:command "list"

--- a/app/src/monkey/ci/commands.clj
+++ b/app/src/monkey/ci/commands.clj
@@ -1,7 +1,9 @@
 (ns monkey.ci.commands
   "Event handlers for commands"
   (:require [aleph.http :as http]
+            [babashka.fs :as fs]
             [clj-commons.byte-streams :as bs]
+            [clj-kondo.core :as clj-kondo]
             [clojure.tools.logging :as log]
             [manifold.deferred :as md]
             [medley.core :as mc]
@@ -42,34 +44,49 @@
   ;; TODO
   [config])
 
-(defn- verify-in-proc
-  "Verifies the build in the current directory by loading the script files in-process
-   and resolving the jobs.  This is useful when checking if there are any compilation
-   errors in the script."
-  [rt]
-  (letfn [(report [rep]
-            (rt/report rt rep)
-            (if (= :verify/success (:type rep)) 0 err/error-script-failure))]
-    (try
-      ;; TODO Git branch and other options
-      ;; TODO Build parameters
-      (let [jobs (script/load-jobs (:build rt) rt)]
-        (report
-         (if (not-empty jobs)
-           {:type :verify/success
-            :jobs jobs}
-           {:type :verify/failed
-            :message "No jobs found in build script for the active configuration"})))
-      (catch Exception ex
-        (log/error "Error verifying build" ex)
-        (report {:type :verify/failed
-                 :message (ex-message ex)})))))
+;; (defn- deps-exists? [rt]
+;;   (fs/exists? (fs/path (get-in rt [:build :script :script-dir]) "deps.edn")))
 
-(defn verify-build [conf]
-  ;; TODO Use child process if there is a deps.edn
+;; (defn- verify-child-proc
+;;   "Starts a child process to perform verification.  This is necessary if a `deps.edn`
+;;    exists with custom dependencies."
+;;   [rt]
+;;   ;; TODO Need to get back reported info.  Using a UDS?
+;;   1)
+
+;; (defn- verify-in-proc
+;;   "Verifies the build in the current directory by loading the script files in-process
+;;    and resolving the jobs.  This is useful when checking if there are any compilation
+;;    errors in the script."
+;;   [rt]
+;;   (letfn [(report [rep]
+;;             (rt/report rt rep)
+;;             (if (= :verify/success (:type rep)) 0 err/error-script-failure))]
+;;     (try
+;;       ;; TODO Git branch and other options
+;;       ;; TODO Build parameters
+;;       (let [jobs (script/load-jobs (:build rt) rt)]
+;;         (report
+;;          (if (not-empty jobs)
+;;            {:type :verify/success
+;;             :jobs jobs}
+;;            {:type :verify/failed
+;;             :message "No jobs found in build script for the active configuration"})))
+;;       (catch Exception ex
+;;         (log/error "Error verifying build" ex)
+;;         (report {:type :verify/failed
+;;                  :message (ex-message ex)})))))
+
+(defn verify-build
+  "Runs a linter agains the build script to catch any grammatical errors."
+  [conf]
   (ra/with-cli-runtime conf
-    verify-in-proc))
-
+    (fn [rt]
+      (let [res (clj-kondo/run! {:lint [(get-in rt [:build :script :script-dir])]})]
+        (rt/report rt {:type :verify/result :result res})
+        (-> res
+            :summary
+            :error)))))
 
 (defn list-builds [rt]
   (->> (http/get (apply format "%s/customer/%s/repo/%s/builds"

--- a/app/src/monkey/ci/process.clj
+++ b/app/src/monkey/ci/process.clj
@@ -70,15 +70,6 @@
   ([args]
    (run args cc/env)))
 
-(defn verify
-  "Run function that verifies the build by attempting to load the build script using
-   some given configuration."
-  ([args env]
-   ;; TODO
-   )
-  ([args]
-   (verify args cc/env)))
-
 (defn- find-log-config
   "Finds logback configuration file, either configured on the runner, or present 
    in the script dir"

--- a/app/src/monkey/ci/reporting/print.clj
+++ b/app/src/monkey/ci/reporting/print.clj
@@ -8,6 +8,9 @@
 (defn- error [s]
   (cl/style s :bright :red))
 
+(defn- warning [s]
+  (cl/style s :bright :yellow))
+
 (defn- success [s]
   (cl/style s :bright :green))
 
@@ -137,13 +140,20 @@
 (defmethod printer :verify/failed [{:keys [message]}]
   (println (error "Error:") "Exception while verifying:" message))
 
+(defn- print-finding [{:keys [row col message filename]}]
+  (printf "%s - at %d:%d: %s\n" filename row col message))
+
 (defmethod printer :verify/result [{:keys [result]}]
-  (let [{:keys [error warning]} (:summary result)]
+  (let [{e :error w :warning} (:summary result)]
     (cond
-      (pos? error)
-      (println (error (str "Got " error " errors")))
+      (and e (pos? e))
+      (println (error (str "Got " e " error(s)")))
+      (and w (pos? w))
+      (println (warning (str "Got " w " warning(s)")))
       :else
-      (println (success "Build script is valid!")))))
+      (println (success "Build script is valid!")))
+    (doseq [f (:findings result)]
+      (print-finding f))))
 
 (defmethod printer :default [msg]
   (println (cl/style "Warning:" :bright :cyan) "unknown message type" (accent (str (:type msg)))))

--- a/app/src/monkey/ci/reporting/print.clj
+++ b/app/src/monkey/ci/reporting/print.clj
@@ -137,6 +137,14 @@
 (defmethod printer :verify/failed [{:keys [message]}]
   (println (error "Error:") "Exception while verifying:" message))
 
+(defmethod printer :verify/result [{:keys [result]}]
+  (let [{:keys [error warning]} (:summary result)]
+    (cond
+      (pos? error)
+      (println (error (str "Got " error " errors")))
+      :else
+      (println (success "Build script is valid!")))))
+
 (defmethod printer :default [msg]
   (println (cl/style "Warning:" :bright :cyan) "unknown message type" (accent (str (:type msg)))))
 

--- a/app/src/monkey/ci/runtime/app.clj
+++ b/app/src/monkey/ci/runtime/app.clj
@@ -263,7 +263,8 @@
   (co/system-map
    :runtime (co/using
              {:config config}
-             [:build])
+             [:build :reporter])
+   :reporter (new-reporter config)
    :build (new-cli-build config)))
 
 (defn with-cli-runtime [config f]

--- a/app/src/monkey/ci/runtime/app.clj
+++ b/app/src/monkey/ci/runtime/app.clj
@@ -5,6 +5,7 @@
             [medley.core :as mc]
             [monkey.ci
              [blob :as blob]
+             [build :as b]
              [containers :as c]
              [git :as git]
              [listeners :as li]
@@ -252,3 +253,18 @@
 
 (defn with-server-system [config f]
   (rc/with-system (make-server-system config) f))
+
+(defn- new-cli-build [conf]
+  (b/make-build-ctx conf))
+
+(defn make-cli-system
+  "Creates a component system that can be used by CLI commands"
+  [config]
+  (co/system-map
+   :runtime (co/using
+             {:config config}
+             [:build])
+   :build (new-cli-build config)))
+
+(defn with-cli-runtime [config f]
+  (rc/with-runtime (make-cli-system config) f))

--- a/app/src/monkey/ci/storage/sql.clj
+++ b/app/src/monkey/ci/storage/sql.clj
@@ -479,7 +479,7 @@
        (map (fn [j] [(:id j) j]))
        (into {})))
 
-(defn- select-build [conn [cust-id repo-id build-id :as sid]]
+(defn- select-build [conn [cust-id repo-id :as sid]]
   (when-let [build (apply eb/select-build-by-sid conn sid)]
     (let [jobs (select-jobs conn (:id build))]
       (cond-> (-> (db->build build)

--- a/app/src/monkey/ci/web/api/admin.clj
+++ b/app/src/monkey/ci/web/api/admin.clj
@@ -1,8 +1,7 @@
 (ns monkey.ci.web.api.admin
   (:require [monkey.ci
              [cuid :as cuid]
-             [storage :as s]
-             [time :as t]]
+             [storage :as s]]
             [monkey.ci.web
              [auth :as auth]
              [common :as c]]

--- a/app/src/monkey/ci/web/api/customer.clj
+++ b/app/src/monkey/ci/web/api/customer.clj
@@ -19,7 +19,7 @@
 (defn recent-builds [req]
   (let [st (c/req->storage req)
         cid (c/customer-id req)]
-    (if-let [cust (st/find-customer st cid)]
+    (if (st/find-customer st cid)
       (rur/response (st/list-builds-since st cid (or (query->since req)
                                                      (hours-ago 24))))
       (rur/not-found {:message "Customer not found"}))))

--- a/app/src/monkey/ci/web/auth.clj
+++ b/app/src/monkey/ci/web/auth.clj
@@ -142,7 +142,7 @@
                               (st/find-build storage))]
       (assoc build :customers #{(:customer-id build)}))))
 
-(defmethod resolve-token :default [rt token]
+(defmethod resolve-token :default [_ _]
   ;; Fallback, for backwards compatibility
   nil)
 

--- a/app/src/monkey/ci/web/bitbucket.clj
+++ b/app/src/monkey/ci/web/bitbucket.clj
@@ -4,9 +4,7 @@
             [clj-commons.byte-streams :as bs]
             [clojure.tools.logging :as log]
             [manifold.deferred :as md]
-            [monkey.ci
-             [runtime :as rt]
-             [utils :as u]]
+            [monkey.ci.runtime :as rt]
             [monkey.ci.web
              [common :as c]
              [oauth2 :as oauth2]]
@@ -32,7 +30,7 @@
          (md/chain c/parse-body)
          (md/catch handle-error))))
 
-(defn- ->oauth-user [{:keys [uuid email] :as u}]
+(defn- ->oauth-user [{:keys [uuid] :as u}]
   (log/debug "Converting Bitbucket user:" u)
   {:sid [:bitbucket uuid]})
 

--- a/app/src/monkey/ci/web/common.clj
+++ b/app/src/monkey/ci/web/common.clj
@@ -1,8 +1,6 @@
 (ns monkey.ci.web.common
   (:require [buddy.auth :as ba]
             [camel-snake-kebab.core :as csk]
-            [clj-commons.byte-streams :as bs]
-            [clojure.java.io :as io]
             [clojure.tools.logging :as log]
             [manifold.deferred :as md]
             [muuntaja.core :as mc]

--- a/app/src/monkey/ci/web/handler.clj
+++ b/app/src/monkey/ci/web/handler.clj
@@ -9,7 +9,6 @@
             [manifold.deferred :as md]
             [medley.core :refer [update-existing] :as mc]
             [monkey.ci
-             [config :as config]
              [metrics :as metrics]
              [runtime :as rt]
              [version :as v]]

--- a/app/test/unit/monkey/ci/build_test.clj
+++ b/app/test/unit/monkey/ci/build_test.clj
@@ -13,29 +13,28 @@
 
   (testing "defaults to `main` branch"
     (is (= "main"
-           (-> {:config {:args {:git-url "test-url"}}}
+           (-> {:args {:git-url "test-url"}}
                (sut/make-build-ctx)
                :git
                :branch))))
 
   (testing "takes global work dir as build checkout dir"
     (is (= "global-work-dir"
-           (-> {:config {:args {:dir ".monkeci"}
-                         :work-dir "global-work-dir"}}
+           (-> {:args {:dir ".monkeci"}
+                :work-dir "global-work-dir"}
                (sut/make-build-ctx)
                :checkout-dir))))
 
   (testing "adds pipeline from args"
     (is (= "test-pipeline"
-           (-> {:config
-                {:args {:pipeline "test-pipeline"}}}
+           (-> {:args {:pipeline "test-pipeline"}}
                (sut/make-build-ctx)
                :pipeline))))
 
   (testing "adds script dir from args, as relative to work dir"
     (is (= "work-dir/test-script"
-           (-> {:config {:args {:dir "test-script"}
-                         :work-dir "work-dir"}}
+           (-> {:args {:dir "test-script"}
+                :work-dir "work-dir"}
                (sut/make-build-ctx)
                sut/script
                :script-dir))))
@@ -45,83 +44,58 @@
       (is (= {:url "test-url"
               :branch "test-branch"
               :id "test-id"}
-             (-> {:config
-                  {:args {:git-url "test-url"
-                          :branch "test-branch"
-                          :commit-id "test-id"}}}
+             (-> {:args {:git-url "test-url"
+                         :branch "test-branch"
+                         :commit-id "test-id"}}
                  (sut/make-build-ctx)
                  :git))))
 
     (testing "sets tag"
       (is (= "test-tag"
-             (-> {:config
-                  {:args {:git-url "test-url"
-                          :tag "test-tag"
-                          :commit-id "test-id"}}}
+             (-> {:args {:git-url "test-url"
+                         :tag "test-tag"
+                         :commit-id "test-id"}}
                  (sut/make-build-ctx)
                  :git
                  :tag))))
 
     (testing "sets script dir to arg"
       (is (= "test-script"
-             (-> {:config
-                  {:args {:git-url "test-url"
-                          :branch "test-branch"
-                          :commit-id "test-id"
-                          :dir "test-script"}
-                   :work-dir "work"}}
+             (-> {:args {:git-url "test-url"
+                         :branch "test-branch"
+                         :commit-id "test-id"
+                         :dir "test-script"}
+                  :work-dir "work"}
                  (sut/make-build-ctx)
                  sut/script
-                 :script-dir))))
-
-    (testing "merges with existing git opts from runtime"
-      (is (= "test-dir"
-             (-> {:config
-                  {:args {:git-url "test-url"
-                          :branch "test-branch"
-                          :commit-id "test-id"
-                          :dir "test-script"}
-                   :work-dir "work"}
-                  :build {:git {:ssh-keys-dir "test-dir"}}}
-                 (sut/make-build-ctx)
-                 :git
-                 :ssh-keys-dir)))))
+                 :script-dir)))))
 
   (testing "when sid specified"
     (testing "parses on delimiter"
       (is (= ["a" "b" "c"]
-             (->> {:config
-                   {:args {:sid "a/b/c"}}}
+             (->> {:args {:sid "a/b/c"}}
                   (sut/make-build-ctx)
                   :sid
                   (take 3)))))
     
     (testing "adds build id"
-      (is (string? (-> {:config
-                        {:args {:sid "a/b/c"}}}
+      (is (string? (-> {:args {:sid "a/b/c"}}
                        (sut/make-build-ctx)
                        :sid
                        last))))
 
     (testing "when sid includes build id, reuses it"
       (let [sid "a/b/c"
-            ctx (-> {:config
-                     {:args {:sid sid}}}
+            ctx (-> {:args {:sid sid}}
                     (sut/make-build-ctx))]
         (is (= "c" (:build-id ctx)))
         (is (= "c" (last (:sid ctx)))))))
 
   (testing "when no sid specified"
     (testing "leaves it unspecified"
-      (is (empty? (-> {:config {:args {}}}
+      (is (empty? (-> {:args {}}
                       (sut/make-build-ctx)
-                      :sid)))))
-
-  (testing "merges in build from config"
-    (is (= ::test-changes
-           (-> {:config {:build {:changes ::test-changes}}}
-               (sut/make-build-ctx)
-               :changes)))))
+                      :sid))))))
 
 (deftest calc-checkout-dir
   (testing "combines build id with checkout base dir from config"

--- a/app/test/unit/monkey/ci/commands_test.clj
+++ b/app/test/unit/monkey/ci/commands_test.clj
@@ -61,14 +61,9 @@
   (testing "zero when successful"
     (is (zero? (sut/verify-build {:work-dir "examples"
                                   :args {:dir "basic-clj"}}))))
-
+  
   (testing "nonzero exit on failure"
-    (is (not= 0 (sut/verify-build {}))))
-
-  (testing "runs child process when `deps.edn` present"
-    (is (zero? (sut/verify-build {:work-dir "examples"
-                                  :args {:dir "extra-deps"}
-                                  :dev-mode true})))))
+    (is (not= 0 (sut/verify-build {})))))
 
 (deftest list-builds
   (testing "reports builds from server"

--- a/app/test/unit/monkey/ci/commands_test.clj
+++ b/app/test/unit/monkey/ci/commands_test.clj
@@ -59,12 +59,16 @@
 
 (deftest verify-build
   (testing "zero when successful"
-    (is (zero? (sut/verify-build {:config
-                                  {:work-dir "examples"
-                                   :args {:dir "basic-clj"}}}))))
+    (is (zero? (sut/verify-build {:work-dir "examples"
+                                  :args {:dir "basic-clj"}}))))
 
   (testing "nonzero exit on failure"
-    (is (not= 0 (sut/verify-build {})))))
+    (is (not= 0 (sut/verify-build {}))))
+
+  (testing "runs child process when `deps.edn` present"
+    (is (zero? (sut/verify-build {:work-dir "examples"
+                                  :args {:dir "extra-deps"}
+                                  :dev-mode true})))))
 
 (deftest list-builds
   (testing "reports builds from server"

--- a/app/test/unit/monkey/ci/reporting/print_test.clj
+++ b/app/test/unit/monkey/ci/reporting/print_test.clj
@@ -91,8 +91,16 @@
 
 (deftest print-verify
   (testing "prints error on error"
-    (is (not-empty (capture-out {:type :verify/failed
-                                 :result {:summary {:error 1}}})))))
+    (is (not-empty (capture-out {:type :verify/result
+                                 :result {:summary {:error 1}}}))))
+  
+  (testing "prints warnings"
+    (is (not-empty (capture-out {:type :verify/result
+                                 :result {:summary {:warning 1}}}))))
+
+  (testing "prints success when no errors"
+    (is (not-empty (capture-out {:type :verify/result
+                                 :result {:summary {:error 0}}})))))
 
 (deftest unknown-types
   (testing "prints warning"

--- a/app/test/unit/monkey/ci/reporting/print_test.clj
+++ b/app/test/unit/monkey/ci/reporting/print_test.clj
@@ -89,6 +89,11 @@
     (is (not-empty (capture-out {:type :verify/failed
                                  :message "test error"})))))
 
+(deftest print-verify
+  (testing "prints error on error"
+    (is (not-empty (capture-out {:type :verify/failed
+                                 :result {:summary {:error 1}}})))))
+
 (deftest unknown-types
   (testing "prints warning"
     (is (string? (capture-out {:type :unkown/type})))))


### PR DESCRIPTION
Adding improved script verification.  When verifying a script that has a custom `deps.edn`, we need to start a child process for the dependencies to be included.  Additional complication is we need to find a way to get the reported information back to the parent process.