### PR TITLE
Feature/oci runner rework

### DIFF
--- a/.monkeyci/build.clj
+++ b/.monkeyci/build.clj
@@ -13,7 +13,7 @@
 
 ;; Version assigned when building main branch
 ;; TODO Determine automatically
-(def snapshot-version "0.10.1-SNAPSHOT")
+(def snapshot-version "0.10.2-SNAPSHOT")
 
 (def tag-regex #"^refs/tags/(\d+\.\d+\.\d+(\.\d+)?$)")
 

--- a/app/dev-resources/logback-test.xml
+++ b/app/dev-resources/logback-test.xml
@@ -1,7 +1,7 @@
 <configuration scan="true" scanPeriod="5 seconds">
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>DEBUG</level>
+      <level>INFO</level>
     </filter>		
     <encoder>
       <pattern>[%blue(DEV)] %d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
@@ -26,7 +26,7 @@
   <logger name="io" level="WARN"/>
   <logger name="monkey.ci" level="DEBUG"/>
 
-  <root level="WARN">
+  <root level="DEBUG">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="FILE" />
   </root>

--- a/app/env/dev/runners.clj
+++ b/app/env/dev/runners.clj
@@ -8,7 +8,8 @@
              [commands :as cmd]
              [process :as proc]
              [runners]
-             [script :as s]]
+             [script :as s]
+             [time :as t]]
             [monkey.ci.build.api-server :as bas]
             [monkey.ci.runtime
              [app :as ra]
@@ -62,47 +63,47 @@
   [example]
   (run-build-local (example-build example)))
 
-(defn- run-controller [run-file rt]
-  ;; Prepare workspace
-  ;; Check out cache
-  ;; Create start file
-  ;; Wait for script to create stop file
-  ;; Upload new cache, if changed
-  (log/info "Running controller, creating run file")
-  (fs/create-file run-file)
-  (while (fs/exists? run-file)
-    (Thread/sleep 1000))
-  (log/info "Script finished"))
+;; (defn- run-controller [run-file rt]
+;;   ;; Prepare workspace
+;;   ;; Check out cache
+;;   ;; Create start file
+;;   ;; Wait for script to create stop file
+;;   ;; Upload new cache, if changed
+;;   (log/info "Running controller, creating run file")
+;;   (fs/create-file run-file)
+;;   (while (fs/exists? run-file)
+;;     (Thread/sleep 1000))
+;;   (log/info "Script finished"))
 
-(defn- run-script [run-file config]
-  (log/info "Running script with config:" config)
-  (while (not (fs/exists? run-file)) 
-    (Thread/sleep 1000))
-  (log/info "Run file created, starting script")
-  (rs/with-runtime config
-    (fn [rt]
-      (let [ns *ns*]
-        (try
-          (s/exec-script! rt)
-          (finally
-            (fs/delete run-file)
-            (in-ns (ns-name ns))))))))
+;; (defn- run-script [run-file config]
+;;   (log/info "Running script with config:" config)
+;;   (while (not (fs/exists? run-file)) 
+;;     (Thread/sleep 1000))
+;;   (log/info "Run file created, starting script")
+;;   (rs/with-runtime config
+;;     (fn [rt]
+;;       (let [ns *ns*]
+;;         (try
+;;           (s/exec-script! rt)
+;;           (finally
+;;             (fs/delete run-file)
+;;             (in-ns (ns-name ns))))))))
 
-(defn run-oci2-local
-  "Runs an oci 2 test by starting two threads: one for the controller
-   and another one for the build script."
-  [config example]
-  (let [build (example-build example)
-        api-config {:port 3002
-                    :token (bas/generate-token)}
-        run-path (fs/path (fs/temp-dir) (str (:build-id build) ".run"))]
-    (log/info "Using run file:" run-path)
-    (md/future
-      (ra/with-runner-system (assoc config
-                                    :build build
-                                    :runner {:type :noop
-                                             :api-port (:port api-config)
-                                             :api-token (:token api-config)})
-        (fn [rt]
-          (run-controller run-path rt))))
-    (run-script run-path (proc/child-config build api-config))))
+(defn run-build
+  "Runs a build using given or current config"
+  ([config sid url branch]
+   (let [build-id (str "build-" (t/now))
+         sid (conj sid build-id)
+         build (-> (zipmap b/sid-props sid)
+                   (assoc :sid sid
+                          :git {:url url
+                                :branch (or branch "main")}))]
+     (log/info "Running build at url" url)
+     (ra/with-runner-system (assoc config :build build)
+       (fn [sys]
+         (let [rt (:runtime sys)
+               r (get-in sys [:runner :runner])]
+           (r build rt))))))
+
+  ([sid url branch]
+   (run-build @co/global-config sid url branch)))

