### PR TITLE
Bugfix/build id generation

### DIFF
--- a/app/src/monkey/ci/build.clj
+++ b/app/src/monkey/ci/build.clj
@@ -168,7 +168,9 @@
              :build build))
 
 (defn build-triggered-evt [build]
-  (with-build-evt :build/triggered build))
+  (-> (with-build-evt :build/triggered build)
+      ;; sid at this point is only repo sid, since the build id still needs to be assigned
+      (assoc :sid [(:customer-id build) (:repo-id build)])))
 
 (defn build-init-evt [build]
   (with-build-evt :build/initializing build))

--- a/app/src/monkey/ci/build.clj
+++ b/app/src/monkey/ci/build.clj
@@ -167,8 +167,8 @@
              build
              :build build))
 
-(defn build-pending-evt [build]
-  (with-build-evt :build/pending build))
+(defn build-triggered-evt [build]
+  (with-build-evt :build/triggered build))
 
 (defn build-init-evt [build]
   (with-build-evt :build/initializing build))

--- a/app/src/monkey/ci/storage/sql.clj
+++ b/app/src/monkey/ci/storage/sql.clj
@@ -450,7 +450,8 @@
   (when-let [repo-id (er/repo-for-build-sid conn (:customer-id build) (:repo-id build))]
     (let [{:keys [id] :as ins} (ec/insert-build conn (-> (build->db build)
                                                          (assoc :repo-id repo-id)))]
-      (insert-jobs conn (-> build :script :jobs vals) id)
+      (when (contains? (:script build) :jobs)
+        (insert-jobs conn (-> build :script :jobs vals) id))
       ins)))
 
 (defn- update-build [conn build existing]

--- a/app/src/monkey/ci/web/api.clj
+++ b/app/src/monkey/ci/web/api.clj
@@ -236,7 +236,7 @@
   (if (st/save-build (c/rt->storage rt) build)
     (do
       (-> (rur/response (select-keys build [:build-id]))
-          (r/add-event (b/build-pending-evt build))
+          (r/add-event (b/build-triggered-evt build))
           (rur/status 202)))
     (-> (rur/response {:message "Unable to create build"})
         (rur/status 500))))

--- a/app/src/monkey/ci/web/api.clj
+++ b/app/src/monkey/ci/web/api.clj
@@ -198,31 +198,20 @@
   (some-fn (as-ref :branch "heads")
            (as-ref :tag "tags")))
 
