### PR TITLE
Feature/rename cust to org

### DIFF
--- a/app/env/dev/instances.clj
+++ b/app/env/dev/instances.clj
@@ -172,3 +172,10 @@
                          :branch branch
                          :sid (co/account->sid)}}]
         (runner (assoc rt :build build))))))
+
+(defn delete-stale
+  ([{:keys [containers]}]
+   (oci/delete-stale-instances (ci/make-context containers)
+                               (:compartment-id containers)))
+  ([]
+   (delete-stale @co/global-config)))

--- a/gui/src/monkey/ci/gui/admin.cljs
+++ b/gui/src/monkey/ci/gui/admin.cljs
@@ -39,8 +39,8 @@
     [:div.row.mb-5.mb-sm-5
      [action-card
       :piggy-bank
-      "Customer Credits"
-      "Manage recurring or one-time customer credits."
+      "Organization Credits"
+      "Manage recurring or one-time organization credits."
       "Manage credits"
       (r/path-for :admin/credits)]
 
@@ -75,9 +75,9 @@
   {:admin/root admin-root
    :admin/login login/page
    :admin/credits credits/overview
-   :admin/cust-credits credits/customer-credits
+   :admin/cust-credits credits/org-credits
    :admin/invoicing inv/page
-   :admin/cust-invoices inv/customer-invoices
+   :admin/cust-invoices inv/org-invoices
    :admin/clean-builds clean/page})
 
 (defn render-page [route]

--- a/gui/src/monkey/ci/gui/admin/credits/db.cljc
+++ b/gui/src/monkey/ci/gui/admin/credits/db.cljc
@@ -1,33 +1,33 @@
 (ns monkey.ci.gui.admin.credits.db
   (:require [monkey.ci.gui.loader :as lo]))
 
-(def cust-by-name ::cust-by-name)
-(def cust-by-id ::cust-by-id)
+(def org-by-name ::org-by-name)
+(def org-by-id ::org-by-id)
 (def issues ::issues)
 (def subscriptions ::subs)
 
-(defn get-customers-by-name [db]
-  (lo/get-value db cust-by-name))
+(defn get-orgs-by-name [db]
+  (lo/get-value db org-by-name))
 
-(defn get-customers-by-id [db]
-  (lo/get-value db cust-by-id))
+(defn get-orgs-by-id [db]
+  (lo/get-value db org-by-id))
 
-(defn get-customers [db]
-  (concat (get-customers-by-name db)
-          (get-customers-by-id db)))
+(defn get-orgs [db]
+  (concat (get-orgs-by-name db)
+          (get-orgs-by-id db)))
 
-(defn reset-customers [db]
+(defn reset-orgs [db]
   (-> db
-      (lo/set-value cust-by-name [])
-      (lo/set-value cust-by-id [])))
+      (lo/set-value org-by-name [])
+      (lo/set-value org-by-id [])))
 
-(defn customers-loading? [db]
-  (or (lo/loading? db cust-by-name)
-      (lo/loading? db cust-by-id)))
+(defn orgs-loading? [db]
+  (or (lo/loading? db org-by-name)
+      (lo/loading? db org-by-id)))
 
-(defn customers-loaded? [db]
-  (or (lo/loaded? db cust-by-name)
-      (lo/loaded? db cust-by-id)))
+(defn orgs-loaded? [db]
+  (or (lo/loaded? db org-by-name)
+      (lo/loaded? db org-by-id)))
 
 (defn get-issues [db]
   (lo/get-value db issues))

--- a/gui/src/monkey/ci/gui/admin/credits/views.cljs
+++ b/gui/src/monkey/ci/gui/admin/credits/views.cljs
@@ -41,7 +41,7 @@
           [:span.me-2 [co/icon :card-checklist]] "Issue All"]]]
        [:div.col-6
         [:p
-         "Here you can issue credits for all customers that have active subscriptions on the given date. "
+         "Here you can issue credits for all organizations that have active subscriptions on the given date. "
          "Only subscriptions that have become active on the same day of the month, and for which no existing "
          "credits exist are being processed."]]]
       [co/alerts [:credits/issue-all-alerts]]]]))
@@ -51,9 +51,9 @@
    [:<>
     [:h3 "Credit Management"]
     [:div.mt-3
-     [as/search-customers
-      {:get-route #(vector :admin/cust-credits {:customer-id (:id %)})
-       :init-view [:p.card-text "Search for a customer to manage their credits."]}]]
+     [as/search-orgs
+      {:get-route #(vector :admin/cust-credits {:org-id (:id %)})
+       :init-view [:p.card-text "Search for a org to manage their credits."]}]]
     [:div.mt-3
      [issue-all]]]])
 