--- a/app/examples/basic-clj/build.clj
+++ b/app/examples/basic-clj/build.clj
@@ -1,5 +1,6 @@
-;; Basic Clojure build script
-(require '[monkey.ci.build.core :as core])
+(ns basic-clj
+  ;; Basic Clojure build script
+  (:require [monkey.ci.build.core :as core]))
 
 (def simple-step
   (core/action-job

--- a/app/examples/basic-clj/build.clj
+++ b/app/examples/basic-clj/build.clj
@@ -1,4 +1,4 @@
-(ns basic-clj
+(ns build
   ;; Basic Clojure build script
   (:require [monkey.ci.build.core :as core]))
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>com.monkeyci</groupId>
   <artifactId>app</artifactId>
-  <version>0.10.1-SNAPSHOT</version>
+  <version>0.10.2-SNAPSHOT</version>
   <name>app</name>
   <repositories>
     <repository>
@@ -46,6 +46,11 @@
       <groupId>org.clojure</groupId>
       <artifactId>tools.logging</artifactId>
       <version>1.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>lambdaisland</groupId>
+      <artifactId>kaocha</artifactId>
+      <version>1.91.1392</version>
     </dependency>
     <dependency>
       <groupId>org.zeromq</groupId>
@@ -135,7 +140,7 @@
     <dependency>
       <groupId>com.monkeyprojects</groupId>
       <artifactId>oci-container-instance</artifactId>
-      <version>0.1.0</version>
+      <version>0.2.0</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
@@ -249,7 +254,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.11</version>
+      <version>1.5.12</version>
     </dependency>
     <dependency>
       <groupId>camel-snake-kebab</groupId>

--- a/app/resources/build.sh
+++ b/app/resources/build.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+# This script is responsible for starting the build process, when it is
+# run in a pod alongside a controller.  The controller should create a
+# run file, and this script should start the clojure process running the
+# build script as soon as that file has been created.  Afterwards the
+# run file should be deleted, which is the signal for the controller to
+# terminate as well.
+
+if [ "$MONKEYCI_WORK_DIR" = "" ]; then
+    MONKEYCI_WORK_DIR=$PWD
+fi
+
+if [ "$MONKEYCI_START_FILE" = "" ]; then
+    MONKEYCI_START_FILE=${MONKEYCI_WORK_DIR}/start
+fi
+
+if [ "$MONKEYCI_ABORT_FILE" = "" ]; then
+    MONKEYCI_ABORT_FILE=${MONKEYCI_WORK_DIR}/abort
+fi
+
+wait_for_start()
+{
+    echo "Waiting for start conditions..."
+    while true; do
+	sleep 1
+	if [ -f "$MONKEYCI_START_FILE" ]; then
+	    echo "Ready to start"
+	    START=yes
+	    break
+	fi
+	# Abortion indicates there is something wrong with the sidecar
+	if [ -f "$MONKEYCI_ABORT_FILE" ]; then
+	    echo "Aborting execution"
+	    ABORT=yes
+	    break
+	fi
+    done
+}
+
+post_event()
+{
+    echo $1 >> $MONKEYCI_EVENT_FILE
+}
+
+echo "Starting build with working directory $MONKEYCI_WORK_DIR"
+# Create any directories
+mkdir -p `dirname $MONKEYCI_START_FILE`
+mkdir -p `dirname $MONKEYCI_ABORT_FILE`
+
+wait_for_start
+if [ "$ABORT" = "yes" ]; then
+    echo "Aborted."
+    exit 1
+fi
+
+cd $MONKEYCI_WORK_DIR
+# Run the build.  This assumes the necessary deps.edn is placed in $CLJ_CONFIG.
+clojure -X:monkeyci/build
+echo "All done."

--- a/app/resources/build.sh
+++ b/app/resources/build.sh
@@ -19,6 +19,10 @@ if [ "$MONKEYCI_ABORT_FILE" = "" ]; then
     MONKEYCI_ABORT_FILE=${MONKEYCI_WORK_DIR}/abort
 fi
 
+if [ "$MONKEYCI_EXIT_FILE" = "" ]; then
+    MONKEYCI_EXIT_FILE=${MONKEYCI_WORK_DIR}/exit
+fi
+
 wait_for_start()
 {
     echo "Waiting for start conditions..."
@@ -57,5 +61,6 @@ clojure -X:monkeyci/build
 RESULT=$?
 echo "Script finished with exit code $RESULT, deleting run file."
 rm -f $MONKEYCI_START_FILE
+echo $RESULT > $MONKEYCI_EXIT_FILE
 echo "All done."
 exit $RESULT

--- a/app/resources/build.sh
+++ b/app/resources/build.sh
@@ -22,6 +22,8 @@ fi
 wait_for_start()
 {
     echo "Waiting for start conditions..."
+    echo "Start file: $MONKEYCI_START_FILE"
+    echo "Abort file: $MONKEYCI_ABORT_FILE"
     while true; do
 	sleep 1
 	if [ -f "$MONKEYCI_START_FILE" ]; then
@@ -38,11 +40,6 @@ wait_for_start()
     done
 }
 
-post_event()
-{
-    echo $1 >> $MONKEYCI_EVENT_FILE
-}
-
 echo "Starting build with working directory $MONKEYCI_WORK_DIR"
 # Create any directories
 mkdir -p `dirname $MONKEYCI_START_FILE`
@@ -57,4 +54,8 @@ fi
 cd $MONKEYCI_WORK_DIR
 # Run the build.  This assumes the necessary deps.edn is placed in $CLJ_CONFIG.
 clojure -X:monkeyci/build
+RESULT=$?
+echo "Script finished with exit code $RESULT, deleting run file."
+rm -f $MONKEYCI_START_FILE
 echo "All done."
+exit $RESULT

--- a/app/src/monkey/ci/cli.clj
+++ b/app/src/monkey/ci/cli.clj
@@ -108,7 +108,7 @@
 
 (def sidecar-cmd
   {:command "sidecar"
-   :description "Run as sidecar"
+   :description "Run as sidecar (for internal use)"
    :opts [{:as "Events file"
            :option "events-file"
            :short "e"
@@ -132,6 +132,13 @@
           :app-mode :script
           :runtime? false}})
 
+(def controller-cmd
+  {:command "controller"
+   :description "Runs as controller (for internal use)"
+   :runs {:command cmd/controller
+          :app-mode :script
+          :runtime? false}})
+
 (def base-config
   {:name "monkey-ci"
    :description "MonkeyCI: Powerful build pipeline runner"
@@ -151,7 +158,8 @@
            :multiple true}]
    :subcommands [build-cmd
                  server-cmd
-                 sidecar-cmd]})
+                 sidecar-cmd
+                 controller-cmd]})
 
 (defn set-invoker
   "Updates the cli config to replace the `runs` config with the given invoker."

--- a/app/src/monkey/ci/commands.clj
+++ b/app/src/monkey/ci/commands.clj
@@ -208,6 +208,7 @@
    an API server that is used by the build script, which then runs alongside
    the controller."
   [conf]
+  (log/info "Running controller with config:" conf)
   (ra/with-runner-system conf
     (fn [sys]
       (rc/run-controller (:runtime sys)))))

--- a/app/src/monkey/ci/commands.clj
+++ b/app/src/monkey/ci/commands.clj
@@ -19,6 +19,7 @@
              [spec :as spec]
              [utils :as u]]
             [monkey.ci.events.core :as ec]
+            [monkey.ci.runners.controller :as rc]
             [monkey.ci.runtime
              [app :as ra]
              [sidecar :as rs]]
@@ -199,3 +200,14 @@
   (spec/valid? ::ss/config conf)
   (log/info "Running sidecar with config:" conf)
   (rs/with-runtime conf run-sidecar))
+
+(defn controller
+  "Runs the application as a controller.  This is similar to a sidecar,
+   but for build processes (usually running in cloud containers).  The
+   controller is responsible for preparing the build workspace and running
+   an API server that is used by the build script, which then runs alongside
+   the controller."
+  [conf]
+  (ra/with-runner-system conf
+    (fn [sys]
+      (rc/run-controller (:runtime sys)))))

--- a/app/src/monkey/ci/containers/oci.clj
+++ b/app/src/monkey/ci/containers/oci.clj
@@ -30,7 +30,7 @@
 (def max-pod-cpus "Max number of cpu's to assign to a pod" 16)
 
 (def work-dir oci/work-dir)
