### PR TITLE
Feature/listeners events

### DIFF
--- a/app/test/unit/monkey/ci/helpers.clj
+++ b/app/test/unit/monkey/ci/helpers.clj
@@ -204,8 +204,9 @@
        (filter (comp (partial = type) :type))
        (first)))
 
-(defmethod ec/make-events :fake [{:keys [recv]}]
-  (fake-events recv))
+(defmethod ec/make-events :fake [{:keys [recv] :as config}]
+  (-> (fake-events recv)
+      (assoc :config config)))
 
 (defrecord FakeEventReceiver [listeners]
   p/EventReceiver

--- a/app/test/unit/monkey/ci/runtime/app_test.clj
+++ b/app/test/unit/monkey/ci/runtime/app_test.clj
@@ -148,7 +148,21 @@
         (is (nil? (get-in sys [:http :rt :jwk]))))
 
       (testing "activates listeners"
-        (is (instance? monkey.ci.listeners.Listeners (:listeners sys))))
+        (is (instance? monkey.ci.listeners.Listeners (get-in sys [:listeners :listeners]))))
+
+      (testing "passes events to listeners"
+        (is (some? (-> sys :listeners :listeners :events))))
+
+      (testing "passes listener events if configured"
+        (is (= ::listener-events
+               (-> server-config
+                   (assoc :listeners {:events {:type :fake
+                                               ::kind ::listener-events}})
+                   (sut/with-server-system :listeners)
+                   :listeners
+                   :events
+                   :config
+                   ::kind))))
 
       (testing "provides metrics"
         (is (some? (get sys :metrics)))

--- a/gui/.dir-locals.el
+++ b/gui/.dir-locals.el
@@ -1,0 +1,4 @@
+((clojurescript-mode
+  (cider-preferred-build-tool . shadow-cljs)
+  (cider-default-cljs-repl . shadow)
+  (cider-shadow-watched-builds . ("frontend" "test/browser"))))

--- a/gui/src/monkey/ci/gui/martian.cljc
+++ b/gui/src/monkey/ci/gui/martian.cljc
@@ -374,6 +374,8 @@
  (fn [_ [_ target-evt err]]
    (log/debug "Got error:" (clj->js err))
    {:dispatch (if (= 401 (:status err))
+                ;; TODO Try refreshing the token instead.  Only when that fails too,
+                ;; we should re-login.
                 [:route/goto :page/login]
                 (conj target-evt err))}))
 


### PR DESCRIPTION
Allow for separate events configuraton for listeners, so they can read from a queue.  This avoids duplication when running multiple instances.