### PR TITLE
Use repo-indices table

### DIFF
--- a/app/src/monkey/ci/build.clj
+++ b/app/src/monkey/ci/build.clj
@@ -172,6 +172,9 @@
       ;; sid at this point is only repo sid, since the build id still needs to be assigned
       (assoc :sid [(:customer-id build) (:repo-id build)])))
 
+(defn build-pending-evt [build]
+  (with-build-evt :build/pending build))
+
 (defn build-init-evt [build]
   (with-build-evt :build/initializing build))
 

--- a/app/src/monkey/ci/spec/build.clj
+++ b/app/src/monkey/ci/spec/build.clj
@@ -38,7 +38,7 @@
 (s/def :job/memory int?)
 (s/def :job/cpus int?)
 (s/def :job/arch #{:arm :amd})
-(s/def :job/credit-multiplier int?)
+(s/def :job/credit-multiplier (s/with-gen int? #(gen/choose 1 10)))
 
 (s/def :job/command string?)
 (s/def :job/script (s/coll-of :job/command))

--- a/app/test/unit/monkey/ci/events/mailman/db_test.clj
+++ b/app/test/unit/monkey/ci/events/mailman/db_test.clj
@@ -179,7 +179,6 @@
                     (sut/set-credits 100M)
                     (sut/check-credits))]
         (validate-spec :entity/build (:build res))
-        (is (= :pending (get-in res [:build :status])))
         (is (= :build/pending (:type res)))))
 
     (testing "returns `build/end` event with status `error` if no credits available"

--- a/app/test/unit/monkey/ci/storage/sql_test.clj
+++ b/app/test/unit/monkey/ci/storage/sql_test.clj
@@ -350,6 +350,12 @@
                                            :from :jobs}))))
           (is (= jobs (-> (st/find-build s build-sid) :script :jobs)))))
 
+      (testing "when no jobs, leaves existing jobs as-is"
+        (is (sid/sid? (st/save-build s (update build :script dissoc jobs))))
+        (is (not-empty (-> (st/find-build s build-sid)
+                           :script
+                           :jobs)))) 
+
       (testing "can update jobs"
         (let [job (assoc (h/gen-job) :status :pending)
               jobs {(:id job) job}

--- a/app/test/unit/monkey/ci/storage/sql_test.clj
+++ b/app/test/unit/monkey/ci/storage/sql_test.clj
@@ -351,7 +351,7 @@
           (is (= jobs (-> (st/find-build s build-sid) :script :jobs)))))
 
       (testing "when no jobs, leaves existing jobs as-is"
-        (is (sid/sid? (st/save-build s (update build :script dissoc jobs))))
+        (is (sid/sid? (st/save-build s (update build :script dissoc :jobs))))
         (is (not-empty (-> (st/find-build s build-sid)
                            :script
                            :jobs)))) 

--- a/app/test/unit/monkey/ci/storage/sql_test.clj
+++ b/app/test/unit/monkey/ci/storage/sql_test.clj
@@ -152,6 +152,12 @@
       (testing "lists display ids"
         (is (= ["test-repo" "new-repo"] (st/list-repo-display-ids s (:id cust)))))
 
+      (testing "inserts repo-idx"
+        (let [r (ec/select-repo conn [:= :display-id (:id repo)])
+              ri (ec/select-repo-idx conn [:= :repo-id (:id r)])]
+          (is (some? ri))
+          (is (= 1 (:next-idx ri)))))
+
       (testing "delete repo"
         (is (true? (st/delete-repo s sid)))
         
@@ -387,11 +393,8 @@
           (is (some? (st/save-repo s repo)))
           (is (= 1 (st/find-next-build-idx s repo-sid))
               "initial index is one")
-          (is (some? (st/save-build s (-> (h/gen-build)
-                                          (assoc :customer-id (:id cust)
-                                                 :repo-id (:id repo)
-                                                 :idx 100)))))
-          (is (= 101 (st/find-next-build-idx s repo-sid)))))
+          (is (= 2 (st/find-next-build-idx s repo-sid))
+              "increases on each invocation")))
 
       (testing "can list builds since timestamp"
         (let [repo (h/gen-repo)

--- a/app/test/unit/monkey/ci/web/api_test.clj
+++ b/app/test/unit/monkey/ci/web/api_test.clj
@@ -27,31 +27,27 @@
       (throw (ex-info "Invalid event payload" {:event evt})))))
 
 (deftest create-repo
-  (testing "generates id from repo name"
-    (let [repo {:name "Test repo"
-                :customer-id (st/new-id)}
-          {st :storage :as rt} (trt/test-runtime)
-          r (-> rt
-                (h/->req)
-                (h/with-body repo)
-                (sut/create-repo)
-                :body)]
-      (is (= "test-repo" (:id r)))))
+  (let [repo {:name "Test repo"
+              :customer-id (st/new-id)}
+        {st :storage :as rt} (trt/test-runtime)]
+    
+    (testing "generates id from repo name"
+      (let [r (-> rt
+                  (h/->req)
+                  (h/with-body repo)
+                  (sut/create-repo)
+                  :body)]
+        (is (= "test-repo" (:id r)))))
 
-  (testing "on id collision, appends index"
-    (let [repo {:name "Test repo"
-                :customer-id (st/new-id)}
-          {st :storage :as rt} (trt/test-runtime)
-          _ (st/save-repo st (-> repo
-                                 (select-keys [:customer-id])
-                                 (assoc :id "test-repo"
-                                        :name "Existing repo")))
-          r (-> rt
-                (h/->req)
-                (h/with-body repo)
-                (sut/create-repo)
-                :body)]
-      (is (= "test-repo-2" (:id r))))))
+    (testing "on id collision, appends index"
+      (let [new-repo {:name "Test repo"
+                      :customer-id (:customer-id repo)}
+            r (-> rt
+                  (h/->req)
+                  (h/with-body new-repo)
+                  (sut/create-repo)
+                  :body)]
+        (is (= "test-repo-2" (:id r)))))))
 
 (deftest create-webhook
   (testing "assigns secret key"


### PR DESCRIPTION
The `repo-indices` table existed for a while, but was unused.  This PR updates the build id calculation to use this table, which keeps track of the max index for each repo.  Using `for-update` queries, this should work atomically.