-(def script-dir "/opt/monkeyci/script")
+(def script-dir oci/script-dir)
 (def log-dir (oci/checkout-subdir "log"))
 (def events-dir (oci/checkout-subdir "events"))
 (def start-file (str events-dir "/start"))

--- a/app/src/monkey/ci/oci.clj
+++ b/app/src/monkey/ci/oci.clj
@@ -221,6 +221,7 @@
   [client cid]
   (ci/list-container-instances client {:compartment-id cid :lifecycle-state "ACTIVE"}))
 
+(def home-dir "/home/monkeyci")
 (def checkout-vol "checkout")
 (def checkout-dir "/opt/monkeyci/checkout")
 (def key-dir "/opt/monkeyci/keys")
@@ -271,6 +272,11 @@
   [ci n]
   (mc/find-first (cp/prop-pred :name n)
                  (:volumes ci)))
+
+(defn make-config-vol [name configs]
+  {:name name
+   :volume-type "CONFIGFILE"
+   :configs configs})
 
 (defn config-entry
   "Creates an entry config for a volume, where the contents are base64 encoded."

--- a/app/src/monkey/ci/oci.clj
+++ b/app/src/monkey/ci/oci.clj
@@ -224,6 +224,7 @@
 (def home-dir "/home/monkeyci")
 (def checkout-vol "checkout")
 (def checkout-dir "/opt/monkeyci/checkout")
+(def script-dir "/opt/monkeyci/script")
 (def key-dir "/opt/monkeyci/keys")
 
 (defn- container-config [conf]

--- a/app/src/monkey/ci/process.clj
+++ b/app/src/monkey/ci/process.clj
@@ -41,8 +41,10 @@
 (defn exit! [exit-code]
   (System/exit exit-code))
 
-(defn- load-config [{:keys [config-file]}]
-  (config/load-config-file config-file))
+(defn- load-config
+  "Either loads config from a config file, or passed directly as an exec arg"
+  [{:keys [config config-file]}]
+  (or config (config/load-config-file config-file)))
 
 (defn run
   "Run function for when a build task is executed using clojure tools.  This function

--- a/app/src/monkey/ci/process.clj
+++ b/app/src/monkey/ci/process.clj
@@ -8,7 +8,6 @@
             [clojure.java.io :as io]
             [clojure.string :as cs]
             [clojure.tools.logging :as log]
-            [config.core :as cc]
             [manifold.deferred :as md]
             [monkey.ci
              [blob :as blob]
@@ -49,25 +48,22 @@
   "Run function for when a build task is executed using clojure tools.  This function
    is run in a child process by the `execute!` function below.  This exits the VM
    with a nonzero value on failure."
-  ([args _]
-   (log/debug "Running with args:" args)
-   (try
-     (let [config (load-config args)]
-       (when (-> (merge default-script-config config)
-                 (rs/with-runtime
-                   (fn [rt]
-                     (log/debug "Executing script with config" (:config rt))
-                     (log/debug "Script working directory:" (utils/cwd))
-                     (script/exec-script! rt)))
-                 (bc/failed?))
-         (exit! err/error-script-failure)))
-     (catch Throwable ex
-       ;; This could happen if there is an error loading or initializing the child process
-       (log/error "Failed to run script process" ex)
-       (exit! err/error-process-failure))))
-
-  ([args]
-   (run args cc/env)))
+  [args & _]
+  (log/debug "Running with args:" args)
+  (try
+    (let [config (load-config args)]
+      (when (-> (merge default-script-config config)
+                (rs/with-runtime
+                  (fn [rt]
+                    (log/debug "Executing script with config" (:config rt))
+                    (log/debug "Script working directory:" (utils/cwd))
+                    (script/exec-script! rt)))
+                (bc/failed?))
+        (exit! err/error-script-failure)))
+    (catch Throwable ex
+      ;; This could happen if there is an error loading or initializing the child process
+      (log/error "Failed to run script process" ex)
+      (exit! err/error-process-failure))))
 
 (defn- find-log-config
   "Finds logback configuration file, either configured on the runner, or present 

--- a/app/src/monkey/ci/runners/controller.clj
+++ b/app/src/monkey/ci/runners/controller.clj
@@ -2,13 +2,30 @@
   "Functions for running the application as a controller."
   (:require [babashka.fs :as fs]
             [clojure.tools.logging :as log]
-            [monkey.ci.runners :as r]))
+            [monkey.ci
+             [build :as b]
+             [errors :as err]
+             [runners :as r]
+             [script :as script]]
+            [monkey.ci.events.core :as ec]))
 
 (def run-path (comp :run-path :config))
+(def abort-path (comp :abort-path :config))
+(def exit-path (comp :exit-path :config))
+
+(defn- post-init-evt [{:keys [build] :as rt}]
+  (ec/post-events (:events rt) (script/script-init-evt build (b/script-dir build)))
+  rt)
 
 (defn- create-run-file [rt]
   (log/debug "Creating run file at:" (run-path rt))
   (some-> (run-path rt)
+          (fs/create-file))
+  rt)
+
+(defn- create-abort-file [rt]
+  (log/debug "Creating abort file at:" (abort-path rt))
+  (some-> (abort-path rt)
           (fs/create-file))
   rt)
 
@@ -29,16 +46,34 @@
   (let [rp (run-path rt)]
     (log/debug "Waiting until run file has been deleted at:" rp)
     (while (fs/exists? rp)
-      (Thread/sleep 500)))
+      (Thread/sleep 500))
+    (log/debug "Run file deleted, build script finished."))
   rt)
+
+(defn- post-end-evt [{:keys [build] :as rt}]
+  (ec/post-events (:events rt) (b/build-end-evt build (get rt :exit-code err/error-process-failure)))
+  rt)
+
+(defn- read-exit-code [rt]
+  (let [p (exit-path rt)
+        exit-code (when (fs/exists? p)
+                    (Integer/parseInt (.strip (slurp p))))]
+    (cond-> rt
+      exit-code (assoc :exit-code exit-code))))
 
 (defn run-controller [rt]
   (try
     (-> rt
+        (post-init-evt)
         (download-and-store-src)
         (restore-build-cache)
         (create-run-file)
         (wait-until-run-file-deleted)
-        (save-build-cache))
+        (read-exit-code)
+        (post-end-evt)
+        (save-build-cache)
+        :exit-code)
     (catch Throwable ex
-      (log/error "Failed to run controller" ex))))
+      (log/error "Failed to run controller" ex)
+      (create-abort-file rt)
+      1)))