-(defn- assign-build-id [build req]
-  (let [idx (st/find-next-build-idx (c/req->storage req) (c/repo-sid req))
-        bid (str "build-" idx)
-        build (assoc build :build-id bid)]
-    (-> build
-        (assoc :idx idx
-               :sid (st/ext-build-sid build)))))
-
 (defn- initialize-build [build rt]
   (assoc build
+         :id (st/new-id)
          :source :api
          :start-time (t/now)
-         :status :pending
-         :cleanup? (not (rt/dev-mode? rt))))
+         :status :pending))
 
 (defn make-build-ctx
   "Creates a build object from the request for the repo"
   [{p :parameters :as req} repo]
-  (let [acc (:path p)
-        {st :storage :as rt} (c/req->rt req)
-        ssh-keys (c/find-ssh-keys st repo)
-        {bid :build-id :as build} (-> acc
-                                      (select-keys [:customer-id :repo-id])
-                                      (assign-build-id req))]
-    (-> build
+  (let [{st :storage :as rt} (c/req->rt req)
+        ssh-keys (c/find-ssh-keys st repo)]
+    (-> (:path p)
+        (select-keys [:customer-id :repo-id])
         (initialize-build rt)
         (assoc :git (-> (:query p)
                         (select-keys [:commit-id :branch :tag])
@@ -232,14 +221,10 @@
                                        :ssh-keys ssh-keys
                                        :main-branch (:main-branch repo)))))))
 
-(defn- save-and-run-build [rt build]
-  (if (st/save-build (c/rt->storage rt) build)
-    (do
-      (-> (rur/response (select-keys build [:build-id]))
-          (r/add-event (b/build-triggered-evt build))
-          (rur/status 202)))
-    (-> (rur/response {:message "Unable to create build"})
-        (rur/status 500))))
+(defn- build-triggered-response [build]
+  (-> (rur/response (select-keys build [:id]))
+      (r/add-event (b/build-triggered-evt build))
+      (rur/status 202)))
 
 (defn trigger-build [req]
   (let [{p :parameters} req
@@ -249,7 +234,7 @@
         build (make-build-ctx req repo)]
     (log/debug "Triggering build for repo sid:" repo-sid)
     (if repo
-      (save-and-run-build (c/req->rt req) build)
+      (build-triggered-response build)
       (rur/not-found {:message "Repository does not exist"}))))
 
 (defn retry-build
@@ -259,11 +244,10 @@
         existing (st/find-build st (c/build-sid req))
         rt (c/req->rt req)
         build (some-> existing
-                      (dissoc :start-time :end-time :script)
-                      (assign-build-id req)
+                      (dissoc :start-time :end-time :script :build-id :idx)
                       (initialize-build rt))]
     (if build
-      (save-and-run-build rt build)
+      (build-triggered-response build)
       (rur/not-found {:message "Build not found"}))))
 
 (defn cancel-build

--- a/app/src/monkey/ci/web/bitbucket.clj
+++ b/app/src/monkey/ci/web/bitbucket.clj
@@ -211,7 +211,7 @@
       (let [build (make-build req wh)]
         (if (st/save-build st build)
           (-> (rur/response (select-keys build [:build-id]))
-              (r/add-event (b/build-pending-evt build))
+              (r/add-event (b/build-triggered-evt build))
               (rur/status 202))
           (-> (rur/response {:message "Unable to create build in database"})
               (rur/status 500))))

--- a/app/src/monkey/ci/web/bitbucket.clj
+++ b/app/src/monkey/ci/web/bitbucket.clj
@@ -183,18 +183,15 @@
 (defn- make-build [req {:keys [customer-id repo-id] :as wh}]
   (let [st (c/req->storage req)
         rsid [customer-id repo-id]
-        idx (st/find-next-build-idx st rsid)
-        build-id (c/new-build-id idx)
-        sid (conj rsid build-id)
         body (c/body req)
         repo (st/find-repo st rsid)
         ssh-keys (c/find-ssh-keys st repo)]
-    (-> (zipmap [:customer-id :repo-id :build-id] sid)
-        (assoc :sid sid
+    (-> (zipmap [:customer-id :repo-id] rsid)
+        (assoc :id (st/new-id)
+               :sid rsid ; Return repo sid, because build-id is only assigned in the build/triggered event handler
                :source :bitbucket-webhook
                :start-time (t/now)
                :status :pending
-               :idx idx
                ;; TODO Changed files
                :git (cond-> {:url (:url repo)
                              :ref (git-ref body)}
@@ -209,12 +206,9 @@
         wh (st/find-webhook st webhook-id)]
     (if wh
       (let [build (make-build req wh)]
-        (if (st/save-build st build)
-          (-> (rur/response (select-keys build [:build-id]))
-              (r/add-event (b/build-triggered-evt build))
-              (rur/status 202))
-          (-> (rur/response {:message "Unable to create build in database"})
-              (rur/status 500))))
+        (-> (rur/response (select-keys build [:id]))
+            (r/add-event (b/build-triggered-evt build))
+            (rur/status 202)))
       (c/error-response "Webhook not found" 404))))
 
 (defn- handle-unsupported [type]

--- a/app/src/monkey/ci/web/github.clj
+++ b/app/src/monkey/ci/web/github.clj
@@ -50,17 +50,16 @@
 
 (defn create-build
   "Looks up details for the given github webhook.  If the webhook refers to a valid 
-   configuration, a build entity is created and a build structure is returned, which
-   will be sent in a `build/triggered` event and eventually passed on to a runner."
+   configuration, a build structure is returned, which will be sent in a `build/triggered`
+   event and eventually passed on to a runner.  Creating the entity in the database is
+   up to the event handler, to ensure uniqueness of assigned ids."
   [{st :storage :as rt} {:keys [customer-id repo-id] :as init-build} payload]
   (let [{:keys [master-branch clone-url ssh-url private]} (:repository payload)
-        ;; TODO Ensure idx uniqueness over repo
-        idx (s/find-next-build-idx st [customer-id repo-id])
-        build-id (c/new-build-id idx)
         commit-id (get-in payload [:head-commit :id])
         ssh-keys (find-ssh-keys rt customer-id repo-id)
         build (-> init-build
-                  (assoc :git (-> payload
+                  (assoc :id (s/new-id)
+                         :git (-> payload
                                   :head-commit
                                   (select-keys [:message :author])
                                   (assoc :url (if private ssh-url clone-url)
@@ -72,12 +71,10 @@
                          ;; this is still the time of the last commit, not of the tag creation.
                          :start-time (u/now)
                          :status :pending
-                         :build-id build-id
-                         :idx idx
                          :changes (file-changes payload)))]
-    (when (s/save-build st build)
-      ;; Add the sid, cause it's used downstream
-      (assoc build :sid (s/ext-build-sid build)))))
+    ;; Add the sid, cause it's used downstream.  In this case it's the repo id, because
+    ;; the build id still needs to be assigned.
+    (assoc build :sid [customer-id repo-id])))
 
 (defn create-webhook-build [{st :storage :as rt} id payload]
   (if-let [details (s/find-webhook st id)]
@@ -114,7 +111,7 @@
   (if (should-trigger-build? req)
     (let [rt (c/req->rt req)]
       (if-let [build (create-webhook-build rt (get-in p [:path :id]) (body req))]
-        (-> (rur/response (select-keys build [:build-id]))
+        (-> (rur/response (select-keys build [:id]))
             (r/add-event (b/build-triggered-evt build))
             (rur/status 202))
         ;; No valid webhook found
@@ -123,7 +120,7 @@
     (rur/status 204)))
 
 (defn app-webhook [req]
-  (log/debug "Got github app webhook event:" (pr-str (body req)))
+  (log/trace "Got github app webhook event:" (pr-str (body req)))
   (log/debug "Event type:" (get-in req [:headers "x-github-event"]))
   (if (should-trigger-build? req)
     (let [github-id (get-in (body req) [:repository :id])
@@ -132,7 +129,7 @@
                              (create-app-build (c/req->rt req) repo (body req)))))]
       (log/debug "Found" (count builds) "watched builds for id" github-id)
       (-> builds
-          (as-> b (->> (map #(select-keys % [:build-id]) b)
+          (as-> b (->> (map #(select-keys % [:id]) b)
                        (hash-map :builds)))
           (rur/response)
           (r/add-events (map b/build-triggered-evt builds))

--- a/app/test/unit/monkey/ci/storage/sql_test.clj
+++ b/app/test/unit/monkey/ci/storage/sql_test.clj
@@ -1,22 +1,21 @@
 (ns monkey.ci.storage.sql-test
-  (:require
-   [clojure.spec.alpha :as spec]
-   [clojure.spec.gen.alpha :as gen]
-   [clojure.test :refer [deftest is testing]]
-   [medley.core :as mc]
-   [monkey.ci.build :as b]
-   [monkey.ci.cuid :as cuid]
-   [monkey.ci.entities.core :as ec]
-   [monkey.ci.entities.helpers :as eh]
-   [monkey.ci.protocols :as p]
-   [monkey.ci.sid :as sid]
-   [monkey.ci.spec.entities :as se]
-   [monkey.ci.spec.gen :as sg]
-   [monkey.ci.storage :as st]
-   [monkey.ci.storage.sql :as sut]
-   [monkey.ci.test.helpers :as h]
-   [monkey.ci.time :as t]
-   [monkey.ci.web.auth :as auth]))
+  (:require [clojure.spec.gen.alpha :as gen]
+            [clojure.test :refer [deftest is testing]]
+            [medley.core :as mc]
+            [monkey.ci
+             [build :as b]
+             [cuid :as cuid]
+             [protocols :as p]
+             [sid :as sid]
+             [storage :as st]
+             [time :as t]]
+            [monkey.ci.entities
+             [core :as ec]
+             [helpers :as eh]]
+            [monkey.ci.spec.gen :as sg]
+            [monkey.ci.storage.sql :as sut]
+            [monkey.ci.test.helpers :as h]
+            [monkey.ci.web.auth :as auth]))
 
 (defmacro with-storage [conn s & body]
   `(eh/with-prepared-db ~conn

--- a/app/test/unit/monkey/ci/web/api_test.clj
+++ b/app/test/unit/monkey/ci/web/api_test.clj
@@ -385,14 +385,15 @@
                      first
                      (f)))))]
       
-      (testing "posts build/pending event"
+      (testing "posts `build/triggered` event"
         (verify-response
          {}
          (fn [{:keys [response]}]
-           (is (= :build/pending (-> response
-                                     (r/get-events)
-                                     first
-                                     :type))))))
+           (is (= :build/triggered
+                  (-> response
+                      (r/get-events)
+                      first
+                      :type))))))
       
       (testing "looks up url in repo config"
         (with-repo

--- a/app/test/unit/monkey/ci/web/bitbucket_test.clj
+++ b/app/test/unit/monkey/ci/web/bitbucket_test.clj
@@ -255,7 +255,7 @@
         (let [evts (r/get-events resp)
               {:keys [git] :as build} (:build (first evts))]
           (is (= 1 (count evts)))
-          (is (= :build/pending (-> evts first :type)))
+          (is (= :build/triggered (-> evts first :type)))
           (is (spec/valid? ::sb/build build)
               (spec/explain-str ::sb/build build))
           (is (some? git) "contains git info")

--- a/app/test/unit/monkey/ci/web/bitbucket_test.clj
+++ b/app/test/unit/monkey/ci/web/bitbucket_test.clj
@@ -248,23 +248,21 @@
     (let [resp (sut/webhook req)]
       (is (= 202 (:status resp)))
 
-      (testing "returns build id"
-        (is (re-matches #"^build-\d+$" (get-in resp [:body :build-id]))))
+      (testing "returns id"
+        (is (cuid/cuid? (get-in resp [:body :id]))))
       
       (testing "triggers build for webhook"
         (let [evts (r/get-events resp)
               {:keys [git] :as build} (:build (first evts))]
           (is (= 1 (count evts)))
           (is (= :build/triggered (-> evts first :type)))
-          (is (spec/valid? ::sb/build build)
-              (spec/explain-str ::sb/build build))
+          (is (some? build))
           (is (some? git) "contains git info")
           (is (= "http://test-url" (:url git)))
           (is (= "refs/heads/main" (:ref git)))))
 
-      (testing "creates build in storage"
-        (let [b (st/find-build s [(:id cust) (:id repo) (get-in resp [:body :build-id])])]
-          (is (some? b)))))
+      (testing "does not create build in storage"
+        (is (nil? (st/find-build s [(:id cust) (:id repo) (get-in resp [:body :build-id])])))))
 
     (testing "adds configured encrypted ssh key matching repo labels"
       (let [iv (v/generate-iv)

--- a/app/test/unit/monkey/ci/web/github_test.clj
+++ b/app/test/unit/monkey/ci/web/github_test.clj
@@ -1,37 +1,44 @@
 (ns monkey.ci.web.github-test
-  (:require
-   [buddy.sign.jwt :as jwt]
-   [clojure.math :as cm]
-   [clojure.test :refer [deftest is testing]]
-   [monkey.ci.cuid :as cuid]
-   [monkey.ci.protocols :as p]
-   [monkey.ci.storage :as st]
-   [monkey.ci.test.aleph-test :as af]
-   [monkey.ci.test.helpers :as h]
-   [monkey.ci.test.runtime :as trt]
-   [monkey.ci.web.auth :as auth]
-   [monkey.ci.web.common :as wc]
-   [monkey.ci.web.github :as sut]
-   [monkey.ci.web.response :as r]
-   [ring.mock.request :as mock]))
+  (:require [buddy.sign.jwt :as jwt]
+            [clojure
+             [math :as cm]
+             [test :refer [deftest is testing]]]
+            [monkey.ci
+             [cuid :as cuid]
+             [protocols :as p]
+             [storage :as st]]
+            [monkey.ci.test
+             [aleph-test :as af]
+             [helpers :as h]
+             [runtime :as trt]]
+            [monkey.ci.web
+             [auth :as auth]
+             [github :as sut]
+             [response :as r]]))
 
 (deftest webhook
-  (testing "posts `build/triggered` event"
-    (let [cid (cuid/random-cuid)
-          {st :storage :as rt} (trt/test-runtime)
-          _ (st/save-webhook st {:id "test-hook"
-                                 :customer-id cid})
-          _ (st/save-customer-credit st {:customer-id cid
-                                         :amount 1000})
-          req (-> rt
-                  (h/->req)
-                  (assoc :headers {"x-github-event" "push"}
-                         :parameters {:path {:id "test-hook"}
-                                      :body
-                                      {:head-commit {:id "test-id"}}}))
-          resp (sut/webhook req)]
-      (is (= 202 (:status resp)))
-      (is (= [:build/triggered] (->> resp (r/get-events) (map :type))))))
+  (let [cid (cuid/random-cuid)
+        {st :storage :as rt} (trt/test-runtime)
+        _ (st/save-webhook st {:id "test-hook"
+                               :customer-id cid})
+        _ (st/save-customer-credit st {:customer-id cid
+                                       :amount 1000})
+        req (-> rt
+                (h/->req)
+                (assoc :headers {"x-github-event" "push"}
+                       :parameters {:path {:id "test-hook"}
+                                    :body
+                                    {:head-commit {:id "test-id"}}}))
+        resp (sut/webhook req)]
+    (is (= 202 (:status resp)))
+
+    (let [[evt :as evts] (->> resp (r/get-events))]
+      (testing "posts `build/triggered` event"
+        (is (= [:build/triggered] (map :type evts)))
+        (is (some? (:sid evt))))
+
+      (testing "does not store build in db yet"
+        (is (nil? (st/find-build st (:sid evt)))))))
 
   (testing "ignores non-push events"
     (let [req (-> (trt/test-runtime)
@@ -59,8 +66,7 @@
 
 (deftest app-webhook
   (testing "triggers build on push for watched repo"
-    (let [gid "test-id"
-          cid "test-cust"
+    (let [[gid cid] (repeatedly cuid/random-cuid)
           {s :storage :as rt} (trt/test-runtime)
           sid (st/watch-github-repo s {:customer-id cid
                                        :id "test-repo"
@@ -79,7 +85,7 @@
       (is (= [:build/triggered] (->> resp (r/get-events) (map :type))))))
 
   (testing "ignores non-push events"
-    (let [gid "test-id"
+    (let [gid (cuid/random-cuid)
           {s :storage :as rt} (trt/test-runtime)
           sid (st/watch-github-repo s {:customer-id "test-cust"
                                        :id "test-repo"
@@ -127,7 +133,7 @@
                  (:changes b))))))))
 
 (deftest create-webhook-build
-  (testing "creates build record for customer/repo"
+  (testing "does not create build record for customer/repo"
     (h/with-memory-store s
       (let [wh (test-webhook)]
         (is (st/sid? (st/save-webhook s wh)))
@@ -135,10 +141,10 @@
                                           (:id wh)
                                           {})]
           (is (some? r))
-          (is (p/obj-exists? s (-> wh
-                                   (select-keys [:customer-id :repo-id])
-                                   (assoc :build-id (:build-id r))
-                                   (st/build-sid))))))))
+          (is (not (p/obj-exists? s (-> wh
+                                        (select-keys [:customer-id :repo-id])
+                                        (assoc :build-id (:build-id r))
+                                        (st/build-sid)))))))))
 
   (testing "build contains commit message"
     (h/with-memory-store s
@@ -147,11 +153,9 @@
         (let [r (sut/create-webhook-build {:storage s}
                                           (:id wh)
                                           {:head-commit {:message "test message"}})
-              id (:sid r)
-              md (st/find-build s id)]
+              id (:sid r)]
           (is (st/sid? id))
-          (is (some? md))
-          (is (= "test message" (get-in md [:git :message])))))))
+          (is (= "test message" (get-in r [:git :message])))))))
 
   (testing "adds start time as current epoch millis"
     (h/with-memory-store s
@@ -159,12 +163,8 @@
         (is (st/sid? (st/save-webhook s wh)))
         (let [r (sut/create-webhook-build {:storage s}
                                           (:id wh)
-                                          {:head-commit {:timestamp "2023-10-10"}})
-              id (:sid r)
-              md (st/find-build s id)]
-          (is (st/sid? id))
-          (is (some? md))
-          (is (number? (:start-time md)))))))
+                                          {:head-commit {:timestamp "2023-10-10"}})]
+          (is (number? (:start-time r)))))))
   
   (testing "`nil` if no configured webhook found"
     (h/with-memory-store s
@@ -256,11 +256,9 @@
                    :private-key "encrypted-key"}]
                  (get-in r [:git :ssh-keys])))))))
 
-  (testing "assigns idx"
+  (testing "assigns id"
     (h/with-memory-store s
-      (let [wh (test-webhook)
-            cid (:customer-id wh)
-            rid (:repo-id wh)]
+      (let [{cid :customer-id rid :repo-id :as wh} (test-webhook)]
         (is (st/sid? (st/save-webhook s wh)))
         (is (st/sid? (st/save-repo s {:customer cid
                                       :id rid})))
@@ -268,8 +266,7 @@
                                           (:id wh)
                                           {:ref "test-ref"
                                            :repository {:master-branch "test-main"}})]
-          (is (number? (:idx r)))
-          (is (= (str "build-" (:idx r)) (:build-id r))))))))
+          (is (cuid/cuid? (:id r))))))))
 
 (defn- with-github-user
   "Sets up fake http communication with github to return the given user"

--- a/app/test/unit/monkey/ci/web/handler_test.clj
+++ b/app/test/unit/monkey/ci/web/handler_test.clj
@@ -787,13 +787,13 @@
           (is (= build-id (:build-id (first b))) "should contain build id")))))
   
   (testing "`POST /trigger`"
-    (testing "posts `build/pending` event"
+    (testing "posts `build/triggered` event"
       (with-repo
         (fn [{:keys [app path] :as ctx}]
           (is (= 202 (-> (mock/request :post (str path "/trigger"))
                          (app)
                          :status)))
-          (is (= [:build/pending]
+          (is (= [:build/triggered]
                  (->> ctx
                       (trt/get-mailman)
                       (tmm/get-posted)
@@ -833,6 +833,8 @@
               (is (not-empty l))
               (is (= 200 (:status l)))
               (is (= build-id (:build-id b)))))
+
+          (testing "retrieves build by cuid when no build-id given")
 
           (testing "404 when build does not exist"
             (let [sid (generate-build-sid)

--- a/gui/src/monkey/ci/gui/alerts.cljc
+++ b/gui/src/monkey/ci/gui/alerts.cljc
@@ -55,6 +55,12 @@
 (def builds-load-failed
   (error-msg "Failed to load builds"))
 
+(def build-trigger-success
+  (alert-msg :info (constantly "A new build has been triggered.")))
+
+(def build-trigger-failed
+  (error-msg "Failed to trigger a new build"))
+
 (def cust-search-failed
   (error-msg "Failed to search for customers"))
 

--- a/gui/src/monkey/ci/gui/repo/events.cljc
+++ b/gui/src/monkey/ci/gui/repo/events.cljc
@@ -118,15 +118,13 @@
  :repo/trigger-build--success
  (fn [db [_ {:keys [body]}]]
    (-> db
-       (db/set-alerts [{:type :info
-                        :message (str "Build " (:build-id body) " started.")}])
+       (db/set-alerts [(a/build-trigger-success)])
        (db/set-show-trigger-form nil))))
 
 (rf/reg-event-db
  :repo/trigger-build--failed
  (fn [db [_ err]]
-   (db/set-alerts db [{:type :danger
-                       :message (str "Could not start build: " (u/error-msg err))}])))
+   (db/set-alerts db [(a/build-trigger-failed err)])))
 
 (rf/reg-event-fx
  :repo/load+edit


### PR DESCRIPTION
A long pending issue was the uniqueness of build indices.  For user-friendliness, I have opted to use a numeric build index, which is unique to the repo.  This is also used to generate the build id, which, when combined with customer and repo ids, yields the globally unique build `sid` (from "storage id").

Since triggers are just http requests, and multiple can be received at once, by separate replicas, the uniqueness of this index is problematic.  Especially if you push multiple refs at once, this can be an issue.  This PR fixes that by moving the assignment of the build index (and also the creation of the build record) to the `build/triggered` handler, which is guaranteed to only be called once per event.  So each trigger launches a new `build/triggered`, which is then processed one by one by the server.

Note that this still does not fix the issue when multiple trigger events are handled by multiple replicas.  For this we still may have to resort to some table locking mechanism.  See #183 for more.