### PR TITLE
Bugfix/class not found

### DIFF
--- a/app/deps.edn
+++ b/app/deps.edn
@@ -20,7 +20,7 @@
         com.github.seancorfield/honeysql {:mvn/version "2.6.1281"}
         com.github.seancorfield/next.jdbc {:mvn/version "1.3.1002"}
         com.monkeyprojects/aero-ext {:mvn/version "0.3.0"}
-        com.monkeyprojects/clompress {:mvn/version "0.1.2"}
+        com.monkeyprojects/clompress {:mvn/version "0.1.3-SNAPSHOT"}
         com.monkeyprojects/mailman-core {:mvn/version "0.2.5"}
         com.monkeyprojects/mailman-jms {:mvn/version "0.2.5"}
         com.monkeyprojects/mailman-manifold {:mvn/version "0.2.5"}
@@ -34,7 +34,7 @@
         dev.weavejester/ragtime {:mvn/version "0.11.0"}
         com.stuartsierra/component {:mvn/version "1.1.0"}
         com.taoensso/telemere {:mvn/version "1.0.0-RC4"}
-        commons-io/commons-io {:mvn/version "2.18.0"}
+        commons-io/commons-io {:mvn/version "2.19.0"}
         io.prometheus/prometheus-metrics-core {:mvn/version "1.3.6"}
         io.prometheus/prometheus-metrics-exporter-pushgateway {:mvn/version "1.3.6"}
         io.prometheus/prometheus-metrics-instrumentation-jvm {:mvn/version "1.3.6"}
@@ -109,6 +109,10 @@
   :agent
   ;; clj -M:agent
   {:main-opts ["-m" "monkey.ci.agent.main"]}
+
+  :agent/test
+  ;; clj -X:agent/test '{:config "config.edn" :event "event.edn"}'
+  {:exec-fn monkey.ci.agent.test/run-test}
 
   :jar
   {:extra-deps {com.monkeyprojects/build {:mvn/version "0.3.1"

--- a/app/src/monkey/ci/agent/events.clj
+++ b/app/src/monkey/ci/agent/events.clj
@@ -162,11 +162,12 @@
      :dir sd
      :out (log-file wd "out.log")
      :err (log-file wd "err.log")
-     :exit-fn (fn [{:keys [exit]}]
-                ;; TODO Clean up build files
-                (log/info "Build container exited with code:" exit)
-                (em/post-events (:mailman conf)
-                                [(b/build-end-evt build exit)]))}))
+     :exit-fn (p/exit-fn
+               (fn [{:keys [exit]}]
+                 ;; TODO Clean up build files
+                 (log/info "Build container exited with code:" exit)
+                 (em/post-events (:mailman conf)
+                                 [(b/build-end-evt build exit)])))}))
 
 ;;; Routing
 

--- a/app/src/monkey/ci/agent/main.clj
+++ b/app/src/monkey/ci/agent/main.clj
@@ -20,7 +20,7 @@
   (log/info "Starting build agent")
   (rc/with-system-async
     (ar/make-system conf)
-    (fn [{:keys [api-server] :as  sys}]
+    (fn [{:keys [api-server] :as sys}]
       (log/debug "API server started at port" (:port api-server))
       (waiter sys))))
 
@@ -30,3 +30,4 @@
                 (comp wh/on-server-close :api-server))
     (finally
       (log/info "Build agent terminated."))))
+

--- a/app/src/monkey/ci/agent/test.clj
+++ b/app/src/monkey/ci/agent/test.clj
@@ -1,0 +1,35 @@
+(ns monkey.ci.agent.test
+  "Test functionality provided to debug the class not found issue (github #269)"
+  (:require [clojure.tools.logging :as log]
+            [manifold.deferred :as md]
+            [monkey.ci.agent
+             [main :as am]
+             [runtime :as ar]]
+            [monkey.ci
+             [config :as c]
+             [edn :as edn]]
+            [monkey.ci.events.mailman :as em]
+            [monkey.ci.runtime.common :as rc]))
+
+(defn run-test
+  "Runs a test sequence by loading the given config and posting the specified
+   event (supposedly a `build/queued` type).  Waits for `build/end` and then 
+   exits."
+  [opts]
+  (let [conf (c/load-config-file (:config opts))
+        evt (edn/edn-> (slurp (:event opts)))]
+    (am/run-agent
+     conf
+     (fn [sys]
+       (let [done (md/deferred)
+             mm (:mailman sys)]
+         (em/add-router mm
+                        [[:build/end [{:handler (fn [evt]
+                                                  (log/debug "Got build/end, terminating")
+                                                  (md/success! done true)
+                                                  nil)}]]]
+                        {})
+         (log/info "Posting event:" evt)
+         (em/post-events mm [evt])
+         (log/info "Waiting for :build/end...")
+         done)))))