--- a/app/src/monkey/ci/runners/controller.clj
+++ b/app/src/monkey/ci/runners/controller.clj
@@ -1,8 +1,33 @@
 (ns monkey.ci.runners.controller
   "Functions for running the application as a controller."
-  (:require [monkey.ci.runners :as r]))
+  (:require [babashka.fs :as fs]
+            [monkey.ci.runners :as r]))
+
+(def run-path (comp :run-path :config))
+
+(defn- create-run-file [rt]
+  (some-> (run-path rt)
+          (fs/create-file))
+  rt)
+
+(defn- download-and-store-src [rt]
+  (assoc rt :build (-> (:build rt)
+                       (r/download-src rt)
+                       (r/store-src rt))))
+
+(defn- restore-build-cache [rt]
+  rt)
+
+(defn- save-build-cache [rt]
+  rt)
+
+(defn- wait-until-run-file-deleted [rt]
+  rt)
 
 (defn run-controller [rt]
-  (-> (:build rt)
-      (r/download-src rt)
-      (r/store-src rt)))
+  (-> rt
+      (download-and-store-src)
+      (restore-build-cache)
+      (create-run-file)
+      (wait-until-run-file-deleted)
+      (save-build-cache)))

--- a/app/src/monkey/ci/runners/controller.clj
+++ b/app/src/monkey/ci/runners/controller.clj
@@ -1,6 +1,7 @@
 (ns monkey.ci.runners.controller
   "Functions for running the application as a controller."
   (:require [babashka.fs :as fs]
+            [clojure.tools.logging :as log]
             [monkey.ci.runners :as r]))
 
 (def run-path (comp :run-path :config))
@@ -32,9 +33,12 @@
   rt)
 
 (defn run-controller [rt]
-  (-> rt
-      (download-and-store-src)
-      (restore-build-cache)
-      (create-run-file)
-      (wait-until-run-file-deleted)
-      (save-build-cache)))
+  (try
+    (-> rt
+        (download-and-store-src)
+        (restore-build-cache)
+        (create-run-file)
+        (wait-until-run-file-deleted)
+        (save-build-cache))
+    (catch Throwable ex
+      (log/error "Failed to run controller" ex))))

--- a/app/src/monkey/ci/runners/controller.clj
+++ b/app/src/monkey/ci/runners/controller.clj
@@ -6,6 +6,7 @@
 (def run-path (comp :run-path :config))
 
 (defn- create-run-file [rt]
+  (log/debug "Creating run file at:" (run-path rt))
   (some-> (run-path rt)
           (fs/create-file))
   rt)
@@ -25,6 +26,7 @@
 
 (defn- wait-until-run-file-deleted [rt]
   (let [rp (run-path rt)]
+    (log/debug "Waiting until run file has been deleted at:" rp)
     (while (fs/exists? rp)
       (Thread/sleep 500)))
   rt)

--- a/app/src/monkey/ci/runners/controller.clj
+++ b/app/src/monkey/ci/runners/controller.clj
@@ -1,0 +1,8 @@
+(ns monkey.ci.runners.controller
+  "Functions for running the application as a controller."
+  (:require [monkey.ci.runners :as r]))
+
+(defn run-controller [rt]
+  (-> (:build rt)
+      (r/download-src rt)
+      (r/store-src rt)))