@@ -108,7 +108,7 @@
   [:form
    {:on-submit (f/submit-handler [:credits/save-issue])}
    [form-input :amount "Credit amount" :number]
-   [form-input :reason "Reason" :text "Optional informational message for the customer."]
+   [form-input :reason "Reason" :text "Optional informational message for the org."]
    [form-input :from-time "Available from" :date "The date the credits become available for use."]
    [:div.d-flex.gap-2
     [issue-save-btn]
@@ -120,7 +120,7 @@
       [:div.card
        [:div.card-body
         [:h5 "Issue Credits"]
-        [:p "Create a new credit issuance for this customer.  One time only."]
+        [:p "Create a new credit issuance for this org.  One time only."]
         [issue-credits-form]]])))
 
 (defn- issue-credits-btn []
@@ -187,7 +187,7 @@
       [:div.card
        [:div.card-body
         [:h5 "Credit Subscription"]
-        [:p "Create a new repeating credit issuance subscription for this customer."]
+        [:p "Create a new repeating credit issuance subscription for this org."]
         [sub-credits-form]]])))
 
 (defn- subscriptions
@@ -214,14 +214,14 @@
      :contents [subscriptions cust-id]}]])
 
 (defn- title []
-  (let [cust (rf/subscribe [:customer/info])]
+  (let [cust (rf/subscribe [:org/info])]
     [:h3.mb-3 (:name @cust) ": Credit Overview"]))
 
-(defn customer-credits
-  "Displays credit overview for a single customer"
+(defn org-credits
+  "Displays credit overview for a single org"
   [route]
-  (let [cust-id (:customer-id (r/path-params route))]
-    (rf/dispatch [:customer/load cust-id])
+  (let [cust-id (:org-id (r/path-params route))]
+    (rf/dispatch [:org/load cust-id])
     (fn [route]
       [l/default
        [:<>

--- a/gui/src/monkey/ci/gui/admin/credits/views.cljs
+++ b/gui/src/monkey/ci/gui/admin/credits/views.cljs
@@ -10,8 +10,8 @@
             [monkey.ci.gui.admin.search :as as]
             [monkey.ci.gui.admin.credits.events]
             [monkey.ci.gui.admin.credits.subs]
-            [monkey.ci.gui.customer.events]
-            [monkey.ci.gui.customer.subs]
+            [monkey.ci.gui.org.events]
+            [monkey.ci.gui.org.subs]
             [re-frame.core :as rf]))
 
 (defn- issue-all

--- a/gui/src/monkey/ci/gui/admin/invoicing/views.cljs
+++ b/gui/src/monkey/ci/gui/admin/invoicing/views.cljs
@@ -10,16 +10,16 @@
   [l/default
    [:<>
     [:h3 "Invoicing"]
-    [as/search-customers
-     {:get-route #(vector :admin/cust-invoices {:customer-id (:id %)})
-      :init-view [:p.card-text "Search for a customer to view or manage their invoices."]}]]])
+    [as/search-orgs
+     {:get-route #(vector :admin/cust-invoices {:org-id (:id %)})
+      :init-view [:p.card-text "Search for an organization to view or manage its invoices."]}]]])
 
 (defn- title []
-  (let [cust (rf/subscribe [:customer/info])]
+  (let [cust (rf/subscribe [:org/info])]
     [:h3 (:name @cust) ": Invoices"]))
 
-(defn customer-invoices [route]
-  (rf/dispatch [:customer/maybe-load (r/customer-id route)])
+(defn org-invoices [route]
+  (rf/dispatch [:org/maybe-load (r/org-id route)])
   (fn [route]
     [l/default
      [:<>

--- a/gui/src/monkey/ci/gui/admin/invoicing/views.cljs
+++ b/gui/src/monkey/ci/gui/admin/invoicing/views.cljs
@@ -1,7 +1,7 @@
 (ns monkey.ci.gui.admin.invoicing.views
   (:require [monkey.ci.gui.admin.search :as as]
-            [monkey.ci.gui.customer.events]
-            [monkey.ci.gui.customer.subs]
+            [monkey.ci.gui.org.events]
+            [monkey.ci.gui.org.subs]
             [monkey.ci.gui.layout :as l]
             [monkey.ci.gui.routing :as r]
             [re-frame.core :as rf]))

--- a/gui/src/monkey/ci/gui/alerts.cljc
+++ b/gui/src/monkey/ci/gui/alerts.cljc
@@ -35,19 +35,19 @@
 (defn error-msg [msg]
   (alert-msg :danger #(str msg ": " (u/error-msg %))))
 
-(defn cust-details-failed [id]
+(defn org-details-failed [id]
   (error-msg (str "Could not load details for organization " id)))
 
-(def cust-fetch-github-repos
+(def org-fetch-github-repos
   (alert-msg :info (constantly "Fetching repositories from Github...")))
 
-(def cust-user-orgs-failed
+(def org-user-orgs-failed
   (error-msg "Unable to fetch user organizations from Github"))
 
-(def cust-github-repos-success
+(def org-github-repos-success
   (alert-msg :success #(str "Found " % " repositories in Github.")))
 
-(def cust-github-repos-failed
+(def org-github-repos-failed
   (alert-msg :danger
              (fn [err]
                [:<>
@@ -88,31 +88,31 @@
 (def build-retry-failed
   (error-msg "Unable to restart this build"))
 
-(def cust-search-failed
+(def org-search-failed
   (error-msg "Failed to search for organizations"))
 
-(def cust-create-success
+(def org-create-success
   (alert-msg :success (fn [body] [:span "Organization " [:b (:name body)] " has been created."])))
 
-(def cust-create-failed
+(def org-create-failed
   (error-msg "Failed to create organization"))
 
-(def cust-recent-builds-failed
+(def org-recent-builds-failed
   (error-msg "Failed to load recent builds"))
 
-(def cust-latest-builds-failed
+(def org-latest-builds-failed
   (error-msg "Failed to load latest builds"))
 
-(def cust-stats-failed
+(def org-stats-failed
   (error-msg "Failed to load statistics"))
 
-(def cust-credits-failed
+(def org-credits-failed
   (error-msg "Failed to load credit information"))
 
-(def cust-ssh-keys-failed
+(def org-ssh-keys-failed
   (error-msg "Failed to load SSH keys"))
 
-(def cust-save-ssh-keys-failed
+(def org-save-ssh-keys-failed
   (error-msg "Failed to save SSH keys"))
 
 (def admin-login-failed
@@ -147,3 +147,6 @@
 
 (def clean-proc-failed
   (error-msg "Failed to clean dangling processes"))
+
+(def user-load-orgs-failed
+  (error-msg "Could not retrieve linked organizations"))

--- a/gui/src/monkey/ci/gui/alerts.cljc
+++ b/gui/src/monkey/ci/gui/alerts.cljc
@@ -36,7 +36,7 @@
   (alert-msg :danger #(str msg ": " (u/error-msg %))))
 
 (defn cust-details-failed [id]
-  (error-msg (str "Could not load details for customer " id)))
+  (error-msg (str "Could not load details for organization " id)))
 
 (def cust-fetch-github-repos
   (alert-msg :info (constantly "Fetching repositories from Github...")))
@@ -89,13 +89,13 @@
   (error-msg "Unable to restart this build"))
 
 (def cust-search-failed
-  (error-msg "Failed to search for customers"))
+  (error-msg "Failed to search for organizations"))
 
 (def cust-create-success
-  (alert-msg :success (fn [body] [:span "Customer " [:b (:name body)] " has been created."])))
+  (alert-msg :success (fn [body] [:span "Organization " [:b (:name body)] " has been created."])))
 
 (def cust-create-failed
-  (error-msg "Failed to create customer"))
+  (error-msg "Failed to create organization"))
 
 (def cust-recent-builds-failed
   (error-msg "Failed to load recent builds"))

--- a/gui/src/monkey/ci/gui/apis/github.cljc
+++ b/gui/src/monkey/ci/gui/apis/github.cljc
@@ -38,7 +38,7 @@
  (fn [{:keys [db]} _]
    {:db (-> db
             (set-repos nil)
-            (set-alerts [(a/cust-fetch-github-repos)]))
+            (set-alerts [(a/org-fetch-github-repos)]))
     :dispatch-n [[::load-user-repos]
                  [::load-orgs]]}))
 
@@ -82,7 +82,7 @@
  ::load-orgs--failed
  (u/req-error-handler-db
   (fn [db [_ err]]
-    (set-alerts db [(a/cust-user-orgs-failed err)]))))
+    (set-alerts db [(a/org-user-orgs-failed err)]))))
 
 (rf/reg-event-db
  :github/load-repos--success
@@ -92,13 +92,13 @@
      (-> db
          ;; Add to existing repos since we're doing multiple calls
          (set-repos all)
-         (set-alerts [(a/cust-github-repos-success (count all))])))))
+         (set-alerts [(a/org-github-repos-success (count all))])))))
 
 (rf/reg-event-fx
  :github/load-repos--failed
  (u/req-error-handler-db
   (fn [db [_ err]]
-    (set-alerts db [(a/cust-github-repos-failed err)]))))
+    (set-alerts db [(a/org-github-repos-failed err)]))))
 
 (u/db-sub :github/alerts alerts)
 (u/db-sub :github/repos repos)

--- a/gui/src/monkey/ci/gui/breadcrumb.cljc
+++ b/gui/src/monkey/ci/gui/breadcrumb.cljc
@@ -1,6 +1,6 @@
 (ns monkey.ci.gui.breadcrumb
   (:require [medley.core :as mc]
-            [monkey.ci.gui.customer.db :as cdb]
+            [monkey.ci.gui.org.db :as cdb]
             [monkey.ci.gui.routing :as r]
             [monkey.ci.gui.utils :as u]
             [re-frame.core :as rf]))

--- a/gui/src/monkey/ci/gui/breadcrumb.cljc
+++ b/gui/src/monkey/ci/gui/breadcrumb.cljc
@@ -9,22 +9,22 @@
            :name "Home"})
 
 (defn default-breadcrumb [db]
-  (let [{:keys [customer-id repo-id build-id job-id] :as p} (r/path-params (r/current db))
-        ci (cdb/get-customer db)]
+  (let [{:keys [org-id repo-id build-id job-id] :as p} (r/path-params (r/current db))
+        ci (cdb/get-org db)]
     (cond-> [home]
-      customer-id
-      (conj {:url (r/path-for :page/customer (select-keys p [:customer-id]))
+      org-id
+      (conj {:url (r/path-for :page/org (select-keys p [:org-id]))
              :name (:name ci)})
       
       repo-id
-      (conj {:url (r/path-for :page/repo (select-keys p [:customer-id :repo-id]))
+      (conj {:url (r/path-for :page/repo (select-keys p [:org-id :repo-id]))
              :name (->> ci
                         :repos
                         (u/find-by-id repo-id)
                         :name)})
 
       build-id
-      (conj {:url (r/path-for :page/build (select-keys p [:customer-id :repo-id :build-id]))
+      (conj {:url (r/path-for :page/build (select-keys p [:org-id :repo-id :build-id]))
              :name build-id})
 
       job-id
@@ -33,12 +33,12 @@
 
 (defn- params-breadcrumb [db]
   (conj (default-breadcrumb db)
-        {:url (r/path-for :page/customer-params (r/path-params (r/current db)))
+        {:url (r/path-for :page/org-params (r/path-params (r/current db)))
          :name "Parameters"}))
 
 (defn- ssh-keys-breadcrumb [db]
   (conj (default-breadcrumb db)
-        {:url (r/path-for :page/customer-ssh-keys (r/path-params (r/current db)))
+        {:url (r/path-for :page/org-ssh-keys (r/path-params (r/current db)))
          :name "SSH Keys"}))
 
 (defn- repo-edit-breadcrumb [db]
@@ -66,8 +66,8 @@
 (def routes
   "Breadcrumb configuration per route.  If no match is found, the default behaviour
    is applied."
-  {:page/customer-params params-breadcrumb
-   :page/customer-ssh-keys ssh-keys-breadcrumb
+  {:page/org-params params-breadcrumb
+   :page/org-ssh-keys ssh-keys-breadcrumb
    :page/repo-edit repo-edit-breadcrumb
    :page/add-repo cust-watch-repo
    :admin/credits credits-breadcrumb

--- a/gui/src/monkey/ci/gui/build/db.cljc
+++ b/gui/src/monkey/ci/gui/build/db.cljc
@@ -4,7 +4,7 @@
 
 (def id ::build-id)
 
-(def params->sid (juxt :customer-id :repo-id :build-id))
+(def params->sid (juxt :org-id :repo-id :build-id))
 
 (def r->sid (comp params->sid r/path-params r/current))
 

--- a/gui/src/monkey/ci/gui/build/events.cljc
+++ b/gui/src/monkey/ci/gui/build/events.cljc
@@ -12,7 +12,7 @@
    (lo/on-initialize
     db (db/get-id db)
     {:init-events         [[:build/load]
-                           [:customer/maybe-load (r/customer-id db)]]
+                           [:org/maybe-load (r/org-id db)]]
      :leave-event         [:build/leave]
      :event-handler-event [:build/handle-event]})))
 
@@ -31,7 +31,7 @@
 (defn- same-build?
   "True if the build in db is the same as referred to by the current route"
   [db]
-  (let [id (juxt :customer-id :repo-id :build-id)]
+  (let [id (juxt :org-id :repo-id :build-id)]
     (= (id (r/path-params (r/current db)))
        (id (db/get-build db)))))
 
@@ -61,9 +61,9 @@
        (lo/on-success (db/get-id db) resp)
        ;; Override build with conversion
        (db/set-build (-> (convert-build build)
-                         ;; Also add customer and repo id because they don't come in the reply
+                         ;; Also add org and repo id because they don't come in the reply
                          (merge (select-keys (r/path-params (r/current db))
-                                             [:customer-id :repo-id])))))))
+                                             [:org-id :repo-id])))))))
 
 (rf/reg-event-db
  :build/load--failed
@@ -77,7 +77,7 @@
     :db (lo/set-loading db (db/get-id db))}))
 
 (defn- for-build? [db evt]
-  (let [get-id (juxt :customer-id :repo-id :build-id)]
+  (let [get-id (juxt :org-id :repo-id :build-id)]
     (= (:sid evt)
        (-> (r/current db)
            (r/path-params)

--- a/gui/src/monkey/ci/gui/components.cljc
+++ b/gui/src/monkey/ci/gui/components.cljc
@@ -32,7 +32,7 @@
 (def overview-icon
   [icon :house])
 
-(def customer-icon
+(def org-icon
   [icon :people-fill])
 
 (def repo-icon

--- a/gui/src/monkey/ci/gui/customer/views.cljs
+++ b/gui/src/monkey/ci/gui/customer/views.cljs
@@ -207,7 +207,7 @@
   (rf/dispatch [:customer/load-latest-builds])
   (let [c (rf/subscribe [:customer/info])]
     (if (empty? (:repos @c))
-      [:p "No repositories configured for this customer.  You can start by"
+      [:p "No repositories configured for this organization.  You can start by"
        [:a.mx-1 {:href (r/path-for :page/add-github-repo {:customer-id (:id @c)})} "watching one."]]
       [repos-list @c])))
 
@@ -222,7 +222,7 @@
     (let [loaded? (rf/subscribe [:loader/loaded? db/recent-builds])
           recent (rf/subscribe [:customer/recent-builds])]
       (if (and @loaded? (empty? @recent))
-        [with-recent-reload id "No recent builds found for this customer."]
+        [with-recent-reload id "No recent builds found for this organization."]
         [:<>
          (if @loaded?
            [with-recent-reload id "Recent builds for all repositories."]
@@ -239,7 +239,7 @@
              :loading {:sub [:loader/init-loading? db/recent-builds]}}]]]]))))
 
 (defn- overview-tabs
-  "Displays tab pages for various customer overview screens"
+  "Displays tab pages for various organization overview screens"
   [id]
   [tabs/tabs ::overview
    [{:id :overview
@@ -259,7 +259,7 @@
    [overview-tabs id]])
 
 (defn page
-  "Customer overview page"
+  "Organization overview page"
   [route]
   (let [id (-> route (r/path-params) :customer-id)]
     (rf/dispatch [:customer/init id])
@@ -348,7 +348,7 @@
        [:div.card-body
         [table]]]
       [:a {:href (r/path-for :page/customer (r/path-params @route))}
-       [:span.me-1 [co/icon :chevron-left]] "Back to customer"]])))
+       [:span.me-1 [co/icon :chevron-left]] "Back to organization"]])))
 
 (defn add-github-repo-page []
   (rf/dispatch [:github/load-repos])
@@ -364,18 +364,18 @@
   [add-repo-page nil bitbucket-repo-table])
 
 (defn page-new
-  "New customer page"
+  "New org page"
   []
   (l/default
    [:<>
-    [:h3 [customer-icon] "New Customer"]
+    [:h3 [customer-icon] "New Organization"]
     [:form.mb-3
      {:on-submit (f/submit-handler [:customer/create])}
      [:div.mb-3
       [:label.form-label {:for :name} "Name"]
       [:input#name.form-control {:aria-describedby :name-help :name :name}]
-      [:div#name-help.form-text "The customer name.  We recommend to make it as unique as possible."]]
+      [:div#name-help.form-text "The organization name.  We recommend to make it as unique as possible."]]
      [:div
-      [:button.btn.btn-primary.me-2 {:type :submit} [:span.me-2 [co/icon :save]] "Create Customer"]
+      [:button.btn.btn-primary.me-2 {:type :submit} [:span.me-2 [co/icon :save]] "Create Organization"]
       [co/cancel-btn [:route/goto :page/root]]]]
     [co/alerts [:customer/create-alerts]]]))

--- a/gui/src/monkey/ci/gui/home/db.cljc
+++ b/gui/src/monkey/ci/gui/home/db.cljc
@@ -3,10 +3,10 @@
 
 (def id ::home)
 
-(defn get-customers [db]
+(defn get-orgs [db]
   (lo/get-value db id))
 
-(defn set-customers [db c]
+(defn set-orgs [db c]
   (lo/set-value db id c))
 
 (defn get-alerts [db]
@@ -18,13 +18,13 @@
 (defn clear-alerts [db]
   (lo/reset-alerts db id))
 
-(def customer-searching? ::customer-searching?)
+(def org-searching? ::org-searching?)
 
-(defn set-customer-searching [db v]
-  (assoc db customer-searching? v))
+(defn set-org-searching [db v]
+  (assoc db org-searching? v))
 
-(defn reset-customer-searching [db]
-  (dissoc db customer-searching?))
+(defn reset-org-searching [db]
+  (dissoc db org-searching?))
 
 (def join-alerts ::join-alerts)
 
@@ -47,19 +47,19 @@
 (defn update-join-requests [db f & args]
   (apply update db join-requests f args))
 
-(defn customer-joining?
-  "Checks if we're in the process of sending a join request to the given customer."
+(defn org-joining?
+  "Checks if we're in the process of sending a join request to the given org."
   ([db cust-id]
-   (some? (when-let [ids (::customer-joining db)]
+   (some? (when-let [ids (::org-joining db)]
             (ids cust-id))))
   ([db]
-   (::customer-joining db)))
+   (::org-joining db)))
 
-(defn mark-customer-joining [db cust-id]
-  (update db ::customer-joining (fnil conj #{}) cust-id))
+(defn mark-org-joining [db cust-id]
+  (update db ::org-joining (fnil conj #{}) cust-id))
 
-(defn unmark-customer-joining [db cust-id]
-  (update db ::customer-joining disj cust-id))
+(defn unmark-org-joining [db cust-id]
+  (update db ::org-joining disj cust-id))
 
-(defn clear-customer-joining [db]
-  (dissoc db ::customer-joining))
+(defn clear-org-joining [db]
+  (dissoc db ::org-joining))

--- a/gui/src/monkey/ci/gui/home/subs.cljc
+++ b/gui/src/monkey/ci/gui/home/subs.cljc
@@ -4,29 +4,29 @@
             [monkey.ci.gui.utils :as u]
             [re-frame.core :as rf]))
 
-(u/db-sub :user/customers db/get-customers)
+(u/db-sub :user/orgs db/get-orgs)
 (u/db-sub :user/alerts db/get-alerts)
-(u/db-sub :customer/join-alerts db/join-alerts)
-(u/db-sub :customer/searching? (comp true? db/customer-searching?))
-(u/db-sub :customer/search-results db/search-results)
+(u/db-sub :org/join-alerts db/join-alerts)
+(u/db-sub :org/searching? (comp true? db/org-searching?))
+(u/db-sub :org/search-results db/search-results)
 (u/db-sub :user/join-requests db/join-requests)
 
 (rf/reg-sub
- :customer/joining?
+ :org/joining?
  (fn [db [_ cust-id]]
    (if cust-id
-     (db/customer-joining? db cust-id)
-     (or (db/customer-joining? db) #{}))))
+     (db/org-joining? db cust-id)
+     (or (db/org-joining? db) #{}))))
 
 (rf/reg-sub
- :customer/join-list
- :<- [:customer/search-results]
+ :org/join-list
+ :<- [:org/search-results]
  :<- [:login/user]
  :<- [:user/join-requests]
- :<- [:customer/joining?]
+ :<- [:org/joining?]
  (fn [[r u jr j?] _]
    (when r
-     (let [cust (set (:customers u))
+     (let [cust (set (:orgs u))
            mark-joined (fn [{:keys [id] :as c}]
                          (cond-> c
                            (cust id) (assoc :status :joined)

--- a/gui/src/monkey/ci/gui/home/views.cljs
+++ b/gui/src/monkey/ci/gui/home/views.cljs
@@ -12,12 +12,12 @@
 (defn- create-cust-btn []
   [:a.btn.btn-primary
    {:href (r/path-for :page/customer-new)}
-   [:span.me-2 [co/icon :plus-square]] "Create New Customer"])
+   [:span.me-2 [co/icon :plus-square]] "Create New Organization"])
 
 (defn- join-cust-btn []
   [:a.btn.btn-primary
    {:href (r/path-for :page/customer-join)}
-   [:span.me-2 [co/icon :arrow-right-square]] "Join Customer"])
+   [:span.me-2 [co/icon :arrow-right-square]] "Join Organization"])
 
 (defn- cust-item [{:keys [id name owner?]}]
   [:div.card
@@ -37,7 +37,7 @@
   [:div
    (->> (map cust-item cust)
         (into [:div.d-flex.gap-3.mb-3]))
-   [:p "You can join any number of customers, as long as a customer administrator approves your request."]
+   [:p "You can join any number of organizations, as long as an organization administrator approves your request."]
    [join-cust-btn]])
 
 ;; TODO Configure centrally somewhere
@@ -47,11 +47,11 @@
   (let [c (rf/subscribe [:user/customers])]
     (when @c
       [:<>
-       [:h3 [:span.me-2 co/overview-icon] "Your Linked Customers"]
-       [:p "Welcome! This screen shows all customers linked to your user account."]
+       [:h3 [:span.me-2 co/overview-icon] "Your Linked Organizations"]
+       [:p "Welcome! This screen shows all organizations linked to your user account."]
        (if (empty? @c)
          [:<>
-          [:p "No customers have been linked to your account yet.  You could either "
+          [:p "No organizations have been linked to your account yet.  You could either "
            [:a {:href (r/path-for :page/customer-new)} "create a new one"]
            " or "
            [:a {:href (r/path-for :page/customer-join)} "request to join an existing one"] "."]
@@ -59,11 +59,11 @@
            [:span.me-2 [create-cust-btn]]
            [join-cust-btn]]
           [:p
-           "You can create one customer per user account." [:b.mx-1 "Creating a customer is free,"]
-           "a credit card is not required.  Each customer gets" [:b.mx-1 free-credits " free credits"]
+           "You can create one organization per user account." [:b.mx-1 "Creating an organization is free,"]
+           "a credit card is not required.  Each organization gets" [:b.mx-1 free-credits " free credits"]
            "per month. "
            "One credit can be spent on one cpu minute, or one memory GB per minute. "
-           "You can join an unlimited number of customers.  See more details in "
+           "You can join an unlimited number of organizations.  See more details in "
            ;; TODO Make docs url configurable per env
            [:a {:href "https://docs.monkeyci.com" :target :_blank} "the documentation."]]]
          [linked-customers @c])])))
@@ -98,7 +98,7 @@
    {:on-submit (f/submit-handler [:customer/search])}
    [:div.row
     [:div.col
-     [:label.form-label {:for :customer-search} "Search customer"]
+     [:label.form-label {:for :customer-search} "Search organization"]
      [:input.form-control.mb-3
       {:id :customer-search
        :name :customer-search
@@ -118,7 +118,7 @@
   (case status
     :joined
     [:span.badge.text-bg-success
-     {:title "You have already joined this customer"}
+     {:title "You have already joined this organization"}
      "joined"]
     :pending
     [:span.badge.text-bg-warning
@@ -165,7 +165,7 @@
     [t/paged-table
      {:id :user/join-requests
       :items-sub [:user/join-requests]
-      :columns [{:label "Customer"
+      :columns [{:label "Organization"
                  :value (comp :name :customer)}
                 {:label "Status"
                  :value request-status}
@@ -184,7 +184,7 @@
          [join-requests-table]))]))
 
 (defn page-join
-  "Displays the 'join customer' page"
+  "Displays the 'join organization' page"
   []
   (rf/dispatch-sync [:customer/join-init])
   (fn []
@@ -193,10 +193,10 @@
       [:div.col-lg-6
        [:div.card
         [:div.card-body
-         [:h3.card-title "Join Existing Customer"]
+         [:h3.card-title "Join Existing Organization"]
          [:p
-          "On this page you can search for a customer and request to join it.  A user "
-          "with administrator permissions for that customer can approve your request."]
+          "On this page you can search for an organization and request to join it.  A user "
+          "with administrator permissions for that organization can approve your request."]
          [co/alerts [:customer/join-alerts]]
          [search-customer]
          [:div.mt-2

--- a/gui/src/monkey/ci/gui/labels.cljc
+++ b/gui/src/monkey/ci/gui/labels.cljc
@@ -136,7 +136,7 @@
                [:b.mx-1 "AND"])
              (str label " = " value)])]
     (if (empty? lf)
-      [:i "Applies to all builds for this customer."]
+      [:i "Applies to all builds for this organization."]
       [:<>
        [:i "Applies to all builds where:"]
        (->> lf

--- a/gui/src/monkey/ci/gui/loader.cljc
+++ b/gui/src/monkey/ci/gui/loader.cljc
@@ -130,7 +130,7 @@
       (update :dispatch-n (fnil conj []) [:route/on-page-leave leave-event])
 
       event-handler-event
-      (update :dispatch-n (fnil conj []) [:event-stream/start id (r/customer-id db) event-handler-event]))))
+      (update :dispatch-n (fnil conj []) [:event-stream/start id (r/org-id db) event-handler-event]))))
 
 (defn on-leave
   "Creates a context for an leave fx handler that clears the initialized flag

--- a/gui/src/monkey/ci/gui/login/events.cljc
+++ b/gui/src/monkey/ci/gui/login/events.cljc
@@ -77,9 +77,9 @@
       (and redir (not= "/" redir))
       ;; If a redirect path was stored, go there
       [:route/goto-path redir]
-      ;; If the user only has one customer, go directly there
+      ;; If the user only has one org, go directly there
       (= 1 (count (:customers user)))
-      [:route/goto :page/customer {:customer-id (first (:customers user))}]
+      [:route/goto :page/org {:org-id (first (:customers user))}]
       ;; Any other case, go to the root page
       :else
       [:route/goto :page/root])))

--- a/gui/src/monkey/ci/gui/martian.cljc
+++ b/gui/src/monkey/ci/gui/martian.cljc
@@ -9,31 +9,31 @@
             [re-frame.core :as rf]
             [schema.core :as s]))
 
-(def customer-path ["/customer/" :customer-id])
-(def repo-path (into customer-path ["/repo/" :repo-id]))
+(def org-path ["/customer/" :org-id])
+(def repo-path (into org-path ["/repo/" :repo-id]))
 (def build-path (into repo-path ["/builds/" :build-id]))
-(def param-path (into customer-path ["/param/" :param-id]))
+(def param-path (into org-path ["/param/" :param-id]))
 (def user-path ["/user/" :user-id])
 
-(def customer-schema
-  {:customer-id s/Str})
+(def org-schema
+  {:org-id s/Str})
 
 (def repo-schema
-  (assoc customer-schema
+  (assoc org-schema
          :repo-id s/Str))
 
 (def build-schema
   (assoc repo-schema :build-id s/Str))
 
 (def param-schema
-  (assoc customer-schema
+  (assoc org-schema
          :param-id s/Str))
 
 (def user-schema
   {:user-id s/Str})
 
 ;; TODO Use the same source as backend for this
-(s/defschema NewCustomer
+(s/defschema NewOrg
   {:name s/Str})
 
 (s/defschema Label
@@ -41,7 +41,7 @@
    :value s/Str})
 
 (s/defschema UpdateRepo
-  {:customer-id s/Str
+  {:org-id s/Str
    :name s/Str
    :url s/Str
    (s/optional-key :main-branch) s/Str
@@ -106,50 +106,50 @@
 
 (def routes
   [(api-route
-    {:route-name :get-customer
-     :path-parts customer-path
-     :path-schema customer-schema})
+    {:route-name :get-org
+     :path-parts org-path
+     :path-schema org-schema})
 
    (api-route
-    {:route-name :create-customer
+    {:route-name :create-org
      :method :post
-     :path-parts ["/customer"]
-     :body-schema {:customer NewCustomer}})
+     :path-parts ["/org"]
+     :body-schema {:org NewOrg}})
 
    (api-route
-    {:route-name :search-customers
-     :path-parts ["/customer"]
+    {:route-name :search-orgs
+     :path-parts ["/org"]
      :query-schema {(s/optional-key :name) s/Str
                     (s/optional-key :id) s/Str}})
 
    (api-route
     {:route-name :get-recent-builds
-     :path-parts (into customer-path ["/builds/recent"])
-     :path-schema customer-schema
+     :path-parts (into org-path ["/builds/recent"])
+     :path-schema org-schema
      :query-schema {(s/optional-key :since) s/Int
                     (s/optional-key :n) s/Int}})
 
    (api-route
-    {:route-name :get-customer-latest-builds
-     :path-parts (into customer-path ["/builds/latest"])
-     :path-schema customer-schema})
+    {:route-name :get-org-latest-builds
+     :path-parts (into org-path ["/builds/latest"])
+     :path-schema org-schema})
 
    (api-route
-    {:route-name :get-customer-params
-     :path-parts (into customer-path ["/param"])
-     :path-schema customer-schema})
+    {:route-name :get-org-params
+     :path-parts (into org-path ["/param"])
+     :path-schema org-schema})
 
    (api-route
-    {:route-name :update-customer-params
-     :path-parts (into customer-path ["/param"])
-     :path-schema customer-schema
+    {:route-name :update-org-params
+     :path-parts (into org-path ["/param"])
+     :path-schema org-schema
      :method :post
      :body-schema {:params [UpdateParamSet]}})
 
    (api-route
     {:route-name :create-param-set
-     :path-parts (into customer-path ["/param"])
-     :path-schema customer-schema
+     :path-parts (into org-path ["/param"])
+     :path-schema org-schema
      :method :post
      :body-schema {:params NewParamSet}})
 
@@ -167,41 +167,41 @@
      :method :delete})
 
    (api-route
-    {:route-name :get-customer-ssh-keys
-     :path-parts (into customer-path ["/ssh-keys"])
-     :path-schema customer-schema})
+    {:route-name :get-org-ssh-keys
+     :path-parts (into org-path ["/ssh-keys"])
+     :path-schema org-schema})
 
    (api-route
-    {:route-name :update-customer-ssh-keys
-     :path-parts (into customer-path ["/ssh-keys"])
-     :path-schema customer-schema
+    {:route-name :update-org-ssh-keys
+     :path-parts (into org-path ["/ssh-keys"])
+     :path-schema org-schema
      :method :put
      :body-schema {:ssh-keys [SshKey]}})
 
    (api-route
-    {:route-name :get-customer-stats
-     :path-parts (into customer-path ["/stats"])
-     :path-schema customer-schema
+    {:route-name :get-org-stats
+     :path-parts (into org-path ["/stats"])
+     :path-schema org-schema
      :query-schema {(s/optional-key :since) s/Int
                     (s/optional-key :until) s/Int}
      :method :get})
 
    (api-route
-    {:route-name :get-customer-credits
-     :path-parts (into customer-path ["/credits"])
-     :path-schema customer-schema
+    {:route-name :get-org-credits
+     :path-parts (into org-path ["/credits"])
+     :path-schema org-schema
      :method :get})
 
    (api-route
     {:route-name :get-credit-issues
-     :path-parts ["/admin/credits/" :customer-id]
-     :path-schema customer-schema
+     :path-parts ["/admin/credits/" :org-id]
+     :path-schema org-schema
      :method :get})
 
    (api-route
     {:route-name :create-credit-issue
-     :path-parts ["/admin/credits/" :customer-id "/issue"]
-     :path-schema customer-schema
+     :path-parts ["/admin/credits/" :org-id "/issue"]
+     :path-schema org-schema
      :body-schema {:credits UserCredits}
      :method :post})
 
@@ -213,19 +213,19 @@
 
    (api-route
     {:route-name :get-credit-subs
-     :path-parts ["/admin/credits/" :customer-id "/subscription"]
-     :path-schema customer-schema
+     :path-parts ["/admin/credits/" :org-id "/subscription"]
+     :path-schema org-schema
      :method :get})
 
    (api-route
     {:route-name :create-credit-sub
-     :path-parts ["/admin/credits/" :customer-id "/subscription"]
-     :path-schema customer-schema
+     :path-parts ["/admin/credits/" :org-id "/subscription"]
+     :path-schema org-schema
      :body-schema {:sub CreditSubscription}
      :method :post})
 
    (api-route
-    {:route-name :get-user-customers
+    {:route-name :get-user-orgs
      :path-parts (into user-path ["/customers"])
      :path-schema user-schema})
 
@@ -240,7 +240,7 @@
      :path-parts (into user-path "/join-request")
      :path-schema user-schema
      :body-schema {:join-request
-                   {:customer-id s/Str}}})
+                   {:org-id s/Str}}})
 
    (api-route
     {:route-name :get-repo
@@ -294,44 +294,44 @@
 
    (api-route
     {:route-name :download-log
-     :path-parts ["/logs/" :customer-id "/entries"]
-     :path-schema customer-schema
+     :path-parts ["/logs/" :org-id "/entries"]
+     :path-schema org-schema
      :query-schema log-query-schema
      :produces #{"application/json"}})
 
    (api-route
     {:route-name :get-log-stats
-     :path-parts ["/logs/" :customer-id "/stats"]
-     :path-schema customer-schema
+     :path-parts ["/logs/" :org-id "/stats"]
+     :path-schema org-schema
      :query-schema log-query-schema
      :produces #{"application/json"}})
 
    (api-route
     {:route-name :get-log-label-values
-     :path-parts ["/logs/" :customer-id "/label/" :label "/values"]
-     :path-schema (assoc customer-schema :label s/Str)
+     :path-parts ["/logs/" :org-id "/label/" :label "/values"]
+     :path-schema (assoc org-schema :label s/Str)
      :query-schema log-query-schema
      :produces #{"application/json"}})
    
    (api-route
     {:route-name :watch-github-repo
      :method :post
-     :path-parts (conj customer-path "/repo/github/watch")
-     :path-schema customer-schema
+     :path-parts (conj org-path "/repo/github/watch")
+     :path-schema org-schema
      :body-schema {:repo {:name s/Str
                           :url s/Str
-                          :customer-id s/Str
+                          :org-id s/Str
                           :github-id s/Int}}
      :consumes ["application/edn"]})
 
    (api-route
     {:route-name :watch-bitbucket-repo
      :method :post
-     :path-parts (conj customer-path "/repo/bitbucket/watch")
-     :path-schema customer-schema
+     :path-parts (conj org-path "/repo/bitbucket/watch")
+     :path-schema org-schema
      :body-schema {:repo {:name s/Str
                           :url s/Str
-                          :customer-id s/Str
+                          :org-id s/Str
                           :workspace s/Str
                           :repo-slug s/Str
                           :token s/Str}}
@@ -352,8 +352,8 @@
 
    (api-route
     {:route-name :search-bitbucket-webhooks
-     :path-parts (conj customer-path "/webhook/bitbucket")
-     :path-schema customer-schema
+     :path-parts (conj org-path "/webhook/bitbucket")
+     :path-schema org-schema
      :query-schema {(s/optional-key :repo-id) s/Str
                     (s/optional-key :workspace) s/Str
                     (s/optional-key :repo-slug) s/Str

--- a/gui/src/monkey/ci/gui/org/db.cljc
+++ b/gui/src/monkey/ci/gui/org/db.cljc
@@ -1,25 +1,25 @@
 (ns monkey.ci.gui.org.db
   (:require [monkey.ci.gui.loader :as lo]))
 
-(def customer ::customer)
+(def org ::org)
 
-(defn set-customer [db i]
-  (lo/set-value db customer i))
+(defn set-org [db i]
+  (lo/set-value db org i))
 
-(defn get-customer [db]
-  (lo/get-value db customer))
+(defn get-org [db]
+  (lo/get-value db org))
 
 (defn get-alerts [db]
-  (lo/get-alerts db customer))
+  (lo/get-alerts db org))
 
 (defn set-alerts [db a]
-  (lo/set-alerts db customer a))
+  (lo/set-alerts db org a))
 
-(defn update-customer [db f & args]
-  (apply lo/update-value db customer f args))
+(defn update-org [db f & args]
+  (apply lo/update-value db org f args))
 
 (defn replace-repo
-  "Updates customer repos by replacing the existing repo with the same id."
+  "Updates org repos by replacing the existing repo with the same id."
   [db updated-repo]
   (letfn [(replace-with [repos]
             (if-let [match (->> repos
@@ -27,7 +27,7 @@
                                 (first))]
               (replace {match updated-repo} repos)
               (conj repos updated-repo)))]
-    (update-customer db update :repos replace-with)))
+    (update-org db update :repos replace-with)))
 
 (def repo-alerts ::repo-alerts)
 
@@ -37,13 +37,13 @@
 (defn reset-repo-alerts [db]
   (dissoc db repo-alerts))
 
-(def customer-creating? ::customer-creating)
+(def org-creating? ::org-creating)
 
-(defn mark-customer-creating [db]
-  (assoc db customer-creating? true))
+(defn mark-org-creating [db]
+  (assoc db org-creating? true))
 
-(defn unmark-customer-creating [db]
-  (dissoc db customer-creating?))
+(defn unmark-org-creating [db]
+  (dissoc db org-creating?))
 
 (def create-alerts ::create-alerts)
 

--- a/gui/src/monkey/ci/gui/org/db.cljc
+++ b/gui/src/monkey/ci/gui/org/db.cljc
@@ -1,4 +1,4 @@
-(ns monkey.ci.gui.customer.db
+(ns monkey.ci.gui.org.db
   (:require [monkey.ci.gui.loader :as lo]))
 
 (def customer ::customer)

--- a/gui/src/monkey/ci/gui/org/events.cljc
+++ b/gui/src/monkey/ci/gui/org/events.cljc
@@ -1,10 +1,10 @@
-(ns monkey.ci.gui.customer.events
+(ns monkey.ci.gui.org.events
   (:require [medley.core :as mc]
             [monkey.ci.gui.alerts :as a]
             [monkey.ci.gui.home.db :as hdb]
             [monkey.ci.gui.logging :as log]
             [monkey.ci.gui.martian]
-            [monkey.ci.gui.customer.db :as db]
+            [monkey.ci.gui.org.db :as db]
             [monkey.ci.gui.loader :as lo]
             [monkey.ci.gui.login.db :as ldb]
             [monkey.ci.gui.routing :as r]

--- a/gui/src/monkey/ci/gui/org/subs.cljc
+++ b/gui/src/monkey/ci/gui/org/subs.cljc
@@ -1,8 +1,8 @@
-(ns monkey.ci.gui.customer.subs
+(ns monkey.ci.gui.org.subs
   (:require [clojure.string :as cs]
             [monkey.ci.gui.apis.bitbucket]
             [monkey.ci.gui.apis.github]
-            [monkey.ci.gui.customer.db :as db]
+            [monkey.ci.gui.org.db :as db]
             [monkey.ci.gui.loader :as lo]
             [monkey.ci.gui.utils :as u]
             [re-frame.core :as rf]))

--- a/gui/src/monkey/ci/gui/org/subs.cljc
+++ b/gui/src/monkey/ci/gui/org/subs.cljc
@@ -7,39 +7,39 @@
             [monkey.ci.gui.utils :as u]
             [re-frame.core :as rf]))
 
-(u/db-sub :customer/create-alerts db/create-alerts)
-(u/db-sub :customer/creating? db/customer-creating?)
-(u/db-sub :customer/group-by-lbl db/get-group-by-lbl)
-(u/db-sub :customer/repo-filter db/get-repo-filter)
-(u/db-sub :customer/ext-repo-filter db/get-ext-repo-filter)
-(u/db-sub :customer/bb-webhooks db/bb-webhooks)
+(u/db-sub :org/create-alerts db/create-alerts)
+(u/db-sub :org/creating? db/org-creating?)
+(u/db-sub :org/group-by-lbl db/get-group-by-lbl)
+(u/db-sub :org/repo-filter db/get-repo-filter)
+(u/db-sub :org/ext-repo-filter db/get-ext-repo-filter)
+(u/db-sub :org/bb-webhooks db/bb-webhooks)
 
 (rf/reg-sub
- :customer/info
- :<- [:loader/value db/customer]
+ :org/info
+ :<- [:loader/value db/org]
  identity)
 
 (rf/reg-sub
- :customer/loading?
- :<- [:loader/loading? db/customer]
+ :org/loading?
+ :<- [:loader/loading? db/org]
  identity)
 
 (rf/reg-sub
- :customer/alerts
+ :org/alerts
  (fn [db _]
    (db/get-alerts db)))
 
 (rf/reg-sub
- :customer/repos
- :<- [:customer/info]
+ :org/repos
+ :<- [:org/info]
  (fn [ci _]
    (:repos ci)))
 
 (rf/reg-sub
- :customer/github-repos
- :<- [:customer/repos]
+ :org/github-repos
+ :<- [:org/repos]
  :<- [:github/repos]
- :<- [:customer/ext-repo-filter]
+ :<- [:org/ext-repo-filter]
  (fn [[cr gr f] _]
    (letfn [(watched-repo [r]
              (->> cr
@@ -62,10 +62,10 @@
           (sort-by :name)))))
 
 (rf/reg-sub
- :customer/bitbucket-repos
+ :org/bitbucket-repos
  :<- [:bitbucket/repos]
- :<- [:customer/ext-repo-filter]
- :<- [:customer/bb-webhooks]
+ :<- [:org/ext-repo-filter]
+ :<- [:org/bb-webhooks]
  (fn [[r ef wh] _]
    (let [wh-by-id (group-by (juxt :workspace :repo-slug) wh)
          watched? (->> (keys wh-by-id)
@@ -85,8 +85,8 @@
             (sort-by :name))))))
 
 (rf/reg-sub
- :customer/recent-builds
- :<- [:loader/value db/customer]
+ :org/recent-builds
+ :<- [:loader/value db/org]
  :<- [:loader/value db/recent-builds]
  (fn [[cust rb] _]
    (let [repos (->> cust
@@ -100,19 +100,19 @@
           (map add-repo)))))
 
 (rf/reg-sub
- :customer/stats
+ :org/stats
  :<- [:loader/value db/stats]
  identity)
 
 (rf/reg-sub
- :customer/credits
+ :org/credits
  :<- [:loader/value db/credits]
  identity)
 
 (rf/reg-sub
- :customer/credit-stats
- :<- [:customer/stats]
- :<- [:customer/credits]
+ :org/credit-stats
+ :<- [:org/stats]
+ :<- [:org/credits]
  (fn [[stats creds] _]
    (when (and stats creds)
      {:available (:available creds)
@@ -121,8 +121,8 @@
                      (reduce + 0))})))
 
 (rf/reg-sub
- :customer/labels
- :<- [:customer/info]
+ :org/labels
+ :<- [:org/info]
  (fn [cust _]
    (->> cust
         :repos
@@ -139,10 +139,10 @@
          :value)))
 
 (rf/reg-sub
- :customer/grouped-repos
- :<- [:customer/repos]
- :<- [:customer/group-by-lbl]
- :<- [:customer/repo-filter]
+ :org/grouped-repos
+ :<- [:org/repos]
+ :<- [:org/group-by-lbl]
+ :<- [:org/repo-filter]
  (fn [[repos lbl rf] _]
    (letfn [(matches-filter? [{:keys [name]}]
              (or (empty? rf)
@@ -155,13 +155,13 @@
 (u/db-sub ::repo-alerts db/repo-alerts)
 
 (rf/reg-sub
- :customer/repo-alerts
+ :org/repo-alerts
  :<- [::repo-alerts]
  :<- [:github/alerts]
  (fn [[ra ga] _]
    (concat ra ga)))
 
 (rf/reg-sub
- :customer/latest-build
+ :org/latest-build
  (fn [db [_ repo-id]]
    (get (db/get-latest-builds db) repo-id)))

--- a/gui/src/monkey/ci/gui/org/views.cljs
+++ b/gui/src/monkey/ci/gui/org/views.cljs
@@ -1,10 +1,9 @@
-(ns monkey.ci.gui.customer.views
+(ns monkey.ci.gui.org.views
   (:require [monkey.ci.gui.charts :as charts]
-            [monkey.ci.gui.colors :as colors]
             [monkey.ci.gui.components :as co]
-            [monkey.ci.gui.customer.db :as db]
-            [monkey.ci.gui.customer.events]
-            [monkey.ci.gui.customer.subs]
+            [monkey.ci.gui.org.db :as db]
+            [monkey.ci.gui.org.events]
+            [monkey.ci.gui.org.subs]
             [monkey.ci.gui.forms :as f]
             [monkey.ci.gui.apis.bitbucket]
             [monkey.ci.gui.apis.github]

--- a/gui/src/monkey/ci/gui/pages.cljc
+++ b/gui/src/monkey/ci/gui/pages.cljc
@@ -18,11 +18,11 @@
    :page/login login/page
    :page/github-callback login/github-callback
    :page/bitbucket-callback login/bitbucket-callback
-   :page/customer org/page
-   :page/customer-new org/page-new
-   :page/customer-join home/page-join
-   :page/customer-params params/page
-   :page/customer-ssh-keys ssh-keys/page
+   :page/org org/page
+   :page/org-new org/page-new
+   :page/org-join home/page-join
+   :page/org-params params/page
+   :page/org-ssh-keys ssh-keys/page
    :page/add-github-repo org/add-github-repo-page
    :page/add-bitbucket-repo org/add-bitbucket-repo-page
    :page/repo repo/page

--- a/gui/src/monkey/ci/gui/pages.cljc
+++ b/gui/src/monkey/ci/gui/pages.cljc
@@ -1,15 +1,14 @@
 (ns ^:dev/always monkey.ci.gui.pages
   "Links route names to actual components to be rendered"
   (:require [monkey.ci.gui.logging :as log]
-            [monkey.ci.gui.login.views :as login]
-            [monkey.ci.gui.login.subs]
+            [monkey.ci.gui.routing :as r]
             [monkey.ci.gui.build.views :as build]
-            [monkey.ci.gui.job.views :as job]
-            [monkey.ci.gui.customer.views :as customer]
+            [monkey.ci.gui.org.views :as org]
             [monkey.ci.gui.home.views :as home]
+            [monkey.ci.gui.job.views :as job]
+            [monkey.ci.gui.login.views :as login]
             [monkey.ci.gui.params.views :as params]
             [monkey.ci.gui.repo.views :as repo]
-            [monkey.ci.gui.routing :as r]
             [monkey.ci.gui.ssh-keys.views :as ssh-keys]
             [re-frame.core :as rf]))
 
@@ -19,13 +18,13 @@
    :page/login login/page
    :page/github-callback login/github-callback
    :page/bitbucket-callback login/bitbucket-callback
-   :page/customer customer/page
-   :page/customer-new customer/page-new
+   :page/customer org/page
+   :page/customer-new org/page-new
    :page/customer-join home/page-join
    :page/customer-params params/page
    :page/customer-ssh-keys ssh-keys/page
-   :page/add-github-repo customer/add-github-repo-page
-   :page/add-bitbucket-repo customer/add-bitbucket-repo-page
+   :page/add-github-repo org/add-github-repo-page
+   :page/add-bitbucket-repo org/add-bitbucket-repo-page
    :page/repo repo/page
    :page/repo-edit repo/edit
    :page/job job/page})

--- a/gui/src/monkey/ci/gui/params/events.cljc
+++ b/gui/src/monkey/ci/gui/params/events.cljc
@@ -12,14 +12,14 @@
 
 (rf/reg-event-fx
  :params/load
- (fn [{:keys [db]} [_ cust-id]]
+ (fn [{:keys [db]} [_ org-id]]
    {:db (-> db
             (db/mark-loading)
             (db/clear-alerts)
             (db/clear-editing))
     :dispatch [:secure-request
-               :get-customer-params
-               {:customer-id cust-id}
+               :get-org-params
+               {:org-id org-id}
                [:params/load--success]
                [:params/load--failed]]}))
 
@@ -35,7 +35,7 @@
  (fn [db [_ err]]
    (-> db
        (db/set-alerts [{:type :danger
-                        :message (str "Failed to load customer params: " (u/error-msg err))}])
+                        :message (str "Failed to load organization params: " (u/error-msg err))}])
        (db/unmark-loading))))
 
 (def new-set? (comp (some-fn nil? db/temp-id?) :id))
@@ -70,7 +70,7 @@
  (fn [{:keys [db]} [_ id]]
    {:dispatch [:secure-request
                :delete-param-set
-               {:customer-id (r/customer-id db)
+               {:org-id (r/org-id db)
                 :param-id id}
                [:params/delete-set--success id]
                [:params/delete-set--failed id]]
@@ -110,7 +110,7 @@
  :params/cancel-all
  (fn [{:keys [db]} _]
    {:db (db/clear-editing db)
-    :dispatch [:route/goto :page/customer {:customer-id (r/customer-id db)}]}))
+    :dispatch [:route/goto :page/org {:org-id (r/org-id db)}]}))
 
 (rf/reg-event-db
  :params/description-changed
@@ -137,7 +137,7 @@
      (log/debug "Saving parameter set:" (str param))
      {:dispatch [:secure-request
                  (if new? :create-param-set :update-param-set)
-                 (cond-> {:customer-id (r/customer-id db)
+                 (cond-> {:org-id (r/org-id db)
                           :params param}
                    (not new?) (assoc :param-id id)
                    new? (update :params dissoc :id))

--- a/gui/src/monkey/ci/gui/params/subs.cljc
+++ b/gui/src/monkey/ci/gui/params/subs.cljc
@@ -4,7 +4,7 @@
             [monkey.ci.gui.utils :as u]
             [re-frame.core :as rf]))
 
-(u/db-sub :customer/params db/params)
+(u/db-sub :org/params db/params)
 (u/db-sub :params/alerts db/alerts)
 (u/db-sub :params/loading? (comp true? db/loading?))
 (u/db-sub :params/saving? (comp true? db/saving?))
@@ -14,7 +14,7 @@
 (u/db-sub :params/editing db/get-editing)
 
 (rf/reg-sub
- :customer/param
+ :org/param
  (fn [db [_ set-id param-idx]]
    (some-> (db/get-editing db set-id)
            :parameters

--- a/gui/src/monkey/ci/gui/params/views.cljs
+++ b/gui/src/monkey/ci/gui/params/views.cljs
@@ -11,7 +11,7 @@
             [re-frame.core :as rf]))
 
 (defn- param-form [set-id param-idx]
-  (let [{:keys [name value]} @(rf/subscribe [:customer/param set-id param-idx])]
+  (let [{:keys [name value]} @(rf/subscribe [:org/param set-id param-idx])]
     [:div.row.mb-2
      [:div.col-md-3
       [:input.form-control
@@ -154,7 +154,7 @@
 
 (defn- params-list []
   (let [loading? (rf/subscribe [:params/loading?])
-        params (rf/subscribe [:customer/params])
+        params (rf/subscribe [:org/params])
         new-sets (rf/subscribe [:params/new-sets])]
     (if @loading?
       [loading-card]
@@ -169,8 +169,8 @@
 (defn page
   "Organization parameters overview"
   [route]
-  (let [id (-> route (r/path-params) :customer-id)]
-    (rf/dispatch [:customer/maybe-load id])
+  (let [id (-> route (r/path-params) :org-id)]
+    (rf/dispatch [:org/maybe-load id])
     (rf/dispatch [:params/load id])
     (l/default
      [:<>

--- a/gui/src/monkey/ci/gui/params/views.cljs
+++ b/gui/src/monkey/ci/gui/params/views.cljs
@@ -1,6 +1,6 @@
 (ns monkey.ci.gui.params.views
   (:require [monkey.ci.gui.components :as co]
-            [monkey.ci.gui.customer.events]
+            [monkey.ci.gui.org.events]
             [monkey.ci.gui.labels :as lbl]
             [monkey.ci.gui.layout :as l]
             [monkey.ci.gui.logging :as log]

--- a/gui/src/monkey/ci/gui/params/views.cljs
+++ b/gui/src/monkey/ci/gui/params/views.cljs
@@ -42,7 +42,7 @@
                [:b.mx-1 "AND"])
              (str label " = " value)])]
     (if (empty? lf)
-      [:i "Applies to all builds for this customer."]
+      [:i "Applies to all builds for this organization."]
       [:<>
        [:i "Applies to all builds where:"]
        (->> lf
@@ -167,7 +167,7 @@
          [global-actions]]]])))
 
 (defn page
-  "Customer parameters overview"
+  "Organization parameters overview"
   [route]
   (let [id (-> route (r/path-params) :customer-id)]
     (rf/dispatch [:customer/maybe-load id])

--- a/gui/src/monkey/ci/gui/repo/events.cljc
+++ b/gui/src/monkey/ci/gui/repo/events.cljc
@@ -15,7 +15,7 @@
  (fn [{:keys [db]} _]
    (lo/on-initialize
     db db/id
-    {:init-events         [[:repo/load (r/customer-id db)]]
+    {:init-events         [[:repo/load (r/org-id db)]]
      :leave-event         [:repo/leave]
      :event-handler-event [:repo/handle-event]})))
 
@@ -28,12 +28,12 @@
 
 (rf/reg-event-fx
  :repo/load
- ;; Since repos are part of the customer, this actually loads the customer.
+ ;; Since repos are part of the org, this actually loads the org.
  (fn [{:keys [db]} [_ cust-id]]
-   (let [existing (cdb/customer db)]
+   (let [existing (cdb/org db)]
      (cond-> {:db (db/set-builds db nil)}
        (not existing)
-       (assoc :dispatch [:customer/load cust-id])))))
+       (assoc :dispatch [:org/load cust-id])))))
 
 (rf/reg-event-fx
  :builds/load
@@ -43,7 +43,7 @@
     (let [params (get-in db [:route/current :parameters :path])]
       [:secure-request
        :get-builds
-       (select-keys params [:customer-id :repo-id])
+       (select-keys params [:org-id :repo-id])
        [:builds/load--success]
        [:builds/load--failed]]))))
 
@@ -70,7 +70,7 @@
     (should-handle-evt? (:type evt)) (db/update-build (:build evt))))
 
 (defn- for-repo? [db evt]
-  (let [get-id (juxt :customer-id :repo-id)]
+  (let [get-id (juxt :org-id :repo-id)]
     (= (get-id (:build evt))
        (-> (r/current db)
            (r/path-params)
@@ -109,7 +109,7 @@
               (db/reset-alerts))
       :dispatch [:secure-request
                  :trigger-build
-                 (-> (select-keys params [:customer-id :repo-id])
+                 (-> (select-keys params [:org-id :repo-id])
                      (add-ref form-vals))
                  [:repo/trigger-build--success]
                  [:repo/trigger-build--failed]]})))
@@ -129,10 +129,10 @@
 (rf/reg-event-fx
  :repo/load+edit
  (fn [{:keys [db]} _]
-   (let [cust-id (r/customer-id db)]
+   (let [cust-id (r/org-id db)]
      {:dispatch [:secure-request
-                 :get-customer
-                 {:customer-id cust-id}
+                 :get-org
+                 {:org-id cust-id}
                  [:repo/load+edit--success]
                  [:repo/load+edit--failed]]
       :db (-> db
@@ -143,7 +143,7 @@
  :repo/load+edit--success
  (fn [{:keys [db]} [_ resp]]
    (let [repo-id (r/repo-id db)]
-     {:dispatch [:customer/load--success resp]
+     {:dispatch [:org/load--success resp]
       :db (db/set-editing db (->> (:body resp)
                                   :repos
                                   (filter (comp (partial = repo-id) :id))
@@ -195,13 +195,13 @@
  (fn [{:keys [db]} _]
    (let [params (-> (r/current db)
                     (r/path-params)
-                    (select-keys [:customer-id :repo-id]))]
+                    (select-keys [:org-id :repo-id]))]
      {:dispatch [:secure-request
                  :update-repo
                  (-> params
                      (assoc :repo (-> (db/editing db)
                                       (assoc :id (:repo-id params)
-                                             :customer-id (:customer-id params)))))
+                                             :org-id (:org-id params)))))
                  [:repo/save--success]
                  [:repo/save--failed]]
       :db (-> db
@@ -243,14 +243,14 @@
  (fn [{:keys [db]} _]
    (let [params (-> (r/current db) (r/path-params))
          repo-id (:repo-id params)
-         repo (u/find-by-id repo-id (:repos (cdb/get-customer db)))]
+         repo (u/find-by-id repo-id (:repos (cdb/get-org db)))]
      {:db (-> db
               (db/unmark-deleting)
-              (cdb/update-customer remove-repo repo-id)
+              (cdb/update-org remove-repo repo-id)
               (cdb/set-alerts
                [{:type :info
                  :message (str "Repository " (:name repo) " has been deleted.")}]))
-      :dispatch [:route/goto :page/customer (select-keys params [:customer-id])]})))
+      :dispatch [:route/goto :page/org (select-keys params [:org-id])]})))
 
 (rf/reg-event-db
  :repo/delete--failed

--- a/gui/src/monkey/ci/gui/repo/events.cljc
+++ b/gui/src/monkey/ci/gui/repo/events.cljc
@@ -1,6 +1,6 @@
 (ns monkey.ci.gui.repo.events
   (:require [monkey.ci.gui.alerts :as a]
-            [monkey.ci.gui.customer.db :as cdb]
+            [monkey.ci.gui.org.db :as cdb]
             [monkey.ci.gui.loader :as lo]
             [monkey.ci.gui.repo.db :as db]
             [monkey.ci.gui.routing :as r]

--- a/gui/src/monkey/ci/gui/repo/subs.cljc
+++ b/gui/src/monkey/ci/gui/repo/subs.cljc
@@ -1,5 +1,5 @@
 (ns monkey.ci.gui.repo.subs
-  (:require [monkey.ci.gui.customer.subs]
+  (:require [monkey.ci.gui.org.subs]
             [monkey.ci.gui.repo.db :as db]
             [monkey.ci.gui.time :as t]
             [monkey.ci.gui.utils :as u]

--- a/gui/src/monkey/ci/gui/repo/subs.cljc
+++ b/gui/src/monkey/ci/gui/repo/subs.cljc
@@ -7,9 +7,9 @@
 
 (rf/reg-sub
  :repo/info
- :<- [:customer/info]
+ :<- [:org/info]
  (fn [c [_ repo-id]]
-   ;; TODO Optimize customer structure for faster lookup
+   ;; TODO Optimize org structure for faster lookup
    (some->> c
             :repos
             (u/find-by-id repo-id))))

--- a/gui/src/monkey/ci/gui/repo/views.cljs
+++ b/gui/src/monkey/ci/gui/repo/views.cljs
@@ -134,7 +134,7 @@
          [:span.me-2 co/repo-icon] 
          "Repository: " (:name @r)
          [:span.fs-6.p-1
-          [cl/clipboard-copy (u/->sid p :customer-id :repo-id) "Click to save the sid to clipboard"]]]
+          [cl/clipboard-copy (u/->sid p :org-id :repo-id) "Click to save the sid to clipboard"]]]
         [:p "Repository url: " [:a {:href (:url @r) :target :_blank} (:url @r)]]
         [co/alerts [:repo/alerts]]
         [:div.card
@@ -255,7 +255,7 @@
         [save-btn]
         [co/close-btn [:route/goto :page/repo (-> route
                                                   (r/path-params)
-                                                  (select-keys [:repo-id :customer-id]))]]
+                                                  (select-keys [:repo-id :org-id]))]]
         [:span.ms-auto [delete-btn]]]]]]))
 
 (defn edit

--- a/gui/src/monkey/ci/gui/routing.cljs
+++ b/gui/src/monkey/ci/gui/routing.cljs
@@ -53,20 +53,20 @@
   (f/router
    [["/" :page/root]
     ["/login" :page/login]
-    ["/c/join" {:conflicting true
+    ["/o/join" {:conflicting true
                 :name :page/customer-join}]
-    ["/c/new" {:conflicting true
+    ["/o/new" {:conflicting true
                :name :page/customer-new}]
-    ["/c/:customer-id" {:conflicting true
+    ["/o/:customer-id" {:conflicting true
                         :name :page/customer}]
-    ["/c/:customer-id/add-repo/github" :page/add-github-repo]
-    ["/c/:customer-id/add-repo/bitbucket" :page/add-bitbucket-repo]
-    ["/c/:customer-id/params" :page/customer-params]
-    ["/c/:customer-id/ssh-keys" :page/customer-ssh-keys]
-    ["/c/:customer-id/r/:repo-id" :page/repo]
-    ["/c/:customer-id/r/:repo-id/edit" :page/repo-edit]
-    ["/c/:customer-id/r/:repo-id/b/:build-id" :page/build]
-    ["/c/:customer-id/r/:repo-id/b/:build-id/j/:job-id" :page/job]
+    ["/o/:customer-id/add-repo/github" :page/add-github-repo]
+    ["/o/:customer-id/add-repo/bitbucket" :page/add-bitbucket-repo]
+    ["/o/:customer-id/params" :page/customer-params]
+    ["/o/:customer-id/ssh-keys" :page/customer-ssh-keys]
+    ["/o/:customer-id/r/:repo-id" :page/repo]
+    ["/o/:customer-id/r/:repo-id/edit" :page/repo-edit]
+    ["/o/:customer-id/r/:repo-id/b/:build-id" :page/build]
+    ["/o/:customer-id/r/:repo-id/b/:build-id/j/:job-id" :page/job]
     ["/github/callback" :page/github-callback]
     ["/bitbucket/callback" :page/bitbucket-callback]]))
 

--- a/gui/src/monkey/ci/gui/routing.cljs
+++ b/gui/src/monkey/ci/gui/routing.cljs
@@ -15,9 +15,9 @@
 (defn set-current [db r]
   (assoc db current r))
 
-(def customer-id
-  "Retrieve current customer id from app db"
-  (comp :customer-id :path :parameters current))
+(def org-id
+  "Retrieve current org id from app db"
+  (comp :org-id :path :parameters current))
 
 (def repo-id
   "Retrieve current repo id from app db"
@@ -54,19 +54,19 @@
    [["/" :page/root]
     ["/login" :page/login]
     ["/o/join" {:conflicting true
-                :name :page/customer-join}]
+                :name :page/org-join}]
     ["/o/new" {:conflicting true
-               :name :page/customer-new}]
-    ["/o/:customer-id" {:conflicting true
-                        :name :page/customer}]
-    ["/o/:customer-id/add-repo/github" :page/add-github-repo]
-    ["/o/:customer-id/add-repo/bitbucket" :page/add-bitbucket-repo]
-    ["/o/:customer-id/params" :page/customer-params]
-    ["/o/:customer-id/ssh-keys" :page/customer-ssh-keys]
-    ["/o/:customer-id/r/:repo-id" :page/repo]
-    ["/o/:customer-id/r/:repo-id/edit" :page/repo-edit]
-    ["/o/:customer-id/r/:repo-id/b/:build-id" :page/build]
-    ["/o/:customer-id/r/:repo-id/b/:build-id/j/:job-id" :page/job]
+               :name :page/org-new}]
+    ["/o/:org-id" {:conflicting true
+                   :name :page/org}]
+    ["/o/:org-id/add-repo/github" :page/add-github-repo]
+    ["/o/:org-id/add-repo/bitbucket" :page/add-bitbucket-repo]
+    ["/o/:org-id/params" :page/org-params]
+    ["/o/:org-id/ssh-keys" :page/org-ssh-keys]
+    ["/o/:org-id/r/:repo-id" :page/repo]
+    ["/o/:org-id/r/:repo-id/edit" :page/repo-edit]
+    ["/o/:org-id/r/:repo-id/b/:build-id" :page/build]
+    ["/o/:org-id/r/:repo-id/b/:build-id/j/:job-id" :page/job]
     ["/github/callback" :page/github-callback]
     ["/bitbucket/callback" :page/bitbucket-callback]]))
 
@@ -75,11 +75,11 @@
    [["/" :admin/root]
     ["/login" :admin/login]
     ["/credits" :admin/credits]
-    ["/credits/:customer-id" :admin/cust-credits]
+    ["/credits/:org-id" :admin/org-credits]
     ["/builds/clean" :admin/clean-builds]
     ["/forget" :admin/forget-users]
     ["/invoicing" :admin/invoicing]
-    ["/invoicing/:customer-id" :admin/cust-invoices]]))
+    ["/invoicing/:org-id" :admin/org-invoices]]))
 
 (defonce router (atom main-router))
 

--- a/gui/src/monkey/ci/gui/ssh_keys/events.cljc
+++ b/gui/src/monkey/ci/gui/ssh_keys/events.cljc
@@ -9,18 +9,18 @@
 
 (rf/reg-event-fx
  :ssh-keys/initialize
- (fn [{:keys [db]} [_ cust-id]]
+ (fn [{:keys [db]} [_ org-id]]
    (lo/on-initialize db db/id
-                     {:init-events [[:ssh-keys/load cust-id]]})))
+                     {:init-events [[:ssh-keys/load org-id]]})))
 
 (rf/reg-event-fx
  :ssh-keys/load
  (lo/loader-evt-handler
   db/id
-  (fn [_ _ [_ cust-id]]
+  (fn [_ _ [_ org-id]]
     [:secure-request
-     :get-customer-ssh-keys
-     {:customer-id cust-id}
+     :get-org-ssh-keys
+     {:org-id org-id}
      [:ssh-keys/load--success]
      [:ssh-keys/load--failed]])))
 
@@ -32,7 +32,7 @@
 (rf/reg-event-db
  :ssh-keys/load--failed
  (fn [db [_ err]]
-   (lo/on-failure db db/id a/cust-ssh-keys-failed err)))
+   (lo/on-failure db db/id a/org-ssh-keys-failed err)))
 
 (rf/reg-event-db
  :ssh-keys/new
@@ -66,15 +66,15 @@
 (rf/reg-event-fx
  :ssh-keys/save-set
  (fn [{:keys [db]} [_ ks]]
-   (let [cust-id (r/customer-id db)
+   (let [org-id (r/org-id db)
          all (db/get-value db)
          orig (->> all
                    (filter (db/same-id? (set-id ks)))
                    (first))
          ks (add-filters db ks)]
      {:dispatch [:secure-request
-                 :update-customer-ssh-keys
-                 {:customer-id cust-id
+                 :update-org-ssh-keys
+                 {:org-id org-id
                   :ssh-keys (cond->> all
                               orig (replace {orig ks})
                               (not orig) (concat [ks])
@@ -93,7 +93,7 @@
 (rf/reg-event-db
  :ssh-keys/save-set--failed
  (fn [db [_ _ err]]
-   (db/set-alerts db [(a/cust-save-ssh-keys-failed err)])))
+   (db/set-alerts db [(a/org-save-ssh-keys-failed err)])))
 
 (rf/reg-event-db
  :ssh-keys/edit-set
@@ -103,11 +103,11 @@
 (rf/reg-event-fx
  :ssh-keys/delete-set
  (fn [{:keys [db]} [_ ks]]
-   (let [cust-id (r/customer-id db)
+   (let [org-id (r/org-id db)
          all (db/get-value db)]
      {:dispatch [:secure-request
-                 :update-customer-ssh-keys
-                 {:customer-id cust-id
+                 :update-org-ssh-keys
+                 {:org-id org-id
                   :ssh-keys (remove (db/same-id? (set-id ks)) all)}
                  [:ssh-keys/save-set--success ks]
                  [:ssh-keys/save-set--failed ks]]})))

--- a/gui/src/monkey/ci/gui/ssh_keys/views.cljs
+++ b/gui/src/monkey/ci/gui/ssh_keys/views.cljs
@@ -86,7 +86,7 @@
          (into [:div.mb-2
                 [:p "Found " (count @v) " configured SSH keys."]]))))
 
-(defn- global-actions [cust-id]
+(defn- global-actions [org-id]
   [:div.d-flex.gap-2.mt-2
    [:button.btn.btn-outline-success
     {:title "Adds a new SSK key pair"
@@ -94,7 +94,7 @@
     [:span.me-2 [co/icon :plus-square]] "Add New"]
    [:a.btn.btn-outline-danger
     {:title "Close this screen"
-     :href (r/path-for :page/customer {:customer-id cust-id})}
+     :href (r/path-for :page/org {:org-id org-id})}
     [:span.me-2 [co/icon :x-square]] "Close"]])
 
 (defn ssh-keys-loader []
@@ -106,13 +106,13 @@
       [ssh-keys])))
 
 (defn page [route]
-  (let [cust-id (:customer-id (r/path-params route))]
-    (rf/dispatch [:ssh-keys/initialize cust-id])
+  (let [org-id (:org-id (r/path-params route))]
+    (rf/dispatch [:ssh-keys/initialize org-id])
     (l/default
      [:<>
       [:div.d-flex
        [:h3 "SSH Keys"]
-       [co/reload-btn-sm [:ssh-keys/load cust-id] {:class :ms-auto}]]
+       [co/reload-btn-sm [:ssh-keys/load org-id] {:class :ms-auto}]]
       [:p
        "SSH keys are used to access private repositories.  When a build is triggered from a "
        "private repo, any SSH keys that are" [:b.mx-1 "configured on the organization with matching labels"]
@@ -120,9 +120,11 @@
       [:p
        "SSH key pairs consist of a" [:b.mx-1 "private and public key"] "and can take an optional "
        "description, which can be useful for your users.  Similar to"
-       [:a.ms-1 {:href (r/path-for :page/customer-params (r/path-params route))} "parameters"]
+       [:a.ms-1 {:href (r/path-for :page/org-params (r/path-params route))} "parameters"]
        ", they can have any labels set on them which allow them to be accessed by builds for "
        "repositories with the same labels."]
       [co/alerts [:ssh-keys/alerts]]
       [ssh-keys-loader]
-      [global-actions cust-id]])))
+      [:div.card
+       [:div.card-body
+        [global-actions org-id]]]])))

--- a/gui/src/monkey/ci/gui/ssh_keys/views.cljs
+++ b/gui/src/monkey/ci/gui/ssh_keys/views.cljs
@@ -115,7 +115,7 @@
        [co/reload-btn-sm [:ssh-keys/load cust-id] {:class :ms-auto}]]
       [:p
        "SSH keys are used to access private repositories.  When a build is triggered from a "
-       "private repo, any SSH keys that are" [:b.mx-1 "configured on the customer with matching labels"]
+       "private repo, any SSH keys that are" [:b.mx-1 "configured on the organization with matching labels"]
        "are exposed to the build script."]
       [:p
        "SSH key pairs consist of a" [:b.mx-1 "private and public key"] "and can take an optional "

--- a/gui/src/monkey/ci/gui/utils.cljc
+++ b/gui/src/monkey/ci/gui/utils.cljc
@@ -113,3 +113,10 @@
   (if (and (string? x) (> (count x) len))
     (str (subs x 0 len) "...")
     x))
+
+(defn cust->org
+  "For compatibility purposes, renames customer-id to org-id"
+  [x]
+  (-> x
+      (dissoc :customer-id)
+      (assoc :org-id (:customer-id x))))

--- a/gui/test/monkey/ci/gui/test/admin/credits/events_test.cljc
+++ b/gui/test/monkey/ci/gui/test/admin/credits/events_test.cljc
@@ -12,14 +12,14 @@
             [re-frame.db :refer [app-db]]))
 
 (deftest credits-load-issues
-  (testing "fetches customer credit issues from backend"
+  (testing "fetches org credit issues from backend"
     (rf-test/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
        (h/initialize-martian {:get-credit-issues
                               {:status 200
                                :body []
                                :error-code :no-error}})
-       (rf/dispatch [:credits/load-issues {:customer-id "test-cust"}])
+       (rf/dispatch [:credits/load-issues {:org-id "test-org"}])
        (is (= 1 (count @c)))))))
 
 (deftest credits-load-issues--success
@@ -48,7 +48,7 @@
    (let [c (h/catch-fx :martian.re-frame/request)]
      (is (some? (reset! app-db (r/set-current {} {:parameters
                                                   {:path
-                                                   {:customer-id "test-cust"}}}))))
+                                                   {:org-id "test-org"}}}))))
      (h/initialize-martian {:create-credit-issue
                             {:status 200
                              :body {}
@@ -68,9 +68,9 @@
                 (select-keys params [:amount :reason])))
          (is (number? (:from-time params)))))
 
-     (testing "adds customer id"
-       (is (= "test-cust"
-              (-> @c first (nth 3) :customer-id))))
+     (testing "adds org id"
+       (is (= "test-org"
+              (-> @c first (nth 3) :org-id))))
 
      (testing "marks saving"
        (is (db/issue-saving? @app-db))))))
@@ -108,14 +108,14 @@
     (is (not (db/issue-saving? @app-db)))))
 
 (deftest credits-load-subs
-  (testing "fetches customer credit subs from backend"
+  (testing "fetches org credit subs from backend"
     (rf-test/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
        (h/initialize-martian {:get-credit-subs
                               {:status 200
                                :body []
                                :error-code :no-error}})
-       (rf/dispatch [:credits/load-subs {:customer-id "test-cust"}])
+       (rf/dispatch [:credits/load-subs {:org-id "test-org"}])
        (is (= 1 (count @c)))))))
 
 (deftest credits-load-subs--success
@@ -144,7 +144,7 @@
    (let [c (h/catch-fx :martian.re-frame/request)]
      (is (some? (reset! app-db (r/set-current {} {:parameters
                                                   {:path
-                                                   {:customer-id "test-cust"}}}))))
+                                                   {:org-id "test-org"}}}))))
      (h/initialize-martian {:create-credit-sub
                             {:status 200
                              :body {}
@@ -166,9 +166,9 @@
        (testing "does not pass empty `valid-until` date"
          (is (not (contains? params :valid-until)))))
 
-     (testing "adds customer id"
-       (is (= "test-cust"
-              (-> @c first (nth 3) :customer-id))))
+     (testing "adds org id"
+       (is (= "test-org"
+              (-> @c first (nth 3) :org-id))))
 
      (testing "marks saving"
        (is (db/sub-saving? @app-db))))))

--- a/gui/test/monkey/ci/gui/test/admin/search_test.cljc
+++ b/gui/test/monkey/ci/gui/test/admin/search_test.cljc
@@ -13,40 +13,39 @@
 (use-fixtures :each f/reset-db)
 (rf/clear-subscription-cache!)
 
-
-(deftest customer-search
-  (testing "searches for customer by name and id"
+(deftest org-search
+  (testing "searches for org by name and id"
     (rf-test/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
-       (h/initialize-martian {:search-customers {:status 200
+       (h/initialize-martian {:search-orgs {:status 200
                                                  :body "ok"
                                                  :error-code :no-error}})
-       (rf/dispatch [:admin/customer-search {:customer-filter ["test-cust"]}])
+       (rf/dispatch [:admin/org-search {:org-filter ["test-org"]}])
        (is (= 2 (count @c))))))
 
-  (testing "clears customers"
-    (is (some? (reset! app-db (lo/set-value {} sut/cust-by-name [::initial-customers]))))
-    (rf/dispatch-sync [:admin/customer-search {}])
-    (is (empty? (sut/get-customers @app-db)))))
+  (testing "clears orgs"
+    (is (some? (reset! app-db (lo/set-value {} sut/org-by-name [::initial-orgs]))))
+    (rf/dispatch-sync [:admin/org-search {}])
+    (is (empty? (sut/get-orgs @app-db)))))
 
-(deftest customer-search--success
-  (testing "when by name, adds customers to db"
-    (is (some? (reset! app-db (lo/set-value {} sut/cust-by-id [::initial]))))
-    (rf/dispatch-sync [:admin/customer-search--success sut/cust-by-name {:body [::new]}])
-    (is (= #{::initial ::new} (set (sut/get-customers @app-db)))))
+(deftest org-search--success
+  (testing "when by name, adds orgs to db"
+    (is (some? (reset! app-db (lo/set-value {} sut/org-by-id [::initial]))))
+    (rf/dispatch-sync [:admin/org-search--success sut/org-by-name {:body [::new]}])
+    (is (= #{::initial ::new} (set (sut/get-orgs @app-db)))))
 
-  (testing "when by id, adds customers to db"
-    (is (some? (reset! app-db (lo/set-value {} sut/cust-by-name [::initial]))))
-    (rf/dispatch-sync [:admin/customer-search--success sut/cust-by-id {:body [::new]}])
-    (is (= #{::initial ::new} (set (sut/get-customers @app-db))))))
+  (testing "when by id, adds orgs to db"
+    (is (some? (reset! app-db (lo/set-value {} sut/org-by-name [::initial]))))
+    (rf/dispatch-sync [:admin/org-search--success sut/org-by-id {:body [::new]}])
+    (is (= #{::initial ::new} (set (sut/get-orgs @app-db))))))
 
-(deftest customer-search--failed
+(deftest org-search--failed
   (testing "sets alert for id"
-    (rf/dispatch-sync [:admin/customer-search--failed sut/cust-by-name "test error"])
-    (is (= 1 (count (lo/get-alerts @app-db sut/cust-by-name))))))
+    (rf/dispatch-sync [:admin/org-search--failed sut/org-by-name "test error"])
+    (is (= 1 (count (lo/get-alerts @app-db sut/org-by-name))))))
 
-(deftest customers-loading?
-  (let [l (rf/subscribe [:admin/customers-loading?])]
+(deftest orgs-loading?
+  (let [l (rf/subscribe [:admin/orgs-loading?])]
     (testing "exists"
       (is (some? l)))
 
@@ -54,32 +53,32 @@
       (is (false? @l)))
     
     (testing "true if loading by id"
-      (is (some? (reset! app-db (lo/set-loading {} sut/cust-by-id))))
+      (is (some? (reset! app-db (lo/set-loading {} sut/org-by-id))))
       (is (true? @l)))
 
     (testing "true if loading by name"
-      (is (some? (reset! app-db (lo/set-loading {} sut/cust-by-name))))
+      (is (some? (reset! app-db (lo/set-loading {} sut/org-by-name))))
       (is (true? @l)))))
 
-(deftest customers
-  (let [c (rf/subscribe [:admin/customers])]
+(deftest orgs
+  (let [c (rf/subscribe [:admin/orgs])]
     (testing "exists"
       (is (some? c)))
 
     (testing "initially empty"
       (is (empty? @c)))
     
-    (testing "contains customers by id"
-      (is (some? (reset! app-db (lo/set-value {} sut/cust-by-id [::cust]))))
-      (is (= [::cust])))
+    (testing "contains orgs by id"
+      (is (some? (reset! app-db (lo/set-value {} sut/org-by-id [::org]))))
+      (is (= [::org])))
 
-    (testing "contains customers by name"
-      (is (some? (reset! app-db (lo/set-value {} sut/cust-by-name [::cust]))))
-      (is (= [::cust])))))
+    (testing "contains orgs by name"
+      (is (some? (reset! app-db (lo/set-value {} sut/org-by-name [::org]))))
+      (is (= [::org])))))
 
-(deftest customers-loaded?
+(deftest orgs-loaded?
   (h/verify-sub
-   [:admin/customers-loaded?]
-   #(lo/set-loaded % sut/cust-by-id)
+   [:admin/orgs-loaded?]
+   #(lo/set-loaded % sut/org-by-id)
    true
    false))

--- a/gui/test/monkey/ci/gui/test/breadcrumb_test.cljc
+++ b/gui/test/monkey/ci/gui/test/breadcrumb_test.cljc
@@ -31,28 +31,28 @@
                :name "Home"}]
              @p)))
 
-    (testing "home and customer when `customer-id` in path"
+    (testing "home and org when `org-id` in path"
       (reset! app-db (-> {}
                          (r/set-current {:parameters
                                          {:path
-                                          {:customer-id "test-cust"}}})
-                         (cdb/set-customer {:name "Test customer"})))
+                                          {:org-id "test-org"}}})
+                         (cdb/set-org {:name "Test org"})))
       (is (= 2 (count @p)))
-      (is (= {:url "/o/test-cust"
-              :name "Test customer"}
+      (is (= {:url "/o/test-org"
+              :name "Test org"}
              (second @p))))
 
     (testing "includes repository when `repo-id` in path"
       (reset! app-db (-> {}
                          (r/set-current {:parameters
                                          {:path
-                                          {:customer-id "test-cust"
+                                          {:org-id "test-org"
                                            :repo-id "test-repo"}}})
-                         (cdb/set-customer {:name "Test customer"
-                                            :repos [{:id "test-repo"
-                                                     :name "Test repo"}]})))
+                         (cdb/set-org {:name "Test org"
+                                       :repos [{:id "test-repo"
+                                                :name "Test repo"}]})))
       (is (= 3 (count @p)))
-      (is (= {:url "/o/test-cust/r/test-repo"
+      (is (= {:url "/o/test-org/r/test-repo"
               :name "Test repo"}
              (last @p))))
 
@@ -60,14 +60,14 @@
       (reset! app-db (-> {}
                          (r/set-current {:parameters
                                          {:path
-                                          {:customer-id "test-cust"
+                                          {:org-id "test-org"
                                            :repo-id "test-repo"
                                            :build-id "test-build"}}})
-                         (cdb/set-customer {:name "Test customer"
-                                            :repos [{:id "test-repo"
-                                                     :name "Test repo"}]})))
+                         (cdb/set-org {:name "Test org"
+                                       :repos [{:id "test-repo"
+                                                :name "Test repo"}]})))
       (is (= 4 (count @p)))
-      (is (= {:url "/o/test-cust/r/test-repo/b/test-build"
+      (is (= {:url "/o/test-org/r/test-repo/b/test-build"
               :name "test-build"}
              (last @p))))
 
@@ -75,30 +75,30 @@
       (reset! app-db (-> {}
                          (r/set-current {:parameters
                                          {:path
-                                          {:customer-id "test-cust"
+                                          {:org-id "test-org"
                                            :repo-id "test-repo"
                                            :build-id "test-build"
                                            :job-id "test-job"}}})
-                         (cdb/set-customer {:name "Test customer"
-                                            :repos [{:id "test-repo"
-                                                     :name "Test repo"}]})))
+                         (cdb/set-org {:name "Test org"
+                                       :repos [{:id "test-repo"
+                                                :name "Test repo"}]})))
       (is (= 5 (count @p)))
-      (is (= {:url "/o/test-cust/r/test-repo/b/test-build/j/test-job"
+      (is (= {:url "/o/test-org/r/test-repo/b/test-build/j/test-job"
               :name "test-job"}
              (last @p))))
 
-    (testing "applies custom calculator for params"
+    (testing "applies orgom calculator for params"
       (reset! app-db (-> {}
                          (r/set-current {:parameters
                                          {:path
-                                          {:customer-id "test-cust"}}
+                                          {:org-id "test-org"}}
                                          :data
-                                         {:name :page/customer-params}})
-                         (cdb/set-customer {:name "Test customer"
-                                            :repos [{:id "test-repo"
-                                                     :name "Test repo"}]})))
+                                         {:name :page/org-params}})
+                         (cdb/set-org {:name "Test org"
+                                       :repos [{:id "test-repo"
+                                                :name "Test repo"}]})))
       (is (= 3 (count @p)))
-      (is (= {:url "/o/test-cust/params"
+      (is (= {:url "/o/test-org/params"
               :name "Parameters"}
              (last @p))))))
 

--- a/gui/test/monkey/ci/gui/test/breadcrumb_test.cljc
+++ b/gui/test/monkey/ci/gui/test/breadcrumb_test.cljc
@@ -3,7 +3,7 @@
                :cljs [cljs.test :refer-macros [deftest testing is use-fixtures]])
             [day8.re-frame.test :as rft]
             [monkey.ci.gui.breadcrumb :as sut]
-            [monkey.ci.gui.customer.db :as cdb]
+            [monkey.ci.gui.org.db :as cdb]
             [monkey.ci.gui.routing :as r]
             [monkey.ci.gui.test.fixtures :as f]
             [monkey.ci.gui.test.helpers :as h]
@@ -38,7 +38,7 @@
                                           {:customer-id "test-cust"}}})
                          (cdb/set-customer {:name "Test customer"})))
       (is (= 2 (count @p)))
-      (is (= {:url "/c/test-cust"
+      (is (= {:url "/o/test-cust"
               :name "Test customer"}
              (second @p))))
 
@@ -52,7 +52,7 @@
                                             :repos [{:id "test-repo"
                                                      :name "Test repo"}]})))
       (is (= 3 (count @p)))
-      (is (= {:url "/c/test-cust/r/test-repo"
+      (is (= {:url "/o/test-cust/r/test-repo"
               :name "Test repo"}
              (last @p))))
 
@@ -67,7 +67,7 @@
                                             :repos [{:id "test-repo"
                                                      :name "Test repo"}]})))
       (is (= 4 (count @p)))
-      (is (= {:url "/c/test-cust/r/test-repo/b/test-build"
+      (is (= {:url "/o/test-cust/r/test-repo/b/test-build"
               :name "test-build"}
              (last @p))))
 
@@ -83,7 +83,7 @@
                                             :repos [{:id "test-repo"
                                                      :name "Test repo"}]})))
       (is (= 5 (count @p)))
-      (is (= {:url "/c/test-cust/r/test-repo/b/test-build/j/test-job"
+      (is (= {:url "/o/test-cust/r/test-repo/b/test-build/j/test-job"
               :name "test-job"}
              (last @p))))
 
@@ -98,7 +98,7 @@
                                             :repos [{:id "test-repo"
                                                      :name "Test repo"}]})))
       (is (= 3 (count @p)))
-      (is (= {:url "/c/test-cust/params"
+      (is (= {:url "/o/test-cust/params"
               :name "Parameters"}
              (last @p))))))
 

--- a/gui/test/monkey/ci/gui/test/build/events_test.cljc
+++ b/gui/test/monkey/ci/gui/test/build/events_test.cljc
@@ -18,13 +18,14 @@
   (repeatedly 3 (comp str random-uuid)))
 
 (defn- gen-build []
-  (zipmap [:org-id :repo-id :build-id] (build-sid)))
+  (zipmap [:customer-id :repo-id :build-id] (build-sid)))
 
 (defn- build->params [build]
   {:parameters
-   {:path (select-keys build [:org-id :repo-id :build-id])}})
+   {:path (-> (select-keys build [:repo-id :build-id])
+              (assoc :org-id (:customer-id build)))}})
 
-(def build-keys [:org-id :repo-id :build-id])
+(def build-keys [:customer-id :repo-id :build-id])
 (def sid (apply juxt build-keys))
 
 (defn- set-build-path
@@ -200,7 +201,7 @@
 
 (defn- test-build []
   (->> (repeatedly 3 (comp str random-uuid))
-       (zipmap [:org-id :repo-id :build-id])))
+       (zipmap [:customer-id :repo-id :build-id])))
 
 (deftest handle-event
   (testing "ignores events for other builds"

--- a/gui/test/monkey/ci/gui/test/build/events_test.cljc
+++ b/gui/test/monkey/ci/gui/test/build/events_test.cljc
@@ -2,7 +2,7 @@
   (:require #?(:cljs [cljs.test :refer-macros [deftest testing is use-fixtures]]
                :clj [clojure.test :refer [deftest testing is use-fixtures]])
             [day8.re-frame.test :as rft]
-            [monkey.ci.gui.customer.db :as cdb]
+            [monkey.ci.gui.org.db :as cdb]
             [monkey.ci.gui.build.db :as db]
             [monkey.ci.gui.build.events :as sut]
             [monkey.ci.gui.loader :as lo]

--- a/gui/test/monkey/ci/gui/test/cards/customer_cards.cljs
+++ b/gui/test/monkey/ci/gui/test/cards/customer_cards.cljs
@@ -1,10 +1,11 @@
 (ns monkey.ci.gui.test.cards.customer-cards
   (:require [devcards.core :refer-macros [defcard-rg]]
-            [monkey.ci.gui.customer.views :as sut]
             [monkey.ci.gui.charts :as charts]
-            [reagent.core]
-            [re-frame.core :as rf]
-            [re-frame.db :as rdb]))
+            [monkey.ci.gui.org.views :as sut]
+            [re-frame
+             [core :as rf]
+             [db :as rdb]]
+            [reagent.core]))
 
 (defcard-rg build-stats
   "Customer build statistics"

--- a/gui/test/monkey/ci/gui/test/home/subs_test.cljc
+++ b/gui/test/monkey/ci/gui/test/home/subs_test.cljc
@@ -11,15 +11,15 @@
 (use-fixtures :each f/reset-db)
 (rf/clear-subscription-cache!)
 
-(deftest user-customers
-  (let [uc (rf/subscribe [:user/customers])]
+(deftest user-orgs
+  (let [uc (rf/subscribe [:user/orgs])]
     (testing "exists"
       (is (some? uc)))
 
-    (testing "returns user customers"
+    (testing "returns user orgs"
       (is (nil? @uc))
-      (is (some? (reset! app-db (db/set-customers {} ::customers))))
-      (is (= ::customers @uc)))))
+      (is (some? (reset! app-db (db/set-orgs {} ::orgs))))
+      (is (= ::orgs @uc)))))
 
 (deftest alerts
   (let [a (rf/subscribe [:user/alerts])]
@@ -32,57 +32,57 @@
       (is (= ::alerts @a)))))
 
 (deftest join-alerts
-  (let [a (rf/subscribe [:customer/join-alerts])]
+  (let [a (rf/subscribe [:org/join-alerts])]
     (testing "exists"
       (is (some? a)))
 
-    (testing "returns customer join alerts"
+    (testing "returns org join alerts"
       (is (nil? @a))
       (is (some? (reset! app-db (db/set-join-alerts {} ::alerts))))
       (is (= ::alerts @a)))))
 
-(deftest customer-searching?
-  (let [s (rf/subscribe [:customer/searching?])]
+(deftest org-searching?
+  (let [s (rf/subscribe [:org/searching?])]
     (testing "exists"
       (is (some? s)))
 
-    (testing "returns customer search status"
+    (testing "returns org search status"
       (is (false? @s))
-      (is (some? (reset! app-db (db/set-customer-searching {} true))))
+      (is (some? (reset! app-db (db/set-org-searching {} true))))
       (is (true? @s)))))
 
-(deftest customer-search-results
-  (let [r (rf/subscribe [:customer/search-results])]
+(deftest org-search-results
+  (let [r (rf/subscribe [:org/search-results])]
     (testing "exists"
       (is (some? r)))
 
-    (testing "returns customer search results"
+    (testing "returns org search results"
       (is (nil? @r))
       (is (some? (reset! app-db (db/set-search-results {} ::results))))
       (is (= ::results @r)))))
 
-(deftest customer-join-list
-  (let [r (rf/subscribe [:customer/join-list])]
+(deftest org-join-list
+  (let [r (rf/subscribe [:org/join-list])]
     (testing "exists"
       (is (some? r)))
 
     (testing "contains search results"
       (is (nil? @r))
-      (is (some? (reset! app-db (db/set-search-results {} [{:id "test customer"}]))))
-      (is (= ["test customer"] (map :id @r))))
+      (is (some? (reset! app-db (db/set-search-results {} [{:id "test org"}]))))
+      (is (= ["test org"] (map :id @r))))
 
     (testing "sets status to `:joined` if user is already linked"
       (is (some? (reset! app-db (-> {}
-                                    (db/set-search-results [{:id "joined-cust"}])
+                                    (db/set-search-results [{:id "joined-org"}])
                                     (ldb/set-user {:id "test-user"
-                                                   :customers ["joined-cust"]})))))
+                                                   :orgs ["joined-org"]})))))
       (is (= :joined (-> @r first :status))))
 
     (testing "sets status to `:joining` if join request is being sent"
-      (let [cust-id "test-customer"]
+      (let [org-id "test-org"]
         (is (some? (reset! app-db (-> {}
-                                      (db/set-search-results [{:id "test-customer"}])
-                                      (db/mark-customer-joining "test-customer")))))
+                                      (db/set-search-results [{:id "test-org"}])
+                                      (db/mark-org-joining "test-org")))))
         (is (= :joining (-> @r first :status)))))))
 
 (deftest user-join-requests
@@ -95,16 +95,16 @@
       (is (some? (reset! app-db (db/set-join-requests {} ::results))))
       (is (= ::results @r)))))
 
-(deftest customer-joining?
-  (let [cust-id "test-customer"
-        c (rf/subscribe [:customer/joining? cust-id])]
+(deftest org-joining?
+  (let [org-id "test-org"
+        c (rf/subscribe [:org/joining? org-id])]
     (testing "exists"
       (is (some? c)))
 
-    (testing "`true` if currently joining customer"
+    (testing "`true` if currently joining org"
       (is (false? @c))
-      (is (some? (reset! app-db (db/mark-customer-joining {} cust-id))))
+      (is (some? (reset! app-db (db/mark-org-joining {} org-id))))
       (is (true? @c)))
 
-    (testing "returns all when no customer id given"
-      (is (= #{cust-id} @(rf/subscribe [:customer/joining?]))))))
+    (testing "returns all when no org id given"
+      (is (= #{org-id} @(rf/subscribe [:org/joining?]))))))

--- a/gui/test/monkey/ci/gui/test/loader_test.cljc
+++ b/gui/test/monkey/ci/gui/test/loader_test.cljc
@@ -121,10 +121,10 @@
                  (sut/on-initialize id {:leave-event [::leave-evt]})
                  :dispatch-n))))
 
-    (testing "dispatches stream start event for customer if handler provided"
-      (is (= [[:event-stream/start id "test-customer" [::handler-evt]]]
+    (testing "dispatches stream start event for org if handler provided"
+      (is (= [[:event-stream/start id "test-org" [::handler-evt]]]
              (-> {}
-                 (r/set-current {:parameters {:path {:customer-id "test-customer"}}}) 
+                 (r/set-current {:parameters {:path {:org-id "test-org"}}}) 
                  (sut/on-initialize id {:event-handler-event [::handler-evt]})
                  :dispatch-n))))))
 

--- a/gui/test/monkey/ci/gui/test/login/events_test.cljc
+++ b/gui/test/monkey/ci/gui/test/login/events_test.cljc
@@ -139,17 +139,17 @@
      (let [c (h/catch-fx :route/goto)]
        (reset! app-db (db/set-user {} {:customers ["test-cust"]}))
        (rf/dispatch [:github/load-user--success {}])
-       (is (= "/c/test-cust" (first @c))))))
+       (is (= "/o/test-cust" (first @c))))))
 
   (testing "redirects to redirect page if set"
     (rf-test/run-test-sync
      (rf/reg-cofx
       :local-storage
       (fn [cofx]
-        (assoc cofx :local-storage {:redirect-to "/c/test-cust"})))
+        (assoc cofx :local-storage {:redirect-to "/o/test-cust"})))
      (let [c (h/catch-fx :route/goto)]
        (rf/dispatch [:github/load-user--success {}])
-       (is (= "/c/test-cust" (first @c))))))
+       (is (= "/o/test-cust" (first @c))))))
 
   (testing "ignores redirect page if `/`"
     (rf-test/run-test-sync
@@ -160,7 +160,7 @@
      (let [c (h/catch-fx :route/goto)]
        (reset! app-db (db/set-user {} {:customers ["test-cust"]}))
        (rf/dispatch [:github/load-user--success {}])
-       (is (= "/c/test-cust" (first @c)))))))
+       (is (= "/o/test-cust" (first @c)))))))
 
 (deftest github-load-user--failed
   (testing "sets error alert"
@@ -281,17 +281,17 @@
      (let [c (h/catch-fx :route/goto)]
        (reset! app-db (db/set-user {} {:customers ["test-cust"]}))
        (rf/dispatch [:bitbucket/load-user--success {}])
-       (is (= "/c/test-cust" (first @c))))))
+       (is (= "/o/test-cust" (first @c))))))
 
   (testing "redirects to redirect page if set"
     (rf-test/run-test-sync
      (rf/reg-cofx
       :local-storage
       (fn [cofx]
-        (assoc cofx :local-storage {:redirect-to "/c/test-cust"})))
+        (assoc cofx :local-storage {:redirect-to "/o/test-cust"})))
      (let [c (h/catch-fx :route/goto)]
        (rf/dispatch [:bitbucket/load-user--success {}])
-       (is (= "/c/test-cust" (first @c))))))
+       (is (= "/o/test-cust" (first @c))))))
 
   (testing "ignores redirect page if `/`"
     (rf-test/run-test-sync
@@ -302,7 +302,7 @@
      (let [c (h/catch-fx :route/goto)]
        (reset! app-db (db/set-user {} {:customers ["test-cust"]}))
        (rf/dispatch [:bitbucket/load-user--success {}])
-       (is (= "/c/test-cust" (first @c)))))))
+       (is (= "/o/test-cust" (first @c)))))))
 
 (deftest bitbucket-load-user--failed
   (testing "sets error alert"

--- a/gui/test/monkey/ci/gui/test/org/events_test.cljc
+++ b/gui/test/monkey/ci/gui/test/org/events_test.cljc
@@ -19,123 +19,123 @@
 ;; Not using run-test-async cause it tends to block and there are issues when
 ;; there are multiple async blocks in one test.
 
-(deftest customer-init
+(deftest org-init
   (rf-test/run-test-sync
-   (rf/reg-event-db :customer/load (fn [db _] (assoc db ::loading? true)))
-   (rf/dispatch [:customer/init "test-customer"])
+   (rf/reg-event-db :org/load (fn [db _] (assoc db ::loading? true)))
+   (rf/dispatch [:org/init "test-org"])
    
-   (testing "loads customer"
+   (testing "loads org"
      (is (true? (::loading? @app-db))))
 
    (testing "marks initialized"
-     (is (true? (lo/initialized? @app-db db/customer))))))
+     (is (true? (lo/initialized? @app-db db/org))))))
 
-(deftest customer-load
+(deftest org-load
   (testing "sets state to loading"
     (rf-test/run-test-sync
-     (rf/dispatch [:customer/load "load-customer"])
-     (is (true? (lo/loading? @app-db db/customer)))))
+     (rf/dispatch [:org/load "load-org"])
+     (is (true? (lo/loading? @app-db db/org)))))
 
-  (testing "sends request to api and sets customer"
+  (testing "sends request to api and sets org"
     (rf-test/run-test-sync
-     (let [cust {:name "test customer"}
+     (let [org {:name "test org"}
            c (h/catch-fx :martian.re-frame/request)]
-       (h/initialize-martian {:get-customer {:status 200
-                                             :body cust
-                                             :error-code :no-error}})
+       (h/initialize-martian {:get-org {:status 200
+                                        :body org
+                                        :error-code :no-error}})
        (is (some? (:martian.re-frame/martian @app-db)))
-       (rf/dispatch [:customer/load "test-customer"])
+       (rf/dispatch [:org/load "test-org"])
        (is (= 1 (count @c)))
-       (is (= :get-customer (-> @c first (nth 2))))))))
+       (is (= :get-org (-> @c first (nth 2))))))))
 
-(deftest customer-maybe-load
-  (testing "loads customer if not in db"
+(deftest org-maybe-load
+  (testing "loads org if not in db"
     (rf-test/run-test-sync
-     (let [cust {:id "test-cust"
-                 :name "Test customer"}
+     (let [org {:id "test-org"
+                :name "Test org"}
            c (h/catch-fx :martian.re-frame/request)]
-       (h/initialize-martian {:get-customer {:status 200
-                                             :body cust
-                                             :error-code :no-error}})
-       (rf/dispatch [:customer/maybe-load (:id cust)])
+       (h/initialize-martian {:get-org {:status 200
+                                        :body org
+                                        :error-code :no-error}})
+       (rf/dispatch [:org/maybe-load (:id org)])
        (is (= 1 (count @c))))))
 
   (testing "does not load if already in db"
     (rf-test/run-test-sync
-     (let [cust {:id "test-cust"
-                 :name "Test customer"}
+     (let [org {:id "test-org"
+                :name "Test org"}
            c (h/catch-fx :martian.re-frame/request)]
-       (reset! app-db (db/set-customer {} cust))
-       (h/initialize-martian {:get-customer {:status 200
-                                             :body cust
-                                             :error-code :no-error}})
-       (rf/dispatch [:customer/maybe-load (:id cust)])
+       (reset! app-db (db/set-org {} org))
+       (h/initialize-martian {:get-org {:status 200
+                                        :body org
+                                        :error-code :no-error}})
+       (rf/dispatch [:org/maybe-load (:id org)])
        (is (empty? @c)))))
 
   (testing "loads if id differs from id in db"
     (rf-test/run-test-sync
-     (let [cust {:id "test-cust"
-                 :name "Test customer"}
+     (let [org {:id "test-org"
+                :name "Test org"}
            c (h/catch-fx :martian.re-frame/request)]
-       (reset! app-db (db/set-customer {} {:id "other-cust"}))
-       (h/initialize-martian {:get-customer {:status 200
-                                             :body cust
-                                             :error-code :no-error}})
-       (rf/dispatch [:customer/maybe-load (:id cust)])
+       (reset! app-db (db/set-org {} {:id "other-org"}))
+       (h/initialize-martian {:get-org {:status 200
+                                        :body org
+                                        :error-code :no-error}})
+       (rf/dispatch [:org/maybe-load (:id org)])
        (is (= 1 (count @c))))))
 
   (testing "takes id from current route if not specified"
     (rf-test/run-test-sync
-     (let [cust {:id "test-cust"
-                 :name "Test customer"}
+     (let [org {:id "test-org"
+                :name "Test org"}
            c (h/catch-fx :martian.re-frame/request)]
-       (reset! app-db (r/set-current {} {:path "/c/test-cust"
-                                         :parameters {:path {:customer-id "test-cust"}}}))
-       (h/initialize-martian {:get-customer {:status 200
-                                             :body cust
-                                             :error-code :no-error}})
-       (rf/dispatch [:customer/maybe-load])
+       (reset! app-db (r/set-current {} {:path "/o/test-org"
+                                         :parameters {:path {:org-id "test-org"}}}))
+       (h/initialize-martian {:get-org {:status 200
+                                        :body org
+                                        :error-code :no-error}})
+       (rf/dispatch [:org/maybe-load])
        (is (= 1 (count @c)))))))
 
-(deftest customer-load--success
+(deftest org-load--success
   (testing "unmarks loading"
-    (is (map? (reset! app-db (lo/set-loading {} db/customer))))
-    (rf/dispatch-sync [:customer/load--success "test-customer"])
-    (is (not (lo/loading? @app-db db/customer))))
+    (is (map? (reset! app-db (lo/set-loading {} db/org))))
+    (rf/dispatch-sync [:org/load--success "test-org"])
+    (is (not (lo/loading? @app-db db/org))))
 
-  (testing "sets customer value"
-    (rf/dispatch-sync [:customer/load--success {:body ::test-customer}])
-    (is (= ::test-customer (lo/get-value @app-db db/customer)))))
+  (testing "sets org value"
+    (rf/dispatch-sync [:org/load--success {:body ::test-org}])
+    (is (= ::test-org (lo/get-value @app-db db/org)))))
 
-(deftest customer-load--failed
+(deftest org-load--failed
   (testing "sets error alert"
-    (rf/dispatch-sync [:customer/load--failed "test-cust" "test error"])
-    (let [[err] (lo/get-alerts @app-db db/customer)]
+    (rf/dispatch-sync [:org/load--failed "test-org" "test error"])
+    (let [[err] (lo/get-alerts @app-db db/org)]
       (is (= :danger (:type err)))
-      (is (re-matches #".*test-cust.*" (:message err)))))
+      (is (re-matches #".*test-org.*" (:message err)))))
 
   (testing "unmarks loading"
-    (is (map? (reset! app-db (lo/set-loading {} db/customer))))
-    (rf/dispatch-sync [:customer/load--failed "test-id" "test-customer"])
-    (is (not (lo/loading? @app-db db/customer)))))
+    (is (map? (reset! app-db (lo/set-loading {} db/org))))
+    (rf/dispatch-sync [:org/load--failed "test-id" "test-org"])
+    (is (not (lo/loading? @app-db db/org)))))
 
-(deftest customer-load-latest-builds
+(deftest org-load-latest-builds
   (testing "requests from backend"
     (rf-test/run-test-sync
-     (let [cust {:id "test-cust"
-                 :name "Test customer"}
+     (let [org {:id "test-org"
+                :name "Test org"}
            c (h/catch-fx :martian.re-frame/request)]
-       (reset! app-db (r/set-current {} {:path "/c/test-cust"
-                                         :parameters {:path {:customer-id "test-cust"}}}))
-       (h/initialize-martian {:get-customer-latest-builds {:status 200
-                                                           :body []
-                                                           :error-code :no-error}})
-       (rf/dispatch [:customer/load-latest-builds])
+       (reset! app-db (r/set-current {} {:path "/c/test-org"
+                                         :parameters {:path {:org-id "test-org"}}}))
+       (h/initialize-martian {:get-org-latest-builds {:status 200
+                                                      :body []
+                                                      :error-code :no-error}})
+       (rf/dispatch [:org/load-latest-builds])
        (is (= 1 (count @c)))))))
 
-(deftest customer-load-latest-builds--success
+(deftest org-load-latest-builds--success
   (testing "sets latest builds in db by repo"
-    (rf/dispatch-sync [:customer/load-latest-builds--success
+    (rf/dispatch-sync [:org/load-latest-builds--success
                        {:body [{:repo-id "repo-1"
                                 :build-id "build-1"}
                                {:repo-id "repo-2"
@@ -146,35 +146,35 @@
                       :build-id "build-2"}}
            (db/get-latest-builds @app-db)))))
 
-(deftest customer-load-latest-builds--failed
+(deftest org-load-latest-builds--failed
   (testing "sets error alert"
-    (rf/dispatch-sync [:customer/load-latest-builds--failed "test error"])
-    (let [[err] (lo/get-alerts @app-db db/customer)]
+    (rf/dispatch-sync [:org/load-latest-builds--failed "test error"])
+    (let [[err] (lo/get-alerts @app-db db/org)]
       (is (= :danger (:type err))))))
 
-(deftest customer-load-bb-webhooks
+(deftest org-load-bb-webhooks
   (testing "sends request to api"
     (rf-test/run-test-sync
-     (let [cust {:name "test customer"
-                 :id "test-cust"}
+     (let [org {:name "test org"
+                :id "test-org"}
            c (h/catch-fx :martian.re-frame/request)]
        (h/initialize-martian {:search-bitbucket-webhooks
                               {:status 200
-                               :body cust
+                               :body org
                                :error-code :no-error}})
        (is (some? (:martian.re-frame/martian @app-db)))
-       (rf/dispatch [:customer/load-bb-webhooks])
+       (rf/dispatch [:org/load-bb-webhooks])
        (is (= 1 (count @c)))
        (is (= :search-bitbucket-webhooks (-> @c first (nth 2))))))))
 
-(deftest customer-load-bb-webhooks--success
+(deftest org-load-bb-webhooks--success
   (testing "sets bitbucket webhooks in db"
-    (rf/dispatch-sync [:customer/load-bb-webhooks--success {:body [::test-wh]}])
+    (rf/dispatch-sync [:org/load-bb-webhooks--success {:body [::test-wh]}])
     (is (= [::test-wh] (db/bb-webhooks @app-db)))))
 
-(deftest customer-load-bb-webhooks--failed
+(deftest org-load-bb-webhooks--failed
   (testing "sets repo alert error"
-    (rf/dispatch-sync [:customer/load-bb-webhooks--failed "test error"])
+    (rf/dispatch-sync [:org/load-bb-webhooks--failed "test error"])
     (is (= [:danger] (->> (db/repo-alerts @app-db)
                           (map :type))))))
 
@@ -211,11 +211,11 @@
        (is (= "https://test-url" (-> @c first (nth 3) :repo :url)))))))
 
 (deftest repo-watch--success
-  (testing "adds repo to customer"
-    (is (some? (reset! app-db (db/set-customer {} {:repos []}))))
+  (testing "adds repo to org"
+    (is (some? (reset! app-db (db/set-org {} {:repos []}))))
     (rf/dispatch-sync [:repo/watch--success {:body {:id "test-repo"}}])
     (is (= {:repos [{:id "test-repo"}]}
-           (lo/get-value @app-db db/customer)))))
+           (lo/get-value @app-db db/org)))))
 
 (deftest repo-watch--failed
   (testing "sets error alert"
@@ -228,7 +228,7 @@
   (testing "invokes github unwatch endpoint"  
     (rf-test/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
-       (is (some? (reset! app-db (r/set-current {} {:parameters {:path {:customer-id "test-cust"}}}))))
+       (is (some? (reset! app-db (r/set-current {} {:parameters {:path {:org-id "test-org"}}}))))
        (h/initialize-martian {:unwatch-github-repo {:status 200
                                                     :error-code :no-error}})
        (is (some? (:martian.re-frame/martian @app-db)))
@@ -238,36 +238,36 @@
            "invokes correct endpoint")
        (is (= "test-repo" (-> @c first (nth 3) :repo-id))
            "passes repo id")
-       (is (= "test-cust" (-> @c first (nth 3) :customer-id))
-           "passes customer id")))))
+       (is (= "test-org" (-> @c first (nth 3) :org-id))
+           "passes org id")))))
 
 (deftest repo-unwatch-bitbucket
   (testing "invokes bitbucket unwatch endpoint"  
     (rf-test/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
-       (is (some? (reset! app-db (r/set-current {} {:parameters {:path {:customer-id "test-cust"}}}))))
+       (is (some? (reset! app-db (r/set-current {} {:parameters {:path {:org-id "test-org"}}}))))
        (h/initialize-martian {:unwatch-bitbucket-repo {:status 200
                                                        :error-code :no-error}})
        (is (some? (:martian.re-frame/martian @app-db)))
        (rf/dispatch [:repo/unwatch-bitbucket {:monkeyci/webhook
-                                              {:customer-id "test-cust"
+                                              {:org-id "test-org"
                                                :repo-id "test-repo"}}])
        (is (= 1 (count @c)))
        (is (= :unwatch-bitbucket-repo (-> @c first (nth 2)))
            "invokes correct endpoint")
        (is (= "test-repo" (-> @c first (nth 3) :repo-id))
            "passes repo id")
-       (is (= "test-cust" (-> @c first (nth 3) :customer-id))
-           "passes customer id")))))
+       (is (= "test-org" (-> @c first (nth 3) :org-id))
+           "passes org id")))))
 
 (deftest repo-unwatch--success
   (testing "updates repo in db"
     (let [repo-id "test-repo"]
-      (is (some? (reset! app-db (db/set-customer {} {:repos [{:id repo-id
-                                                              :github-id "test-github-id"}]}))))
+      (is (some? (reset! app-db (db/set-org {} {:repos [{:id repo-id
+                                                         :github-id "test-github-id"}]}))))
       (rf/dispatch-sync [:repo/unwatch--success {:body {:id repo-id}}])
       (is (= {:repos [{:id "test-repo"}]}
-             (lo/get-value @app-db db/customer))))))
+             (lo/get-value @app-db db/org))))))
 
 (deftest repo-unwatch--failed
   (testing "sets error alert"
@@ -276,68 +276,68 @@
       (is (= 1 (count a)))
       (is (= :danger (:type (first a)))))))
 
-(deftest customer-create
+(deftest org-create
   (testing "posts request to backend"
     (rf-test/run-test-sync
-     (let [cust {:name "test customer"}
+     (let [org {:name "test org"}
            c (h/catch-fx :martian.re-frame/request)]
-       (h/initialize-martian {:create-customer {:status 200
-                                                :body cust
-                                                :error-code :no-error}})
+       (h/initialize-martian {:create-org {:status 200
+                                           :body org
+                                           :error-code :no-error}})
        (is (some? (:martian.re-frame/martian @app-db)))
-       (rf/dispatch [:customer/create {:name ["test customer"]}])
+       (rf/dispatch [:org/create {:name ["test org"]}])
        (is (= 1 (count @c)))
-       (is (= :create-customer (-> @c first (nth 2))))
-       (is (= {:customer cust} (-> @c first (nth 3)))))))
+       (is (= :create-org (-> @c first (nth 2))))
+       (is (= {:org org} (-> @c first (nth 3)))))))
 
   (testing "marks creating"
-    (is (nil? (rf/dispatch-sync [:customer/create {:name "new customer"}])))
-    (is (true? (db/customer-creating? @app-db))))
+    (is (nil? (rf/dispatch-sync [:org/create {:name "new org"}])))
+    (is (true? (db/org-creating? @app-db))))
 
   (testing "clears alerts"
     (is (some? (reset! app-db (db/set-create-alerts {} [{:type :info}]))))
-    (is (nil? (rf/dispatch-sync [:customer/create {:name "new customer"}])))
+    (is (nil? (rf/dispatch-sync [:org/create {:name "new org"}])))
     (is (empty? (db/create-alerts @app-db)))))
 
-(deftest customer-create--success
+(deftest org-create--success
   (h/catch-fx :route/goto)
   
   (testing "unmarks creating"
-    (is (some? (reset! app-db (db/mark-customer-creating {}))))
-    (rf/dispatch-sync [:customer/create--success {:body {:id "test-cust"}}])
-    (is (not (db/customer-creating? @app-db))))
+    (is (some? (reset! app-db (db/mark-org-creating {}))))
+    (rf/dispatch-sync [:org/create--success {:body {:id "test-org"}}])
+    (is (not (db/org-creating? @app-db))))
 
-  (let [cust {:id "test-cust"}]
+  (let [org {:id "test-org"}]
     (is (empty? (reset! app-db {})))
-    (rf/dispatch-sync [:customer/create--success {:body cust}])
+    (rf/dispatch-sync [:org/create--success {:body org}])
 
-    (testing "sets customer in db"
-      (is (= cust (lo/get-value @app-db db/customer))))
+    (testing "sets org in db"
+      (is (= org (lo/get-value @app-db db/org))))
 
-    (testing "adds to user customers"
-      (is (= [cust] (hdb/get-customers @app-db)))))
+    (testing "adds to user orgs"
+      (is (= [org] (hdb/get-orgs @app-db)))))
 
-  (testing "redirects to customer page"
+  (testing "redirects to org page"
     (rf-test/run-test-sync
      (let [e (h/catch-fx :route/goto)]
-       (rf/dispatch [:customer/create--success {:body {:id "test-cust"}}])
+       (rf/dispatch [:org/create--success {:body {:id "test-org"}}])
        (is (= 1 (count @e)))
-       (is (= (r/path-for :page/customer {:customer-id "test-cust"}) (first @e))))))
+       (is (= (r/path-for :page/org {:org-id "test-org"}) (first @e))))))
 
-  (testing "sets success alert for customer"
-    (let [a (lo/get-alerts @app-db db/customer)]
-      (rf/dispatch-sync [:customer/create--success {:body {:name "test customer"}}])
+  (testing "sets success alert for org"
+    (let [a (lo/get-alerts @app-db db/org)]
+      (rf/dispatch-sync [:org/create--success {:body {:name "test org"}}])
       (is (not-empty a))
       (is (= :success (-> a first :type))))))
 
-(deftest customer-create--failed
+(deftest org-create--failed
   (testing "sets error alert"
-    (rf/dispatch-sync [:customer/create--failed {:message "test error"}])
+    (rf/dispatch-sync [:org/create--failed {:message "test error"}])
     (let [a (db/create-alerts @app-db)]
       (is (= 1 (count a)))
       (is (= :danger (:type (first a)))))))
 
-(deftest customer-load-recent-builds
+(deftest org-load-recent-builds
   (testing "sends request to backend"
     (rf-test/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
@@ -345,97 +345,97 @@
                                                   :body []
                                                   :error-code :no-error}})
        (is (some? (:martian.re-frame/martian @app-db)))
-       (rf/dispatch [:customer/load-recent-builds "test-customer"])
+       (rf/dispatch [:org/load-recent-builds "test-org"])
        (is (= 1 (count @c)))
        (is (= :get-recent-builds (-> @c first (nth 2))))))))
 
-(deftest customer-load-recent-builds--success
+(deftest org-load-recent-builds--success
   (testing "sets builds in db"
     (let [builds [{:id ::test-build}]]
-      (rf/dispatch-sync [:customer/load-recent-builds--success {:body builds}])
+      (rf/dispatch-sync [:org/load-recent-builds--success {:body builds}])
       (is (= builds (lo/get-value @app-db db/recent-builds))))))
 
-(deftest customer-load-recent-builds--failed
+(deftest org-load-recent-builds--failed
   (testing "sets error in db"
-    (rf/dispatch-sync [:customer/load-recent-builds--failed "test error"])
+    (rf/dispatch-sync [:org/load-recent-builds--failed "test error"])
     (is (= [:danger] (->> (lo/get-alerts @app-db db/recent-builds)
                           (map :type))))))
 
-(deftest customer-load-stats
+(deftest org-load-stats
   (testing "sends request to backend"
     (rf-test/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
-       (h/initialize-martian {:get-customer-stats {:status 200
-                                                   :body {:stats ::test}
-                                                   :error-code :no-error}})
+       (h/initialize-martian {:get-org-stats {:status 200
+                                              :body {:stats ::test}
+                                              :error-code :no-error}})
        (is (some? (:martian.re-frame/martian @app-db)))
-       (rf/dispatch [:customer/load-stats "test-customer"])
+       (rf/dispatch [:org/load-stats "test-org"])
        (is (= 1 (count @c)))
-       (is (= :get-customer-stats (-> @c first (nth 2)))))))
+       (is (= :get-org-stats (-> @c first (nth 2)))))))
 
   (testing "adds `since` query param if days given"
     (rf-test/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
-       (h/initialize-martian {:get-customer-stats {:status 200
-                                                   :body {}
-                                                   :error-code :no-error}})
+       (h/initialize-martian {:get-org-stats {:status 200
+                                              :body {}
+                                              :error-code :no-error}})
        (is (some? (:martian.re-frame/martian @app-db)))
-       (rf/dispatch [:customer/load-stats "test-customer" 10])
+       (rf/dispatch [:org/load-stats "test-org" 10])
        (is (number? (-> @c first (nth 3) :since)))))))
 
-(deftest customer-load-stats--success
+(deftest org-load-stats--success
   (testing "sets builds in db"
     (let [stats [{:stats {:elapsed-seconds []}}]]
-      (rf/dispatch-sync [:customer/load-stats--success {:body stats}])
+      (rf/dispatch-sync [:org/load-stats--success {:body stats}])
       (is (= stats (lo/get-value @app-db db/stats))))))
 
-(deftest customer-load-stats--failed
+(deftest org-load-stats--failed
   (testing "sets error in db"
-    (rf/dispatch-sync [:customer/load-stats--failed "test error"])
+    (rf/dispatch-sync [:org/load-stats--failed "test error"])
     (is (= [:danger] (->> (lo/get-alerts @app-db db/stats)
                           (map :type))))))
 
-(deftest customer-load-credits
+(deftest org-load-credits
   (testing "sends request to backend"
     (rf-test/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
-       (h/initialize-martian {:get-customer-credits
+       (h/initialize-martian {:get-org-credits
                               {:status 200
                                :body {:available 100}
                                :error-code :no-error}})
        (is (some? (:martian.re-frame/martian @app-db)))
-       (rf/dispatch [:customer/load-credits "test-customer"])
+       (rf/dispatch [:org/load-credits "test-org"])
        (is (= 1 (count @c)))
-       (is (= :get-customer-credits (-> @c first (nth 2))))))))
+       (is (= :get-org-credits (-> @c first (nth 2))))))))
 
-(deftest customer-load-credits--success
+(deftest org-load-credits--success
   (testing "sets credit info in db"
-    (rf/dispatch-sync [:customer/load-credits--success {:body {:available 100}}])
+    (rf/dispatch-sync [:org/load-credits--success {:body {:available 100}}])
     (is (= {:available 100} (db/get-credits @app-db)))))
 
-(deftest customer-load-credits--failed
+(deftest org-load-credits--failed
   (testing "sets error in db"
-    (rf/dispatch-sync [:customer/load-credits--failed "test error"])
+    (rf/dispatch-sync [:org/load-credits--failed "test error"])
     (is (= [:danger] (->> (lo/get-alerts @app-db db/credits)
                           (map :type))))))
 
-(deftest customer-event
+(deftest org-event
   (testing "does nothing when recent builds not loaded"
-    (rf/dispatch-sync [:customer/handle-event {:type :build/updated
-                                               :build {:id "test-build"}}])
+    (rf/dispatch-sync [:org/handle-event {:type :build/updated
+                                          :build {:id "test-build"}}])
     (is (empty? @app-db)))
   
   (testing "adds build to recent builds"
     (let [build {:id "test-build"}]
       (is (some? (reset! app-db (lo/set-loaded {} db/recent-builds))))
-      (rf/dispatch-sync [:customer/handle-event {:type :build/updated
-                                                 :build build}])
+      (rf/dispatch-sync [:org/handle-event {:type :build/updated
+                                            :build build}])
       (is (= [build] (lo/get-value @app-db db/recent-builds)))))
 
   (testing "updates build in recent builds"
     (let [make-build (fn [opts]
                        (merge {:id (random-uuid)
-                               :customer-id "test-cust"
+                               :customer-id "test-org"
                                :repo-id "test-repo"
                                :build-id (random-uuid)}
                               opts))
@@ -450,8 +450,8 @@
                                     (lo/set-loaded db/recent-builds)
                                     (lo/set-value db/recent-builds [build
                                                                     other-build])))))
-      (rf/dispatch-sync [:customer/handle-event {:type :build/updated
-                                                 :build upd}])
+      (rf/dispatch-sync [:org/handle-event {:type :build/updated
+                                            :build upd}])
       (is (= [upd
               other-build]
              (lo/get-value @app-db db/recent-builds))))))
@@ -459,17 +459,17 @@
 (deftest group-by-lbl-changed
   (testing "updates group-by-lbl in db"
     (is (nil? (db/group-by-lbl @app-db)))
-    (rf/dispatch-sync [:customer/group-by-lbl-changed "new-label"])
+    (rf/dispatch-sync [:org/group-by-lbl-changed "new-label"])
     (is (= "new-label" (db/group-by-lbl @app-db)))))
 
 (deftest repo-filter-changed
   (testing "updates repo filter in db"
     (is (nil? (db/get-repo-filter @app-db)))
-    (rf/dispatch-sync [:customer/repo-filter-changed "test-filter"])
+    (rf/dispatch-sync [:org/repo-filter-changed "test-filter"])
     (is (= "test-filter" (db/get-repo-filter @app-db)))))
 
 (deftest ext-repo-filter-changed
   (testing "updates ext repo filter in db"
     (is (nil? (db/get-ext-repo-filter @app-db)))
-    (rf/dispatch-sync [:customer/ext-repo-filter-changed "test-filter"])
+    (rf/dispatch-sync [:org/ext-repo-filter-changed "test-filter"])
     (is (= "test-filter" (db/get-ext-repo-filter @app-db)))))

--- a/gui/test/monkey/ci/gui/test/org/events_test.cljc
+++ b/gui/test/monkey/ci/gui/test/org/events_test.cljc
@@ -1,9 +1,9 @@
-(ns monkey.ci.gui.test.customer.events-test
+(ns monkey.ci.gui.test.org.events-test
   (:require #?(:cljs [cljs.test :refer-macros [deftest testing is use-fixtures async]]
                :clj [clojure.test :refer [deftest testing is use-fixtures]])
             [day8.re-frame.test :as rf-test]
-            [monkey.ci.gui.customer.db :as db]
-            [monkey.ci.gui.customer.events :as sut]
+            [monkey.ci.gui.org.db :as db]
+            [monkey.ci.gui.org.events :as sut]
             [monkey.ci.gui.home.db :as hdb]
             [monkey.ci.gui.loader :as lo]
             [monkey.ci.gui.login.db :as ldb]

--- a/gui/test/monkey/ci/gui/test/org/subs_test.cljc
+++ b/gui/test/monkey/ci/gui/test/org/subs_test.cljc
@@ -1,10 +1,10 @@
-(ns monkey.ci.gui.test.customer.subs-test
+(ns monkey.ci.gui.test.org.subs-test
   (:require #?(:cljs [cljs.test :refer-macros [deftest testing is use-fixtures]]
                :clj [clojure.test :refer [deftest testing is use-fixtures]])
             [monkey.ci.gui.apis.bitbucket :as bb]
             [monkey.ci.gui.apis.github :as github]
-            [monkey.ci.gui.customer.db :as db]
-            [monkey.ci.gui.customer.subs :as sut]
+            [monkey.ci.gui.org.db :as db]
+            [monkey.ci.gui.org.subs :as sut]
             [monkey.ci.gui.loader :as lo]
             [monkey.ci.gui.test.fixtures :as f]
             [monkey.ci.gui.test.helpers :as h]

--- a/gui/test/monkey/ci/gui/test/org/subs_test.cljc
+++ b/gui/test/monkey/ci/gui/test/org/subs_test.cljc
@@ -16,38 +16,38 @@
 (use-fixtures :each f/reset-db)
 
 (deftest alerts
-  (let [s (rf/subscribe [:customer/alerts])]
+  (let [s (rf/subscribe [:org/alerts])]
     (testing "exists"
       (is (some? s)))
 
-    (testing "returns customer alerts from db"
+    (testing "returns org alerts from db"
       (let [a [{:type :info
                 :message "Test alert"}]]
-        (is (map? (reset! app-db (lo/set-alerts {} db/customer a))))
+        (is (map? (reset! app-db (lo/set-alerts {} db/org a))))
         (is (= a @s))))))
 
-(deftest customer-info
-  (let [ci (rf/subscribe [:customer/info])]
+(deftest org-info
+  (let [ci (rf/subscribe [:org/info])]
     (testing "exists"
       (is (some? ci)))
 
-    (testing "holds customer info from db"
+    (testing "holds org info from db"
       (is (nil? @ci))
-      (is (map? (reset! app-db (db/set-customer {} ::test-customer))))
-      (is (= ::test-customer @ci)))))
+      (is (map? (reset! app-db (db/set-org {} ::test-org))))
+      (is (= ::test-org @ci)))))
 
-(deftest customer-loading?
-  (let [l (rf/subscribe [:customer/loading?])]
+(deftest org-loading?
+  (let [l (rf/subscribe [:org/loading?])]
     (testing "exists"
       (is (some? l)))
 
     (testing "holds loading state from db"
       (is (not @l))
-      (is (map? (reset! app-db (lo/set-loading {} db/customer))))
+      (is (map? (reset! app-db (lo/set-loading {} db/org))))
       (is (true? @l)))))
 
 (deftest github-repos
-  (let [r (rf/subscribe [:customer/github-repos])]
+  (let [r (rf/subscribe [:org/github-repos])]
     (testing "exists"
       (is (some? r)))
 
@@ -62,15 +62,15 @@
                                                       :clone-url "https://clone-url"}]))))
 
       (testing "by github id"
-        (is (map? (swap! app-db db/set-customer {:repos [{:github-id "github-repo-id"}]})))
+        (is (map? (swap! app-db db/set-org {:repos [{:github-id "github-repo-id"}]})))
         (is (true? (-> @r first :monkeyci/watched?))))
       
       (testing "not by clone url"
-        (is (map? (swap! app-db db/set-customer {:repos [{:url "https://clone-url"}]})))
+        (is (map? (swap! app-db db/set-org {:repos [{:url "https://clone-url"}]})))
         (is (not (-> @r first :monkeyci/watched?))))
       
       (testing "not by ssh url"
-        (is (map? (swap! app-db db/set-customer {:repos [{:url "ssh@ssh-url"}]})))
+        (is (map? (swap! app-db db/set-org {:repos [{:url "ssh@ssh-url"}]})))
         (is (not (-> @r first :monkeyci/watched?)))))
 
     (testing "contains repo info"
@@ -79,7 +79,7 @@
                                                        :name "test repo"
                                                        :ssh-url "ssh@ssh-url"
                                                        :clone-url "https://clone-url"}])
-                                   (db/set-customer {:repos [{:url "ssh@ssh-url"
+                                   (db/set-org {:repos [{:url "ssh@ssh-url"
                                                               :id "test-repo"
                                                               :github-id "github-repo-id"}]})))))
       (is (= "test-repo" (-> @r first :monkeyci/repo :id))))
@@ -91,7 +91,7 @@
       (is (empty? @r)))))
 
 (deftest bitbucket-repos
-  (let [r (rf/subscribe [:customer/bitbucket-repos])]
+  (let [r (rf/subscribe [:org/bitbucket-repos])]
     (testing "exists"
       (is (some? r)))
 
@@ -108,7 +108,7 @@
                                    (bb/set-repos [{:uuid "bb-repo-id"
                                                    :name "test repo"
                                                    :links {:html "http://test-url"}}])
-                                   (db/set-customer {:repos [{:url "ssh@ssh-url"
+                                   (db/set-org {:repos [{:url "ssh@ssh-url"
                                                               :id "test-repo"
                                                               :github-id "github-repo-id"}]})))))
       (is (= "test-repo" (-> @r first :monkeyci/repo :id))))
@@ -128,7 +128,7 @@
       (is (empty? @r)))))
 
 (deftest repo-alerts
-  (let [a (rf/subscribe [:customer/repo-alerts])]
+  (let [a (rf/subscribe [:org/repo-alerts])]
     (testing "exists"
       (is (some? a)))
 
@@ -144,7 +144,7 @@
           (is (= [alert gh-alert] @a)))))))
 
 (deftest create-alerts
-  (let [s (rf/subscribe [:customer/create-alerts])]
+  (let [s (rf/subscribe [:org/create-alerts])]
     (testing "exists"
       (is (some? s)))
 
@@ -154,18 +154,18 @@
         (is (map? (reset! app-db (db/set-create-alerts {} a))))
         (is (= a @s))))))
 
-(deftest customer-creating?
-  (let [l (rf/subscribe [:customer/creating?])]
+(deftest org-creating?
+  (let [l (rf/subscribe [:org/creating?])]
     (testing "exists"
       (is (some? l)))
 
     (testing "holds creating state from db"
       (is (not @l))
-      (is (map? (reset! app-db (db/mark-customer-creating {}))))
+      (is (map? (reset! app-db (db/mark-org-creating {}))))
       (is (true? @l)))))
 
-(deftest customer-recent-builds
-  (let [l (rf/subscribe [:customer/recent-builds])]
+(deftest org-recent-builds
+  (let [l (rf/subscribe [:org/recent-builds])]
     (testing "exists"
       (is (some? l)))
 
@@ -183,22 +183,22 @@
         (is (map? (reset! app-db (lo/set-value {} db/recent-builds builds))))
         (is (= (:id new) (:id (first @l))))))
 
-    (testing "adds repo name from customer info"
+    (testing "adds repo name from org info"
       (is (some? (reset! app-db (-> {}
                                     (lo/set-value db/recent-builds [{:id "test-build"
                                                                      :repo-id "test-repo"}])
-                                    (db/set-customer {:repos [{:id "test-repo"
+                                    (db/set-org {:repos [{:id "test-repo"
                                                                :name "test repo name"}]})))))
       (is (= "test repo name" (-> @l first :repo :name))))))
 
-(deftest customer-stats
-  (h/verify-sub [:customer/stats] #(lo/set-value % db/stats ::test-stats) ::test-stats nil))
+(deftest org-stats
+  (h/verify-sub [:org/stats] #(lo/set-value % db/stats ::test-stats) ::test-stats nil))
 
-(deftest customer-credits
-  (h/verify-sub [:customer/credits] #(lo/set-value % db/credits ::test-creds) ::test-creds nil))
+(deftest org-credits
+  (h/verify-sub [:org/credits] #(lo/set-value % db/credits ::test-creds) ::test-creds nil))
 
 (deftest credit-stats
-  (h/verify-sub [:customer/credit-stats]
+  (h/verify-sub [:org/credit-stats]
                 (fn [db]
                   (-> db
                       (lo/set-value db/credits {:available 100})
@@ -210,17 +210,17 @@
                  :consumed 15}
                 nil))
 
-(deftest customer-labels
-  (let [l (rf/subscribe [:customer/labels])]
+(deftest org-labels
+  (let [l (rf/subscribe [:org/labels])]
     (testing "exists"
       (is (some? l)))
 
-    (testing "provides distinct labels for all customer repos, sorted"
+    (testing "provides distinct labels for all org repos, sorted"
       (is (empty? @l))
-      (is (some? (reset! app-db (db/set-customer
+      (is (some? (reset! app-db (db/set-org
                                  {}
                                  {:id "test-cust"
-                                  :name "Test customer"
+                                  :name "Test org"
                                   :repos [{:id "repo-1"
                                            :name "Test repo 1"
                                            :labels
@@ -238,15 +238,15 @@
       (is (= ["label-1" "label-2" "label-3"]
              @l)))))
 
-(deftest customer-group-by-lbl
+(deftest org-group-by-lbl
   (h/verify-sub
-   [:customer/group-by-lbl]
+   [:org/group-by-lbl]
    #(db/set-group-by-lbl % "test-lbl")
    "test-lbl"
    "project"))
 
-(deftest customer-grouped-repos
-  (let [r (rf/subscribe [:customer/grouped-repos])]
+(deftest org-grouped-repos
+  (let [r (rf/subscribe [:org/grouped-repos])]
     (testing "exists"
       (is (some? r)))
 
@@ -271,7 +271,7 @@
       (testing "returns repos, grouped by label from db"
         (is (some? (reset! app-db (-> {}
                                       (db/set-group-by-lbl "label-2")
-                                      (db/set-customer
+                                      (db/set-org
                                        {:repos repos})))))
         (is (= {"value 1" [repo-1 repo-2]
                 "value 2" [repo-3]}
@@ -281,23 +281,23 @@
         (is (some? (swap! app-db db/set-repo-filter "2")))
         (is (= {"value 1" [repo-2]} @r))))))
 
-(deftest customer-repo-filter
+(deftest org-repo-filter
   (h/verify-sub
-   [:customer/repo-filter]
+   [:org/repo-filter]
    #(db/set-repo-filter % "test-filter")
    "test-filter"
    nil))
 
-(deftest customer-ext-repo-filter
+(deftest org-ext-repo-filter
   (h/verify-sub
-   [:customer/ext-repo-filter]
+   [:org/ext-repo-filter]
    #(db/set-ext-repo-filter % "test-filter")
    "test-filter"
    nil))
 
 (deftest bb-webhooks
   (h/verify-sub
-   [:customer/bb-webhooks]
+   [:org/bb-webhooks]
    #(db/set-bb-webhooks % ::test-webhooks)
    ::test-webhooks
    nil))
@@ -305,7 +305,7 @@
 (deftest latest-build
   (let [repo-id "test-repo"
         build ::test-build
-        l (rf/subscribe [:customer/latest-build repo-id])]
+        l (rf/subscribe [:org/latest-build repo-id])]
     (testing "exists"
       (is (some? l)))
 

--- a/gui/test/monkey/ci/gui/test/params/events_test.cljc
+++ b/gui/test/monkey/ci/gui/test/params/events_test.cljc
@@ -12,31 +12,31 @@
 
 (use-fixtures :each f/reset-db)
 
-(deftest customer-load-params
+(deftest org-load-params
   (testing "sends request to backend"
     (rf-test/run-test-sync
      (let [params [{:parameters [{:name "test-param" :value "test-val"}]}]
            c (h/catch-fx :martian.re-frame/request)]
-       (h/initialize-martian {:get-customer-params {:status 200
-                                                    :body params
-                                                    :error-code :no-error}})
+       (h/initialize-martian {:get-org-params {:status 200
+                                               :body params
+                                               :error-code :no-error}})
        (is (some? (:martian.re-frame/martian @app-db)))
-       (rf/dispatch [:params/load "test-customer"])
+       (rf/dispatch [:params/load "test-org"])
        (is (= 1 (count @c)))
-       (is (= :get-customer-params (-> @c first (nth 2)))))))
+       (is (= :get-org-params (-> @c first (nth 2)))))))
   
   (testing "marks loading"
-    (rf/dispatch-sync [:params/load "test-cust"])
+    (rf/dispatch-sync [:params/load "test-org"])
     (is (true? (db/loading? @app-db))))
 
   (testing "clears alerts"
     (is (some? (reset! app-db (db/set-alerts {} ::test-alerts))))
-    (rf/dispatch-sync [:params/load "test-cust"])
+    (rf/dispatch-sync [:params/load "test-org"])
     (is (nil? (db/alerts @app-db))))
 
   (testing "clears editing"
     (is (some? (reset! app-db (db/set-editing {} ::test-id ::test-params))))
-    (rf/dispatch-sync [:params/load "test-cust"])
+    (rf/dispatch-sync [:params/load "test-org"])
     (is (nil? (db/get-editing @app-db ::test-id)))))
 
 (deftest load-params--success
@@ -209,7 +209,7 @@
     (rf/dispatch-sync [:params/cancel-all])
     (is (nil? (db/edit-sets @app-db))))
 
-  (testing "redirects to customer page"
+  (testing "redirects to org page"
     (let [e (h/catch-fx :route/goto)]
       (rf-test/run-test-sync
        (rf/dispatch [:params/cancel-all])

--- a/gui/test/monkey/ci/gui/test/params/subs_test.cljc
+++ b/gui/test/monkey/ci/gui/test/params/subs_test.cljc
@@ -13,19 +13,19 @@
 
 (rf/clear-subscription-cache!)
 
-(deftest customer-params
-  (h/verify-sub [:customer/params]
+(deftest org-params
+  (h/verify-sub [:org/params]
                 #(db/set-params % [::test-params])
                 [::test-params]
                 nil))
 
-(deftest customer-param
+(deftest org-param
   (let [id (random-uuid)
-        cp (rf/subscribe [:customer/param id 0])]
+        cp (rf/subscribe [:org/param id 0])]
     (testing "exists"
       (is (some? cp)))
 
-    (testing "returns customer param in set"
+    (testing "returns org param in set"
       (is (some? (reset! app-db (db/set-editing {} id {:id id
                                                        :parameters
                                                        [{:name "param name"

--- a/gui/test/monkey/ci/gui/test/repo/events_test.cljc
+++ b/gui/test/monkey/ci/gui/test/repo/events_test.cljc
@@ -2,7 +2,7 @@
   (:require #?(:cljs [cljs.test :refer-macros [deftest testing is use-fixtures]]
                :clj [clojure.test :refer [deftest testing is use-fixtures]])
             [day8.re-frame.test :as rft]
-            [monkey.ci.gui.customer.db :as cdb]
+            [monkey.ci.gui.org.db :as cdb]
             [monkey.ci.gui.loader :as lo]
             [monkey.ci.gui.repo.db :as db]
             [monkey.ci.gui.repo.events :as sut]

--- a/gui/test/monkey/ci/gui/test/repo/events_test.cljc
+++ b/gui/test/monkey/ci/gui/test/repo/events_test.cljc
@@ -14,21 +14,21 @@
 
 (use-fixtures :each f/reset-db)
 
-(defn- set-repo-path [db cust repo]
+(defn- set-repo-path [db org repo]
   (r/set-current db {:parameters
                      {:path 
-                      {:customer-id cust
+                      {:org-id org
                        :repo-id repo}}}))
 
-(defn- set-repo-path! [cust repo]
-  (swap! app-db set-repo-path cust repo))
+(defn- set-repo-path! [org repo]
+  (swap! app-db set-repo-path org repo))
 
 (defn- test-repo-path!
-  "Generate random ids for customer, repo and build, and sets the current
+  "Generate random ids for org, repo and build, and sets the current
    route to the generated path.  Returns the generated ids."
   []
-  (let [[cust repo _ :as r] (repeatedly 3 random-uuid)]
-    (set-repo-path! cust repo)
+  (let [[org repo _ :as r] (repeatedly 3 random-uuid)]
+    (set-repo-path! org repo)
     r))
 
 (deftest repo-init
@@ -36,7 +36,7 @@
     (rft/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
        (reset! app-db (lo/set-initialized {} db/id))
-       (h/initialize-martian {:get-customer {:error-code :unexpected}})
+       (h/initialize-martian {:get-org {:error-code :unexpected}})
 
        (rf/dispatch [:repo/init])
        (is (empty? @c)))))
@@ -44,7 +44,7 @@
   (testing "when not initialized"
     (rft/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
-       (h/initialize-martian {:get-customer {:body {}
+       (h/initialize-martian {:get-org {:body {}
                                              :error-code :no-error}})
        (rf/dispatch [:repo/init])
        
@@ -55,29 +55,29 @@
          (is (lo/initialized? @app-db db/id)))))))
 
 (deftest repo-load
-  (testing "loads customer if not existing"
+  (testing "loads org if not existing"
     (rft/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
-       (h/initialize-martian {:get-customer {:body {:name "test customer"}
+       (h/initialize-martian {:get-org {:body {:name "test org"}
                                              :error-code :no-error}})
        
-       (rf/dispatch [:repo/load "test-customer-id"])
+       (rf/dispatch [:repo/load "test-org-id"])
        (is (= 1 (count @c)))
-       (is (= :get-customer (-> @c first (nth 2)))))))
+       (is (= :get-org (-> @c first (nth 2)))))))
 
-  (testing "does not load customer if already loaded"
+  (testing "does not load org if already loaded"
     (rft/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
-       (reset! app-db (cdb/set-customer {} {:name "existing customer"}))
-       (h/initialize-martian {:get-customer {:body {:name "test customer"}
+       (reset! app-db (cdb/set-org {} {:name "existing org"}))
+       (h/initialize-martian {:get-org {:body {:name "test org"}
                                              :error-code :no-error}})
        
-       (rf/dispatch [:repo/load "test-customer-id"])
+       (rf/dispatch [:repo/load "test-org-id"])
        (is (empty? @c)))))
 
   (testing "clears builds"
     (is (some? (reset! app-db (db/set-builds {} ::test-builds))))
-    (rf/dispatch-sync [:repo/load "other-customer-id"])
+    (rf/dispatch-sync [:repo/load "other-org-id"])
     (is (nil? (db/get-builds @app-db)))))
 
 (deftest repo-leave
@@ -90,7 +90,7 @@
   (testing "fetches builds from backend"
     (rft/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
-       (set-repo-path! "test-cust" "test-repo")
+       (set-repo-path! "test-org" "test-repo")
        (h/initialize-martian {:get-builds {:body [{:id "test-build"}]
                                            :error-code :no-error}})
        (rf/dispatch [:builds/load])
@@ -110,9 +110,9 @@
 
 (deftest handle-event
   (testing "ignores events for other repos"
-    (let [[cust] (test-repo-path!)]
+    (let [[org] (test-repo-path!)]
       (is (nil? (rf/dispatch-sync [:repo/handle-event {:type :build/start
-                                                       :build {:customer-id cust
+                                                       :build {:org-id org
                                                                :repo-id "other-repo"
                                                                :build-id "other-build"
                                                                :git {:ref "main"}}}])))
@@ -120,14 +120,14 @@
 
   (testing "updates build list when build is started"
     (reset! app-db {})
-    (let [[cust repo build] (test-repo-path!)]
+    (let [[org repo build] (test-repo-path!)]
       (is (empty? (db/get-builds @app-db)))
       (is (nil? (rf/dispatch-sync [:repo/handle-event {:type :build/start
-                                                       :build {:customer-id cust
+                                                       :build {:org-id org
                                                                :repo-id repo
                                                                :build-id build
                                                                :git {:ref "main"}}}])))
-      (is (= [{:customer-id cust
+      (is (= [{:org-id org
                :repo-id repo
                :build-id build
                :git {:ref "main"}}]
@@ -135,14 +135,14 @@
 
   (testing "updates build list when build is pending"
     (reset! app-db {})
-    (let [[cust repo build] (test-repo-path!)]
+    (let [[org repo build] (test-repo-path!)]
       (is (empty? (db/get-builds @app-db)))
       (is (nil? (rf/dispatch-sync [:repo/handle-event {:type :build/pending
-                                                       :build {:customer-id cust
+                                                       :build {:org-id org
                                                                :repo-id repo
                                                                :build-id build
                                                                :git {:ref "main"}}}])))
-      (is (= [{:customer-id cust
+      (is (= [{:org-id org
                :repo-id repo
                :build-id build
                :git {:ref "main"}}]
@@ -150,13 +150,13 @@
 
   (testing "updates build list when build has updated"
     (reset! app-db {})
-    (let [[cust repo build] (test-repo-path!)
-          upd {:customer-id cust
+    (let [[org repo build] (test-repo-path!)
+          upd {:org-id org
                :repo-id repo
                :build-id build
                :git {:ref "main"}
                :status :success}]
-      (is (some? (swap! app-db db/set-builds [{:customer-id cust
+      (is (some? (swap! app-db db/set-builds [{:org-id org
                                                :repo-id repo
                                                :build-id build}])))
       (is (nil? (rf/dispatch-sync [:repo/handle-event {:type :build/updated
@@ -183,7 +183,7 @@
   (testing "invokes build trigger endpoint with params"
     (rft/run-test-sync
      (let [c (h/catch-fx :martian.re-frame/request)]
-       (is (some? (set-repo-path! "test-cust" "test-repo")))
+       (is (some? (set-repo-path! "test-org" "test-repo")))
        (h/initialize-martian {:trigger-build {:body {:build-id "test-build"}
                                               :error-code :no-error}})
        (rf/dispatch [:repo/trigger-build {:trigger-type ["branch"]
@@ -191,7 +191,7 @@
        
        (is (= 1 (count @c)))
        (is (= {:branch "main"
-               :customer-id "test-cust"
+               :org-id "test-org"
                :repo-id "test-repo"}
               (-> @c first (nth 3)))))))
 
@@ -221,15 +221,15 @@
          [_ repo-id _] (test-repo-path!)
          repo {:id repo-id
                :name "test repo"}
-         cust {:repos [repo]}]
+         org {:repos [repo]}]
      (reset! app-db (db/set-edit-alerts {} [{:type :warning}]))
-     (h/initialize-martian {:get-customer {:body cust
+     (h/initialize-martian {:get-org {:body org
                                            :error-code :no-error}})
      (rf/dispatch [:repo/load+edit])
 
-     (testing "loads customer from backend"
+     (testing "loads org from backend"
        (is (= 1 (count @c)))
-       (is (= :get-customer (-> @c first (nth 2)))))
+       (is (= :get-org (-> @c first (nth 2)))))
 
      (testing "clears alerts"
        (is (empty? (db/edit-alerts @app-db)))))))
@@ -239,12 +239,12 @@
    (let [[_ repo-id] (test-repo-path!)
          repo {:id repo-id
                :name "test repo"}
-         cust {:repos [repo]}]
+         org {:repos [repo]}]
 
-     (rf/dispatch [:repo/load+edit--success {:body cust}])
+     (rf/dispatch [:repo/load+edit--success {:body org}])
      
-     (testing "sets current customer"
-       (is (= cust (lo/get-value @app-db cdb/customer))))
+     (testing "sets current org"
+       (is (= org (lo/get-value @app-db cdb/org))))
      
      (testing "sets repo for editing"
        (is (= repo (db/editing @app-db)))))))
@@ -308,7 +308,7 @@
 (deftest repo-save
   (rft/run-test-sync
    (let [c (h/catch-fx :martian.re-frame/request)
-         [cust-id repo-id] (test-repo-path!)]
+         [org-id repo-id] (test-repo-path!)]
      (swap! app-db #(-> %
                         (db/set-editing {:name "updated repo name"})
                         (db/set-edit-alerts [{:type :warning}])))
@@ -321,16 +321,16 @@
      (testing "updates repo in backend"
        (is (= 1 (count @c))))
 
-     (testing "adds customer and repo id to body"
+     (testing "adds org and repo id to body"
        (let [args (-> @c first (nth 3) :repo)]
          (is (map? args))
-         (is (= cust-id (:customer-id args)))
+         (is (= org-id (:org-id args)))
          (is (= repo-id (:id args)))))
 
-     (testing "adds customer and repo id to params"
+     (testing "adds org and repo id to params"
        (let [args (-> @c first (nth 3))]
          (is (map? args))
-         (is (= cust-id (:customer-id args)))
+         (is (= org-id (:org-id args)))
          (is (= repo-id (:repo-id args)))))
 
      (testing "marks saving"
@@ -341,15 +341,15 @@
 
 (deftest repo-save--success
   (testing "updates repo in db"
-    (reset! app-db (cdb/set-customer {}
-                                     {:name "test customer"
-                                      :repos [{:id "test-repo"
-                                               :name "original repo"}]}))
+    (reset! app-db (cdb/set-org {}
+                                {:name "test org"
+                                 :repos [{:id "test-repo"
+                                          :name "original repo"}]}))
     (rf/dispatch-sync [:repo/save--success {:body {:id "test-repo"
                                                    :name "updated repo"}}])
     (is (= "updated repo"
            (-> @app-db
-               (lo/get-value cdb/customer)
+               (lo/get-value cdb/org)
                :repos
                first
                :name))))
@@ -382,7 +382,7 @@
 (deftest repo-delete
   (rft/run-test-sync
    (let [c (h/catch-fx :martian.re-frame/request)
-         [cust-id repo-id] (test-repo-path!)]
+         [org-id repo-id] (test-repo-path!)]
      (swap! app-db #(db/set-editing % {:id "test-repo"}))
      (h/initialize-martian {:delete-repo {:error-code :no-error}})
 
@@ -398,31 +398,31 @@
 (deftest repo-delete--success
   (rft/run-test-sync
    (let [repo {:id "test-repo"}
-         cust {:id "test-cust"
+         org {:id "test-org"
                :repos [repo]}
          e (h/catch-fx :route/goto)]
      (is (some? (reset! app-db (-> {}
-                                   (set-repo-path (:id cust) (:id repo))
-                                   (cdb/set-customer cust)
+                                   (set-repo-path (:id org) (:id repo))
+                                   (cdb/set-org org)
                                    (db/mark-deleting)))))
      (rf/dispatch [:repo/delete--success])
      
      (testing "removes repo from db"
-       (is (empty? (-> (cdb/get-customer @app-db) :repos))))
+       (is (empty? (-> (cdb/get-org @app-db) :repos))))
 
      (testing "unmarks deleting"
        (is (not (db/deleting? @app-db))))
 
-     (testing "sets customer alert"
+     (testing "sets org alert"
        (is (= :info (-> (cdb/get-alerts @app-db)
                         first
                         :type))))
 
-     (testing "redirects to customer page"
+     (testing "redirects to org page"
        (is (= 1 (count @e)))))))
 
 (deftest repo-delete--failed
-  (is (some? (set-repo-path! "test-cust" "test-repo")))
+  (is (some? (set-repo-path! "test-org" "test-repo")))
   (is (some? (swap! app-db db/mark-deleting)))
   (rf/dispatch-sync [:repo/delete--failed])
   

--- a/gui/test/monkey/ci/gui/test/repo/subs_test.cljc
+++ b/gui/test/monkey/ci/gui/test/repo/subs_test.cljc
@@ -1,7 +1,7 @@
 (ns monkey.ci.gui.test.repo.subs-test
   (:require #?(:cljs [cljs.test :refer-macros [deftest testing is use-fixtures]]
                :clj [clojure.test :refer [deftest testing is use-fixtures]])
-            [monkey.ci.gui.customer.db :as cdb]
+            [monkey.ci.gui.org.db :as cdb]
             [monkey.ci.gui.loader :as lo]
             [monkey.ci.gui.repo.db :as db]
             [monkey.ci.gui.repo.subs :as sut]

--- a/gui/test/monkey/ci/gui/test/repo/subs_test.cljc
+++ b/gui/test/monkey/ci/gui/test/repo/subs_test.cljc
@@ -21,7 +21,7 @@
     
     (testing "returns repo by id from customer"
       (is (nil? @r))
-      (is (map? (reset! app-db (cdb/set-customer
+      (is (map? (reset! app-db (cdb/set-org
                                 {}
                                 {:repos
                                  [{:id "test-repo"

--- a/gui/test/monkey/ci/gui/test/routing_test.cljs
+++ b/gui/test/monkey/ci/gui/test/routing_test.cljs
@@ -63,12 +63,12 @@
            (sut/path-for :page/login))))
 
   (testing "sets path parameters"
-    (is (= "/o/test-customer"
-           (sut/path-for :page/customer {:customer-id "test-customer"}))))
+    (is (= "/o/test-org"
+           (sut/path-for :page/org {:org-id "test-org"}))))
 
   (testing "sets multiple path parameters"
-    (is (= "/o/cust/r/repo"
-           (sut/path-for :page/repo {:customer-id "cust"
+    (is (= "/o/org/r/repo"
+           (sut/path-for :page/repo {:org-id "org"
                                      :repo-id "repo"})))))
 
 (deftest route-goto

--- a/gui/test/monkey/ci/gui/test/routing_test.cljs
+++ b/gui/test/monkey/ci/gui/test/routing_test.cljs
@@ -63,11 +63,11 @@
            (sut/path-for :page/login))))
 
   (testing "sets path parameters"
-    (is (= "/c/test-customer"
+    (is (= "/o/test-customer"
            (sut/path-for :page/customer {:customer-id "test-customer"}))))
 
   (testing "sets multiple path parameters"
-    (is (= "/c/cust/r/repo"
+    (is (= "/o/cust/r/repo"
            (sut/path-for :page/repo {:customer-id "cust"
                                      :repo-id "repo"})))))
 

--- a/gui/test/monkey/ci/gui/test/ssh_keys/events_test.cljc
+++ b/gui/test/monkey/ci/gui/test/ssh_keys/events_test.cljc
@@ -20,15 +20,15 @@
                       :private-key "test-private"
                       :public-key "test-public"}]
            c (h/catch-fx :martian.re-frame/request)]
-       (h/initialize-martian {:get-customer-ssh-keys {:status 200
-                                                      :body ssh-keys
-                                                      :error-code :no-error}})
+       (h/initialize-martian {:get-org-ssh-keys {:status 200
+                                                 :body ssh-keys
+                                                 :error-code :no-error}})
        (is (some? (:martian.re-frame/martian @app-db)))
-       (rf/dispatch [:ssh-keys/load "test-customer"])
+       (rf/dispatch [:ssh-keys/load "test-org"])
        (is (= 1 (count @c)))
-       (is (= :get-customer-ssh-keys
+       (is (= :get-org-ssh-keys
               (-> @c first (nth 2))))
-       (is (= {:customer-id "test-customer"}
+       (is (= {:org-id "test-org"}
               (-> @c first (nth 3))))))))
 
 (deftest ssh-keys-load--success
@@ -78,10 +78,10 @@
    (is (some? (reset! app-db (-> {}
                                  (r/set-current {:parameters
                                                  {:path
-                                                  {:customer-id "test-customer"}}})))))
-   (h/initialize-martian {:update-customer-ssh-keys {:status 200
-                                                     :body []
-                                                     :error-code :no-error}})
+                                                  {:org-id "test-org"}}})))))
+   (h/initialize-martian {:update-org-ssh-keys {:status 200
+                                                :body []
+                                                :error-code :no-error}})
    (is (some? (:martian.re-frame/martian @app-db)))
 
    (testing "saves all ssh keys to backend with updated set"
@@ -98,9 +98,9 @@
 
        (rf/dispatch [:ssh-keys/save-set upd])
        (is (= 1 (count @c)))
-       (is (= :update-customer-ssh-keys
+       (is (= :update-org-ssh-keys
               (-> @c first (nth 2))))
-       (is (= {:customer-id "test-customer"
+       (is (= {:org-id "test-org"
                :ssh-keys [(assoc upd :label-filters [])]}
               (-> @c first (nth 3))))))
 
@@ -116,9 +116,9 @@
                                       (db/set-editing-keys [ks]))))))
        (rf/dispatch [:ssh-keys/save-set ks])
        (is (= 1 (count @c)))
-       (is (= :update-customer-ssh-keys
+       (is (= :update-org-ssh-keys
               (-> @c first (nth 2))))
-       (is (= {:customer-id "test-customer"
+       (is (= {:org-id "test-org"
                :ssh-keys [(-> ks
                               (dissoc :temp-id)
                               (assoc :label-filters []))]}
@@ -178,13 +178,13 @@
        (is (some? (reset! app-db (-> {}
                                      (r/set-current {:parameters
                                                      {:path
-                                                      {:customer-id "test-customer"}}})
+                                                      {:org-id "test-org"}}})
                                      (db/set-value ksets)
                                      (db/set-editing-keys [set-2])))))
-       (h/initialize-martian {:update-customer-ssh-keys {:status 200
-                                                         :body []
-                                                         :error-code :no-error}})
+       (h/initialize-martian {:update-org-ssh-keys {:status 200
+                                                    :body []
+                                                    :error-code :no-error}})
        (is (some? (:martian.re-frame/martian @app-db)))
        (rf/dispatch [:ssh-keys/delete-set set-2])
-       (is (= :update-customer-ssh-keys (-> @c first (nth 2))))
+       (is (= :update-org-ssh-keys (-> @c first (nth 2))))
        (is (= [set-1] (-> @c first (nth 3) :ssh-keys)))))))


### PR DESCRIPTION
The term "customer" may be confusing to most users.  Since it's being used for both non-paying and paying organizations, and "customer" implies paying.  Also, "organization" is used by similar tools, so it makes sense to use it as well.

This PR renames customers to organizations, along with changing `:customer-id` to `:org-id` where applicable.  This is a major refactoring and touches most files.  But there is no real functionality change.