--- a/app/src/monkey/ci/blob.clj
+++ b/app/src/monkey/ci/blob.clj
@@ -3,7 +3,9 @@
    or entire directories."
   (:require [babashka.fs :as fs]
             [clj-commons.byte-streams :as bs]
-            [clojure.java.io :as io]
+            [clojure.java
+             [classpath :as cp]
+             [io :as io]]
             [clojure.string :as cs]
             [clojure.tools.logging :as log]
             [clompress.archivers :as ca]

--- a/app/src/monkey/ci/commands.clj
+++ b/app/src/monkey/ci/commands.clj
@@ -39,7 +39,7 @@
 (defn run-build-local
   "Run a build locally, normally from local source but can also be from a git checkout.
    Returns a deferred that will hold zero if the build succeeds, nonzero if it fails."
-  [{:keys [workdir dir] :as config}]
+  [{{:keys [workdir dir]} :args :as config}]
   (let [wd (fs/create-temp-dir) ; TODO Use subdir of current dir .monkeyci?
         cwd (u/cwd)
         build (cond-> {:checkout-dir (or (some->> workdir

--- a/app/src/monkey/ci/containers/podman.clj
+++ b/app/src/monkey/ci/containers/podman.clj
@@ -12,6 +12,7 @@
              [cache :as cache]
              [containers :as mcc]
              [jobs :as j]
+             [process :as proc]
              [protocols :as p]
              [utils :as u]
              [workspace :as ws]]
@@ -190,13 +191,14 @@
      :dir (job-work-dir ctx job)
      :out (log-file "out.log")
      :err (log-file "err.log")
-     :exit-fn (fn [{:keys [exit]}]
-                (log/info "Container job exited with code" exit)
-                (try
-                  (em/post-events (emi/get-mailman ctx)
-                                  [(job-executed-evt job-id sid (if (= 0 exit) bc/success bc/failure))])
-                  (catch Exception ex
-                    (log/error "Failed to post job/executed event" ex))))}))
+     :exit-fn (proc/exit-fn
+               (fn [{:keys [exit]}]
+                 (log/info "Container job exited with code" exit)
+                 (try
+                   (em/post-events (emi/get-mailman ctx)
+                                   [(job-executed-evt job-id sid (if (= 0 exit) bc/success bc/failure))])
+                   (catch Exception ex
+                     (log/error "Failed to post job/executed event" ex)))))}))
 
 (defn job-queued [ctx]
   (let [{:keys [job-id sid]} (:event ctx)]

--- a/app/src/monkey/ci/runners/runtime.clj
+++ b/app/src/monkey/ci/runners/runtime.clj
@@ -150,11 +150,15 @@
         (set))
    exclude-types))
 
+(defn- maybe-deref [x]
+  (cond-> x
+    (md/deferred? x) (deref)))
+
 (defn- broker-forwarder [evts-to-fwd dest]
   (fn [evt]
     (when (evts-to-fwd (:type evt))
       (log/debug "Forwarding event:" evt)
-      (when (empty? (em/post-events dest [evt]))
+      (when (empty? (maybe-deref (em/post-events dest [evt])))
         (log/warn "Unable to forward event:" evt)))
     nil))
 

--- a/app/test/unit/monkey/ci/agent/events_test.clj
+++ b/app/test/unit/monkey/ci/agent/events_test.clj
@@ -175,6 +175,7 @@
         (let [on-exit (:exit-fn cmd)]
           (is (fn? on-exit))
           (is (some? (on-exit {:exit 0})))
+          (is (not (= :timeout (h/wait-until #(not-empty (tm/get-posted broker)) 1000))))
           (is (= [:build/end]
                  (->> (tm/get-posted broker)
                       (map :type)))))))))

--- a/app/test/unit/monkey/ci/commands_test.clj
+++ b/app/test/unit/monkey/ci/commands_test.clj
@@ -37,8 +37,8 @@
   (testing "passes `workdir` as checkout dir and `dir` as script dir"
     (let [broker (tm/test-component)]
       (is (md/deferred? (sut/run-build-local {:mailman broker
-                                              :workdir "/test/dir"
-                                              :dir ".script"})))
+                                              :args {:workdir "/test/dir"
+                                                     :dir ".script"}})))
       (let [build (-> broker
                       :broker
                       (tm/get-posted)

--- a/app/test/unit/monkey/ci/local/events_test.clj
+++ b/app/test/unit/monkey/ci/local/events_test.clj
@@ -161,7 +161,8 @@
     (testing "exit fn fires `build/end`"
       (let [exit-fn (:exit-fn r)]
         (is (fn? exit-fn))
-        (is (some? (exit-fn ::process-result)))
+        (is (some? (exit-fn {:exit ::process-result})))
+        (is (not (= :timeout (h/wait-until #(not-empty (tm/get-posted mailman)) 1000))))
         (is (= [:build/end] (->> (tm/get-posted mailman)
                                  (map :type))))))))
 


### PR DESCRIPTION
Workaround for #269 , which seems to be caused by an issue in the `onExit` function in `java.lang.Process`.  Somehow the classloader inside that function is a different one, and many basic classes cannot be found.  As a workaround, we're using a `promise` and do the actual exit handling on `deliver`.