--- a/app/src/monkey/ci/runners/controller.clj
+++ b/app/src/monkey/ci/runners/controller.clj
@@ -16,12 +16,17 @@
                        (r/store-src rt))))
 
 (defn- restore-build-cache [rt]
+  ;; TODO
   rt)
 
 (defn- save-build-cache [rt]
+  ;; TODO
   rt)
 
 (defn- wait-until-run-file-deleted [rt]
+  (let [rp (run-path rt)]
+    (while (fs/exists? rp)
+      (Thread/sleep 500)))
   rt)
 
 (defn run-controller [rt]

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -23,7 +23,7 @@
 (def ssh-keys-volume "ssh-keys")
 (def ssh-keys-dir oci/key-dir)
 (def log-config-volume "log-config")
-(def log-config-dir "/home/monkeyci/config")
+(def log-config-dir (str oci/home-dir "/config"))
 (def log-config-file "logback.xml")
 (def config-volume "config")
 
@@ -81,9 +81,8 @@
                  ((juxt :private-key :public-key) ssh-keys)
                  ["" ".pub"]))]
     (when-let [ssh-keys (build-ssh-keys build)]
-      {:name ssh-keys-volume
-       :volume-type "CONFIGFILE"
-       :configs (mapcat ->config-entries (range) ssh-keys)})))
+      (oci/make-config-vol ssh-keys-volume
+                           (mapcat ->config-entries (range) ssh-keys)))))
 
 (defn- add-ssh-keys-volume [conf build]
   (let [vc (ssh-keys-volume-config build)]

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -180,10 +180,11 @@
   "Max msecs a build script can run before we terminate it"
   config/max-script-timeout)
 
-(defn run-oci-build [{:keys [client conf build rt find-container]}]
+(defn run-oci-build [ic {:keys [client conf build rt find-container]}]
   (s/valid? ::sb/build build)
   (rt/post-events rt (b/build-init-evt build))
-  (-> (oci/run-instance client (instance-config conf build rt)
+  (-> (oci/run-instance client
+                        ic
                         {:delete? true
                          :exited? (fn [id]
                                     (md/chain
@@ -211,7 +212,8 @@
   "Runs the build script as an OCI container instance.  Returns a deferred with
    the container exit code."
   [client conf build rt]
-  (run-oci-build {:client client
+  (run-oci-build (instance-config conf build rt)
+                 {:client client
                   :conf conf
                   :build build
                   :rt rt

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -48,7 +48,7 @@
   (cond-> conf
     (log-config rt) (assoc-in [:runner :log-config] (str log-config-dir "/" log-config-file))))
 
-(defn- add-api-token
+(defn add-api-token
   "Generates a new API token that can be used by the build runner to invoke
    certain API calls."
   [conf build rt]

--- a/app/src/monkey/ci/runners/oci.clj
+++ b/app/src/monkey/ci/runners/oci.clj
@@ -140,10 +140,9 @@
                 ;; Run the build as a child process.  This allows us to add dependencies
                 ;; in the build, but also isolates the untrusted build script.  Alternatively,
                 ;; we could try to run the clj process directly but then we'd have to set up
-                ;; and external build api server for the script to communicate with in order
+                ;; an external build api server for the script to communicate with in order
                 ;; to shield off any sensitive info, or use the general API server.  This
-                ;; could lead to performance bottlenecks and could lead to higher costs wrt.
-                ;; the API gateway.
+                ;; could lead to performance bottlenecks and higher costs wrt. the API gateway.
                 :arguments (cond-> ["-w" oci/checkout-dir
                                     "build" "run"
                                     "-u" url]

--- a/app/src/monkey/ci/runners/oci2.clj
+++ b/app/src/monkey/ci/runners/oci2.clj
@@ -3,13 +3,11 @@
    one running the controller process, that starts the build api, and the other that
    actually runs the build script.  This is more secure and less error-prone than
    starting a child process."
-  (:gen-class)
   (:require [monkey.ci
              [build :as b]
              [edn :as edn]
              [oci :as oci]]
-            #_[monkey.ci.runners.oci :as ro]
-            [monkey.ci.runtime.app :as ra]))
+            #_[monkey.ci.runners.oci :as ro]))
 
 ;; Necessary to be able to write to the shared volume
 (def root-user {:security-context-type "LINUX"
@@ -72,14 +70,3 @@
         (update :containers make-containers ctx)
         (update :volumes conj (config-volume ctx)))))
 
-(defn run-controller [rt]
-  ;; TODO
-  )
-
-(defn -main
-  "Main entry point for the oci2 controller process"
-  [& [config-file]]
-  (let [config (edn/edn-> (slurp (or config-file config-path)))]
-    (ra/with-runner-system config
-      (fn [sys]
-        (run-controller (:runtime sys))))))

--- a/app/src/monkey/ci/runners/oci2.clj
+++ b/app/src/monkey/ci/runners/oci2.clj
@@ -1,0 +1,10 @@
+(ns monkey.ci.runners.oci2
+  "Variation of the oci runner, that creates a container instance with two containers:
+   one running the controller process, that starts the build api, and the other that
+   actually runs the build script.  This is more secure and less error-prone than
+   starting a child process.")
+
+(defn run-controller [])
+
+(defn run-script [])
+

--- a/app/src/monkey/ci/runners/oci2.clj
+++ b/app/src/monkey/ci/runners/oci2.clj
@@ -31,16 +31,13 @@
                  (edn/->edn))]
     (oci/make-config-vol
      config-vol
+     ;; TODO Logback config
      [(oci/config-entry config-file conf)])))
 
 (defn controller-container [config]
   (-> default-container
       (assoc :display-name "controller"
-             :arguments ["java"
-                         "-Xmx1g"
-                         "-Dlogback.configurationFile=config/logback.xml"
-                         "-cp" "monkeyci.jar"
-                         "monkey.ci.runners.oci2"])
+             :arguments ["controller"])
       (update :volume-mounts conj config-mount)))
 
 (defn script-container [config]
@@ -48,7 +45,7 @@
   (-> default-container
       (assoc :display-name "build"
              ;; TODO Run script that waits for run file to be created
-             :arguments ["clojure"])))
+             :arguments ["bash" "-c"])))
 
 (defn- make-containers [[orig] config]
   ;; Use the original container but modify it where necessary

--- a/app/src/monkey/ci/runners/oci2.clj
+++ b/app/src/monkey/ci/runners/oci2.clj
@@ -2,9 +2,84 @@
   "Variation of the oci runner, that creates a container instance with two containers:
    one running the controller process, that starts the build api, and the other that
    actually runs the build script.  This is more secure and less error-prone than
-   starting a child process.")
+   starting a child process."
+  (:gen-class)
+  (:require [monkey.ci
+             [build :as b]
+             [edn :as edn]
+             [oci :as oci]]
+            #_[monkey.ci.runners.oci :as ro]
+            [monkey.ci.runtime.app :as ra]))
 
-(defn run-controller [])
+;; Necessary to be able to write to the shared volume
+(def root-user {:security-context-type "LINUX"
+                :run-as-user 0})
 
-(defn run-script [])
+(def default-container
+  {:security-context root-user})
 
+(def config-vol "config")
+(def config-path (str oci/home-dir "/config"))
+(def config-file "config.edn")
+
+(def config-mount
+  {:mount-path config-path
+   :volume-name config-vol
+   :is-read-only true})
+
+(defn- config-volume [config]
+  (let [conf (-> (:config config)
+                 (assoc :build (:build config))
+                 (edn/->edn))]
+    (oci/make-config-vol
+     config-vol
+     [(oci/config-entry config-file conf)])))
+
+(defn controller-container [config]
+  (-> default-container
+      (assoc :display-name "controller"
+             :arguments ["java"
+                         "-Xmx1g"
+                         "-Dlogback.configurationFile=config/logback.xml"
+                         "-cp" "monkeyci.jar"
+                         "monkey.ci.runners.oci2"])
+      (update :volume-mounts conj config-mount)))
+
+(defn script-container [config]
+  ;; TODO Use clojure base image instead of the one from monkeyci
+  (-> default-container
+      (assoc :display-name "build"
+             ;; TODO Run script that waits for run file to be created
+             :arguments ["clojure"])))
+
+(defn- make-containers [[orig] config]
+  ;; Use the original container but modify it where necessary
+  [(merge orig (controller-container config))
+   (merge orig (script-container config))])
+
+(defn instance-config
+  "Prepares container instance configuration to run a build.  It contains two
+   containers, one for the controller process and another one for the script
+   itself.  The controller is responsible for preparing the workspace and 
+   starting an API server, which the script will connect to."
+  [config build]
+  (let [run-path (str oci/checkout-dir "/" (b/build-id) ".run")
+        ctx (assoc config
+                   :build (dissoc build :ssh-keys :cleanup? :status)
+                   :run-path run-path)]
+    (-> (oci/instance-config config)      
+        (assoc :display-name (b/build-id build))
+        (update :containers make-containers ctx)
+        (update :volumes conj (config-volume ctx)))))
+
+(defn run-controller [rt]
+  ;; TODO
+  )
+
+(defn -main
+  "Main entry point for the oci2 controller process"
+  [& [config-file]]
+  (let [config (edn/edn-> (slurp (or config-file config-path)))]
+    (ra/with-runner-system config
+      (fn [sys]
+        (run-controller (:runtime sys))))))

--- a/app/src/monkey/ci/runtime/app.clj
+++ b/app/src/monkey/ci/runtime/app.clj
@@ -25,7 +25,10 @@
              [oci :as cco]]
             [monkey.ci.events
              [core :as ec]
-             [split  :as es]]
+             [split :as es]]
+            [monkey.ci.runners
+             [oci]
+             [oci2]]
             [monkey.ci.runtime.common :as rc]
             [monkey.ci.web
              [auth :as auth]

--- a/app/src/monkey/ci/runtime/app.clj
+++ b/app/src/monkey/ci/runtime/app.clj
@@ -143,9 +143,10 @@
 (defn- random-port []
   (+ (rand-int 10000) 30000))
 
-(defn new-api-config [config]
-  {:token (bas/generate-token)
-   :port (or (get-in config [:runner :api-port])
+(defn new-api-config [{:keys [runner]}]
+  {:token (or (:api-token runner)
+              (bas/generate-token))
+   :port (or (:api-port runner)
              (random-port))})
 
 (defn- new-metrics []

--- a/app/test/unit/monkey/ci/cli_test.clj
+++ b/app/test/unit/monkey/ci/cli_test.clj
@@ -155,7 +155,11 @@
               (is (= {:key "value"}
                      (-> (run-cli "sidecar" "-e" "events" "-s" "start" "-t" p)
                          :args
-                         :job-config))))))))))
+                         :job-config)))))))
+
+      (testing "`controller` command"
+        (testing "runs `controller` command"
+          (is (= cmd/controller (:cmd (run-cli "controller")))))))))
 
 (deftest set-invoker
   (testing "applies invoker to `runs` in commands"

--- a/app/test/unit/monkey/ci/commands_test.clj
+++ b/app/test/unit/monkey/ci/commands_test.clj
@@ -14,6 +14,7 @@
              [sidecar :as sc]]
             [monkey.ci.config.sidecar :as cs]
             [monkey.ci.helpers :as h]
+            [monkey.ci.runners.controller :as rc]
             [monkey.ci.spec.sidecar :as ss]
             [monkey.ci.web.handler :as wh]
             [monkey.ci.test
@@ -152,3 +153,9 @@
                                                        (swap! recv concat (edn/edn-> (:body req)))
                                                        (md/success-deferred {:status 200}))]
               (validate-sidecar config job (fn [] @recv)))))))))
+
+(deftest controller
+  (testing "invokes `run-controller` with runtime created from config"
+    (with-redefs [rc/run-controller (fn [rt]
+                                       (when (some? rt) ::ok))]
+      (is (= ::ok (sut/controller tc/base-config))))))

--- a/app/test/unit/monkey/ci/process_test.clj
+++ b/app/test/unit/monkey/ci/process_test.clj
@@ -51,7 +51,17 @@
                 (is (nil? (sut/run {:config-file (.getAbsolutePath config-file)})))
                 (is (= build
                        (-> @captured-args
-                           :build)))))))))))
+                           :build)))))))
+
+        (testing "parses arg as config"
+          (let [captured-args (atom nil)]
+            (with-redefs [script/exec-script! (fn [args]
+                                                (reset! captured-args args)
+                                                bc/success)]
+              (is (nil? (sut/run {:config config})))
+              (is (= build
+                     (-> @captured-args
+                         :build))))))))))
 
 (deftype FakeProcess [exitValue])
 

--- a/app/test/unit/monkey/ci/runners/controller_test.clj
+++ b/app/test/unit/monkey/ci/runners/controller_test.clj
@@ -1,6 +1,7 @@
 (ns monkey.ci.runners.controller-test
   (:require [clojure.test :refer [deftest testing is]]
             [babashka.fs :as fs]
+            [manifold.deferred :as md]
             [monkey.ci.build.api-server :as bas]
             [monkey.ci.runners.controller :as sut]
             [monkey.ci.helpers :as h]
@@ -17,8 +18,15 @@
                                           :branch "main"})
                  (assoc-in [:build :script :script-dir] (str checkout-dir "/.monkeyci"))
                  (assoc-in [:git :clone] (fn [_] (reset! cloned? true)))
-                 (assoc-in [:build :workspace] "/test/ws"))]
-      (is (some? (sut/run-controller rt)))
+                 (assoc-in [:build :workspace] "/test/ws"))
+          ;; Run controller async otherwise it will block tests
+          res (md/future (sut/run-controller rt))]
+      (is (not (md/realized? res)))
+      
+      (testing "creates run file"
+        ;; Since we're running the controller async, wait until the run path exists,
+        ;; which indicates it has started
+        (is (not= :timeout (h/wait-until #(fs/exists? run-path) 1000))))
       
       (testing "performs git clone"
         (is (true? @cloned?)))
@@ -28,10 +36,11 @@
       (testing "stores workspace"
         (is (not-empty @(:stored (:workspace rt)))))
       
-      (testing "creates run file"
-        (is (fs/exists? run-path)))
-      
       (testing "waits until run file has been deleted"
-        )
+        (is (= :timeout (deref res 100 :timeout)) "controller should be running until run file is deleted")
+        (is (nil? (fs/delete run-path)))
+        (is (not= :timeout (deref res 1000 :timeout))))
 
-      (testing "saves build cache afterwards"))))
+      (testing "saves build cache afterwards")
+
+      (testing "creates abort file on error"))))

--- a/app/test/unit/monkey/ci/runners/controller_test.clj
+++ b/app/test/unit/monkey/ci/runners/controller_test.clj
@@ -1,5 +1,7 @@
 (ns monkey.ci.runners.controller-test
   (:require [clojure.test :refer [deftest testing is]]
+            [babashka.fs :as fs]
+            [monkey.ci.build.api-server :as bas]
             [monkey.ci.runners.controller :as sut]
             [monkey.ci.helpers :as h]
             [monkey.ci.test.runtime :as trt]))
@@ -8,20 +10,28 @@
   (h/with-tmp-dir dir
     (let [run-path (str dir "/test.run")
           checkout-dir (str dir "/checkout")
+          cloned? (atom nil)
           rt (-> (trt/test-runtime)
-                 (assoc :run-path run-path
-                        :git {:clone (constantly checkout-dir)})
+                 (assoc-in [:config :run-path] run-path)
                  (assoc-in [:build :git] {:url "git://test-url"
                                           :branch "main"})
-                 (assoc-in [:build :script :script-dir] (str checkout-dir "/.monkeyci")))]
+                 (assoc-in [:build :script :script-dir] (str checkout-dir "/.monkeyci"))
+                 (assoc-in [:git :clone] (fn [_] (reset! cloned? true)))
+                 (assoc-in [:build :workspace] "/test/ws"))]
+      (is (some? (sut/run-controller rt)))
+      
       (testing "performs git clone"
-        (let [cloned? (atom nil)
-              rt (assoc-in rt [:git :clone] (fn [_] (reset! cloned? true)))]
-          (is (some? (sut/run-controller rt)))
-          (is (true? @cloned?))))
+        (is (true? @cloned?)))
       
       (testing "restores build cache")
-      (testing "stores workspace")
-      (testing "creates run file")
-      (testing "starts api server")
-      (testing "waits until run file has been deleted"))))
+
+      (testing "stores workspace"
+        (is (not-empty @(:stored (:workspace rt)))))
+      
+      (testing "creates run file"
+        (is (fs/exists? run-path)))
+      
+      (testing "waits until run file has been deleted"
+        )
+
+      (testing "saves build cache afterwards"))))

--- a/app/test/unit/monkey/ci/runners/controller_test.clj
+++ b/app/test/unit/monkey/ci/runners/controller_test.clj
@@ -1,0 +1,27 @@
+(ns monkey.ci.runners.controller-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [monkey.ci.runners.controller :as sut]
+            [monkey.ci.helpers :as h]
+            [monkey.ci.test.runtime :as trt]))
+
+(deftest run-controller
+  (h/with-tmp-dir dir
+    (let [run-path (str dir "/test.run")
+          checkout-dir (str dir "/checkout")
+          rt (-> (trt/test-runtime)
+                 (assoc :run-path run-path
+                        :git {:clone (constantly checkout-dir)})
+                 (assoc-in [:build :git] {:url "git://test-url"
+                                          :branch "main"})
+                 (assoc-in [:build :script :script-dir] (str checkout-dir "/.monkeyci")))]
+      (testing "performs git clone"
+        (let [cloned? (atom nil)
+              rt (assoc-in rt [:git :clone] (fn [_] (reset! cloned? true)))]
+          (is (some? (sut/run-controller rt)))
+          (is (true? @cloned?))))
+      
+      (testing "restores build cache")
+      (testing "stores workspace")
+      (testing "creates run file")
+      (testing "starts api server")
+      (testing "waits until run file has been deleted"))))

--- a/app/test/unit/monkey/ci/runners/controller_test.clj
+++ b/app/test/unit/monkey/ci/runners/controller_test.clj
@@ -2,31 +2,48 @@
   (:require [clojure.test :refer [deftest testing is]]
             [babashka.fs :as fs]
             [manifold.deferred :as md]
+            [monkey.ci.protocols :as p]
             [monkey.ci.build.api-server :as bas]
             [monkey.ci.runners.controller :as sut]
             [monkey.ci.helpers :as h]
             [monkey.ci.test.runtime :as trt]))
 
+(defrecord FailingEventsPoster []
+  p/EventPoster
+  (post-events [this evt]
+    (throw (ex-info "Always fails" {}))))
+
 (deftest run-controller
   (h/with-tmp-dir dir
-    (let [run-path (str dir "/test.run")
+    (let [[run-path abort-path exit-path] (->> ["run" "abort" "exit"]
+                                               (map (partial str dir "/test.")))
           checkout-dir (str dir "/checkout")
           cloned? (atom nil)
           rt (-> (trt/test-runtime)
-                 (assoc-in [:config :run-path] run-path)
+                 (update :config merge {:run-path run-path
+                                        :abort-path abort-path
+                                        :exit-path exit-path})
                  (assoc-in [:build :git] {:url "git://test-url"
                                           :branch "main"})
                  (assoc-in [:build :script :script-dir] (str checkout-dir "/.monkeyci"))
                  (assoc-in [:git :clone] (fn [_] (reset! cloned? true)))
                  (assoc-in [:build :workspace] "/test/ws"))
+          exit-code 1232
           ;; Run controller async otherwise it will block tests
           res (md/future (sut/run-controller rt))]
+      (is (nil? (spit exit-path (str exit-code))))
       (is (not (md/realized? res)))
-      
+
       (testing "creates run file"
         ;; Since we're running the controller async, wait until the run path exists,
         ;; which indicates it has started
         (is (not= :timeout (h/wait-until #(fs/exists? run-path) 1000))))
+      
+      (testing "posts `script/initializing` event"
+        (let [events (:events rt)]
+          (is (some? events))
+          (is (some? (->> (h/received-events events)
+                          (h/first-event-by-type :script/initializing))))))
       
       (testing "performs git clone"
         (is (true? @cloned?)))
@@ -43,4 +60,18 @@
 
       (testing "saves build cache afterwards")
 
-      (testing "creates abort file on error"))))
+      (testing "posts `build/end` event"
+        (let [events (:events rt)]
+          (is (some? events))
+          (is (some? (->> (h/received-events events)
+                          (h/first-event-by-type :build/end))))))
+
+      (testing "returns exit code read from exit file"
+        (is (= exit-code (deref res 100 :timeout))))
+      
+      (testing "creates abort file on error"
+        (is (not= 0
+                  (-> rt
+                      (assoc :events (->FailingEventsPoster)) ; force error
+                      (sut/run-controller))))
+        (is (fs/exists? abort-path))))))

--- a/app/test/unit/monkey/ci/runners/oci2_test.clj
+++ b/app/test/unit/monkey/ci/runners/oci2_test.clj
@@ -51,7 +51,10 @@
         (testing "has config volume mount"
           (let [vm (oci/find-mount c "config")]
             (is (some? vm))
-            (is (= "/home/monkeyci/config" (:mount-path vm)))))))
+            (is (= "/home/monkeyci/config" (:mount-path vm)))))
+
+        (testing "has checkout volume mount"
+          (is (some? (oci/find-mount c oci/checkout-vol))))))
 
     (testing "build"
       (let [c (->> co
@@ -81,7 +84,10 @@
 
         (testing "sets abort file"
           (is (= (str oci/checkout-dir "/" (:build-id build) ".abort")
-                 (get env "MONKEYCI_ABORT_FILE"))))))
+                 (get env "MONKEYCI_ABORT_FILE"))))
+
+        (testing "has checkout volume mount"
+          (is (some? (oci/find-mount c oci/checkout-vol))))))
 
     (testing "volumes"
       (testing "contains config"

--- a/app/test/unit/monkey/ci/runners/oci2_test.clj
+++ b/app/test/unit/monkey/ci/runners/oci2_test.clj
@@ -3,7 +3,8 @@
             [babashka.fs :as fs]
             [monkey.ci
              [edn :as edn]
-             [oci :as oci]]
+             [oci :as oci]
+             [runners :as r]]
             [monkey.ci.config.script :as cs]
             [monkey.ci.runners.oci2 :as sut]
             [monkey.ci.helpers :as h]
@@ -128,3 +129,7 @@
           (testing "contains `build.sh`"
             (is (some? (decode-vol-config vol "build.sh")))))))))
 
+(deftest make-runner
+  (testing "creates runner fn for type `oci2`"
+    (is (fn? (r/make-runner {:runner
+                             {:type :oci2}})))))

--- a/app/test/unit/monkey/ci/runners/oci2_test.clj
+++ b/app/test/unit/monkey/ci/runners/oci2_test.clj
@@ -46,7 +46,7 @@
 
         (testing "runs monkeyci controller main"
           (let [args (:arguments c)]
-            (is (= "controller" (first args)))))
+            (is (= "controller" (last args)))))
 
         (testing "has config volume mount"
           (let [vm (oci/find-mount c "config")]
@@ -61,7 +61,7 @@
         (is (some? c))
 
         (testing "invokes script"
-          (is (= "bash" (first (:arguments c)))))
+          (is (= "bash" (first (:command c)))))
 
         (let [config-env (get env "CLJ_CONFIG")]
           (testing "sets `CLJ_CONFIG` location"

--- a/app/test/unit/monkey/ci/runners/oci2_test.clj
+++ b/app/test/unit/monkey/ci/runners/oci2_test.clj
@@ -1,0 +1,90 @@
+(ns monkey.ci.runners.oci2-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [babashka.fs :as fs]
+            [monkey.ci
+             [edn :as edn]
+             [oci :as oci]]
+            [monkey.ci.runners.oci2 :as sut]
+            [monkey.ci.helpers :as h]
+            [monkey.ci.test
+             [config :as tc]
+             [runtime :as trt]]))
+
+(deftest instance-config
+  (let [ic (sut/instance-config {} {:build-id "test-build"})
+        co (:containers ic)]
+    (testing "creates container instance configuration"
+      (is (map? ic))
+      (is (= "test-build" (:display-name ic))))
+
+    (testing "contains two containers"
+      (is (= 2 (count co)))
+      (is (every? string? (map :image-url co))))
+
+    (testing "containers run as root"
+      (is (every? zero? (map (comp :run-as-user :security-context) co))))
+
+    (testing "assigns freeform tags containing build info")
+
+    (testing "controller"
+      (let [c (->> co
+                   (filter (comp (partial = "controller") :display-name))
+                   (first))]
+        (is (some? c))
+
+        (testing "runs monkeyci controller main"
+          (let [args (:arguments c)]
+            (is (= "java" (first args)))
+            (is (some? (->> args
+                            (filter (partial = "monkey.ci.runners.oci2"))
+                            (first))))))
+
+        (testing "has config volume mount"
+          (let [vm (oci/find-mount c "config")]
+            (is (some? vm))
+            (is (= "/home/monkeyci/config" (:mount-path vm)))))))
+
+    (testing "build"
+      (let [c (->> co
+                   (filter (comp (partial = "build") :display-name))
+                   (first))]
+        (is (some? c))
+
+        (testing "invokes clojure process"
+          (is (= "clojure" (first (:arguments c)))))))
+
+    (testing "volumes"
+      (testing "contains config"
+        (let [vol (oci/find-volume ic "config")
+              conf (some->> vol
+                            :configs
+                            (filter (comp (partial = "config.edn") :file-name))
+                            first
+                            :data
+                            (h/base64->)
+                            (edn/edn->))]
+          (is (some? vol))
+          (is (some? conf)
+              "should contain config file")
+          (is (some? (:build conf))
+              "config should contain build"))))))
+
+(deftest run-controller
+  (h/with-tmp-dir dir
+    (let [run-path (str dir "/test.run")
+          rt (-> (trt/test-runtime)
+                 (assoc :run-path run-path))]
+      (testing "performs git clone")
+      (testing "restores build cache")
+      (testing "creates run file")
+      (testing "starts api server")
+      (testing "waits until run file has been deleted"))))
+
+(deftest controller-main
+  (testing "invokes `run-controller` with runtime created from config"
+    (h/with-tmp-dir dir
+      (let [config (str (fs/path dir "config.edn"))]
+        (is (nil? (spit config (pr-str tc/base-config))))
+        (with-redefs [sut/run-controller (fn [rt]
+                                           (when (some? rt) ::ok))]
+          (is (= ::ok (sut/-main config))))))))

--- a/app/test/unit/monkey/ci/runners/oci2_test.clj
+++ b/app/test/unit/monkey/ci/runners/oci2_test.clj
@@ -34,10 +34,7 @@
 
         (testing "runs monkeyci controller main"
           (let [args (:arguments c)]
-            (is (= "java" (first args)))
-            (is (some? (->> args
-                            (filter (partial = "monkey.ci.runners.oci2"))
-                            (first))))))
+            (is (= "controller" (first args)))))
 
         (testing "has config volume mount"
           (let [vm (oci/find-mount c "config")]
@@ -50,8 +47,8 @@
                    (first))]
         (is (some? c))
 
-        (testing "invokes clojure process"
-          (is (= "clojure" (first (:arguments c)))))))
+        (testing "invokes script"
+          (is (= "bash" (first (:arguments c)))))))
 
     (testing "volumes"
       (testing "contains config"

--- a/app/test/unit/monkey/ci/runners/oci2_test.clj
+++ b/app/test/unit/monkey/ci/runners/oci2_test.clj
@@ -69,22 +69,3 @@
           (is (some? (:build conf))
               "config should contain build"))))))
 
-(deftest run-controller
-  (h/with-tmp-dir dir
-    (let [run-path (str dir "/test.run")
-          rt (-> (trt/test-runtime)
-                 (assoc :run-path run-path))]
-      (testing "performs git clone")
-      (testing "restores build cache")
-      (testing "creates run file")
-      (testing "starts api server")
-      (testing "waits until run file has been deleted"))))
-
-(deftest controller-main
-  (testing "invokes `run-controller` with runtime created from config"
-    (h/with-tmp-dir dir
-      (let [config (str (fs/path dir "config.edn"))]
-        (is (nil? (spit config (pr-str tc/base-config))))
-        (with-redefs [sut/run-controller (fn [rt]
-                                           (when (some? rt) ::ok))]
-          (is (= ::ok (sut/-main config))))))))


### PR DESCRIPTION
Reworked implementation of the oci runner, to create two containers instead of one that creates a child process.  Should be more secure and a workaround for the m2 cache problem.