### PR TITLE
Feature/agent poller

### DIFF
--- a/app/deps.edn
+++ b/app/deps.edn
@@ -112,7 +112,8 @@
 
   :agent
   ;; clj -M:agent
-  {:main-opts ["-m" "monkey.ci.agent.main"]}
+  {:main-opts ["-m" "monkey.ci.agent.main"]
+   :jvm-opts ["-Dlogback.configurationFile=dev-resources/logback-agent.xml"]}
 
   :agent/test
   ;; clj -X:agent/test '{:config "config.edn" :event "event.edn"}'

--- a/app/dev-resources/logback-agent.xml
+++ b/app/dev-resources/logback-agent.xml
@@ -1,0 +1,36 @@
+<configuration scan="true" scanPeriod="5 seconds">
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>		
+    <encoder>
+      <pattern>[%blue(AGENT)] %d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <append>true</append>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>logs/agent-%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>30</maxHistory>
+      <totalSizeCap>1GB</totalSizeCap>
+    </rollingPolicy>
+  </appender>
+  
+  <logger name="org" level="WARN"/>
+  <logger name="com" level="WARN"/>
+  <logger name="net" level="WARN"/>
+  <logger name="io" level="WARN"/>
+  <logger name="monkey.ci" level="DEBUG"/>
+  <logger name="monkey.ci.agent" level="TRACE"/>
+  <logger name="monkey.mailman" level="DEBUG"/>
+  <logger name="monkey.nats" level="TRACE"/>
+  
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILE" />
+  </root>
+</configuration>

--- a/app/src/monkey/ci/agent/events.clj
+++ b/app/src/monkey/ci/agent/events.clj
@@ -12,7 +12,8 @@
             [monkey.ci.build.api-server :as bas]
             [monkey.ci.events.mailman :as em]
             [monkey.ci.events.mailman.interceptors :as emi]
-            [monkey.ci.script.config :as sc]))
+            [monkey.ci.script.config :as sc]
+            [monkey.mailman.core :as mmc]))
 
 (def m2-cache-path
   "Location of the m2 cache path in the container"
@@ -35,11 +36,14 @@
 (defn set-ssh-keys [ctx k]
   (assoc ctx ::ssh-keys k))
 
-(defn- build-work-dir [{:keys [work-dir]} sid]
+(defn build-work-dir [{:keys [work-dir]} sid]
   (str (apply fs/path work-dir sid)))
 
-(defn- ctx->wd [ctx]
-  (build-work-dir (get-config ctx) (get-in ctx [:event :sid])))
+(defn- ctx->wd
+  ([conf ctx]
+   (build-work-dir conf (get-in ctx [:event :sid])))
+  ([ctx]
+   (ctx->wd (get-config ctx) ctx)))
 
 (defn- checkout-dir [wd]
   (str (fs/create-dirs (fs/path wd "checkout"))))
@@ -83,7 +87,7 @@
 
 (def add-token
   "Generates a new token and adds it to the current build list.  This is used by the
-   http server to verify client requests."
+   http server to verify client requests.  The build list is shared across event handlers."
   {:name ::add-token
    :enter (fn [ctx]
             (let [token (bas/generate-token)]
@@ -135,6 +139,16 @@
    :leave (fn [ctx]
             (assoc ctx :result [(b/build-init-evt (::build ctx))]))})
 
+(def cleanup
+  "Interceptor that deletes all files from a build, after build end"
+  {:name ::cleanup
+   :leave (fn [ctx]
+            (when (:cleanup? (get-config ctx))
+              (let [wd (ctx->wd ctx)]
+                (log/debug "Cleaning up build files in" wd)
+                (fs/delete-tree wd)))
+            ctx)})
+
 ;;; Event handlers
 
 (defn prepare-build-cmd [ctx]
@@ -165,7 +179,8 @@
      :err (log-file wd "err.log")
      :exit-fn (p/exit-fn
                (fn [{:keys [exit]}]
-                 ;; TODO Clean up build files
+                 ;; TODO Clean up build files.  We could also do this using
+                 ;; a cronjob on the agent.
                  (log/info "Build container exited with code:" exit)
                  (em/post-events (:mailman conf)
                                  [(b/build-end-evt build exit)])))}))
@@ -183,7 +198,6 @@
 (defn make-routes [conf]
   [[:build/queued
     [{:handler prepare-build-cmd
-      ;; TODO Restore build cache
       :interceptors [emi/handle-build-error
                      (add-config conf)
                      add-token
@@ -198,6 +212,27 @@
 
    [:build/end
     [{:handler (constantly nil)
-      ;; TODO Save build cache
       :interceptors [(add-config conf)
-                     remove-token]}]]])
+                     remove-token
+                     cleanup]}]]])
+
+;;; Polling
+
+(defn poll-next [{:keys [mailman]} router max-reached?]
+  (when-not (max-reached?)
+    (when-let [[evt] (mmc/poll-events (:broker mailman) 1)]
+      (when (= :build/queued (:type evt))
+        (log/debug "Polled next build event:" evt)
+        (router evt)))))
+
+(defn poll-loop
+  "Starts a poll loop that takes events from an event receiver as long as
+   the max number of simultaneous builds has not been reached.  When a 
+   build finishes, a new event is taken from the queue.  This loop should
+   only receive `build/queued` events.  The list of builds is then updated
+   by an async listener whenever a build ends."
+  [{:keys [poll-interval] :or {poll-interval 1000} :as conf} router running? max-reached?]
+  (while @running?
+    (when-not (poll-next conf router max-reached?)
+      (Thread/sleep poll-interval)))
+  (log/debug "Poll loop terminated"))

--- a/app/src/monkey/ci/agent/events.clj
+++ b/app/src/monkey/ci/agent/events.clj
@@ -219,7 +219,9 @@
 ;;; Polling
 
 (defn poll-next [{:keys [mailman]} router max-reached?]
+  (log/trace "Max reached?" (max-reached?))
   (when-not (max-reached?)
+    (log/trace "Polling for next event")
     (when-let [[evt] (mmc/poll-events (:broker mailman) 1)]
       (when (= :build/queued (:type evt))
         (log/debug "Polled next build event:" evt)

--- a/app/src/monkey/ci/agent/events.clj
+++ b/app/src/monkey/ci/agent/events.clj
@@ -219,13 +219,16 @@
 ;;; Polling
 
 (defn poll-next [{:keys [mailman]} router max-reached?]
-  (log/trace "Max reached?" (max-reached?))
-  (when-not (max-reached?)
-    (log/trace "Polling for next event")
-    (when-let [[evt] (mmc/poll-events (:broker mailman) 1)]
-      (when (= :build/queued (:type evt))
-        (log/debug "Polled next build event:" evt)
-        (router evt)))))
+  (try
+    (log/trace "Max reached?" (max-reached?))
+    (when-not (max-reached?)
+      (log/trace "Polling for next event")
+      (when-let [[evt] (mmc/poll-events (:broker mailman) 1)]
+        (when (= :build/queued (:type evt))
+          (log/trace "Polled next build event:" evt)
+          (router evt))))
+    (catch Exception ex
+      (log/warn "Got error when polling:" (ex-message ex) ex))))
 
 (defn poll-loop
   "Starts a poll loop that takes events from an event receiver as long as

--- a/app/src/monkey/ci/agent/main.clj
+++ b/app/src/monkey/ci/agent/main.clj
@@ -25,9 +25,5 @@
       (waiter sys))))
 
 (defn -main [& args]
-  (try
-    @(run-agent (c/load-config-file (first args))
-                (comp wh/on-server-close :api-server))
-    (finally
-      (log/info "Build agent terminated."))))
-
+  @(run-agent (c/load-config-file (first args))
+              (comp wh/on-server-close :api-server)))

--- a/app/src/monkey/ci/agent/runtime.clj
+++ b/app/src/monkey/ci/agent/runtime.clj
@@ -22,14 +22,12 @@
             [monkey.ci.events.mailman :as em]
             [monkey.ci.metrics.core :as mc]
             [monkey.ci.runners.runtime :as rr]
-            [monkey.ci.web.auth :as auth]))
+            [monkey.ci.web.auth :as auth]
+            [monkey.mailman.core :as mmc]))
 
 (defrecord ApiServer [builds api-config]
   co/Lifecycle
   (start [this]
-    ;; FIXME Api server needs a token to send requests to the global api, but this
-    ;; is ideally generated for each build separately, with limited permissions and
-    ;; expiration time.  For this we would need the private key of the global api.
     (merge this (aa/start-server (merge this (select-keys api-config [:port])))))
 
   (stop [this]
@@ -93,9 +91,13 @@
       (update :cache c/make-blob-repository)
       (c-podman/make-routes)))
 
+(defmethod make-container-routes :noop [conf]
+  (log/info "Not handling container routes")
+  [])
+
 (defmethod make-container-routes :default [conf]
   (log/warn "Unknown container runner type:" (:type conf))
-  {})
+  [])
 
 (defn new-container-routes [config]
   (em/map->RouteComponent
@@ -104,32 +106,78 @@
 
 (def global-to-local-events #{:build/queued :build/canceled})
 
+(defrecord PollLoop [config running? mailman agent-routes builds]
+  co/Lifecycle
+  (start [this]
+    (log/info "Starting poll loop with config:" config)
+    (letfn [(max-reached? []
+              (>= (count @(:builds this)) (:max-builds config)))]
+      (reset! running? true)
+      (assoc this :future (future
+                            (e/poll-loop (assoc config :mailman mailman)
+                                         (mmc/router (:routes agent-routes))
+                                         running?
+                                         max-reached?)))))
+
+  (stop [this]
+    (log/info "Stopping poll loop")
+    (reset! running? false)
+    (-> this
+        (assoc :result (deref (:future this) (* 2 (:poll-interval config)) :timeout))
+        (dissoc :future))))
+
+(defn new-poll-loop [conf]
+  (map->PollLoop {:running? (atom false)
+                  :config (merge {:poll-interval 1000
+                                  :max-builds 1}
+                                 conf)}))
+
+(defn new-poll-mailman
+  "Sets up a mailman component that will be used by the poll loop.  It should only
+   provide `build/queued` events, since the loop will stop polling as long as the
+   maximum number of builds has been reached."
+  [conf]
+  (em/make-component (:poll-loop conf)))
+
 (defn make-system [conf]
-  (co/system-map
-   :builds (atom {})
-   :artifacts (rr/new-artifacts conf)
-   :cache (rr/new-cache conf)
-   :workspace (rr/new-workspace conf)
-   :event-stream (rr/new-event-stream)
-   :git (rr/new-git)
-   :ssh-keys-fetcher (new-ssh-keys-fetcher conf)
-   :api-server (co/using
-                (new-api-server conf)
-                [:builds :artifacts :cache :workspace :mailman :event-stream :params :metrics])
-   :mailman (rr/new-local-mailman)
-   :global-mailman (rr/new-mailman conf)
-   :local-to-global (co/using
-                     (rr/new-local-to-global-forwarder global-to-local-events)
-                     [:global-mailman :mailman :event-stream])
-   :global-to-local (co/using
-                     (rr/global-to-local-routes global-to-local-events)
-                     {:mailman :global-mailman
-                      :local-mailman :mailman})
-   :agent-routes (co/using
-                  (new-agent-routes conf)
-                  [:mailman :api-server :git :builds :workspace :ssh-keys-fetcher])
-   :params (new-params conf)
-   :container-routes (co/using
-                      (new-container-routes conf)
-                      [:mailman :artifacts :cache :workspace :api-server])
-   :metrics (mc/make-metrics)))
+  (letfn [(as-map [deps]
+            (zipmap deps deps))]
+    (co/system-map
+     :builds (atom {})
+     :artifacts (rr/new-artifacts conf)
+     :cache (rr/new-cache conf)
+     :workspace (rr/new-workspace conf)
+     :event-stream (rr/new-event-stream)
+     :git (rr/new-git)
+     :ssh-keys-fetcher (new-ssh-keys-fetcher conf)
+     :api-server (co/using
+                  (new-api-server conf)
+                  [:builds :artifacts :cache :workspace :mailman :event-stream :params :metrics])
+     :mailman (rr/new-local-mailman)
+     :global-mailman (rr/new-mailman conf)
+     :local-to-global (co/using
+                       (rr/new-local-to-global-forwarder global-to-local-events)
+                       [:global-mailman :mailman :event-stream])
+     ;; Pushes events received from global mailman to the local mailman.  This
+     ;; is actually only the build/canceled event, since the build/queued must
+     ;; be polled, and the rest is received via the build api on the local mailman.
+     :global-to-local (co/using
+                       (rr/global-to-local-routes global-to-local-events)
+                       {:mailman :global-mailman
+                        :local-mailman :mailman})
+     :agent-routes (co/using
+                    (new-agent-routes conf)
+                    [:mailman :api-server :git :builds :workspace :ssh-keys-fetcher])
+     ;; Set up separate mailman to poll only the build/queued subject
+     :poll-mailman (new-poll-mailman conf)
+     ;; Poll loop that takes build/queued events, as long as there is capacity.
+     :poll-loop (co/using
+                 (new-poll-loop conf)
+                 (-> [:agent-routes :builds]
+                     (as-map)
+                     (assoc :mailman :poll-mailman)))
+     :params (new-params conf)
+     :container-routes (co/using
+                        (new-container-routes conf)
+                        [:mailman :artifacts :cache :workspace :api-server])
+     :metrics (mc/make-metrics))))

--- a/app/src/monkey/ci/events/mailman/nats.clj
+++ b/app/src/monkey/ci/events/mailman/nats.clj
@@ -9,7 +9,7 @@
             [monkey.mailman.core :as mmc]
             [monkey.mailman.nats.core :as mnc]))
 
-(def subject-types
+(def ^:private subject-types
   ;; Use the same as jms
   jms/destination-types)
 

--- a/app/src/monkey/ci/events/mailman/nats.clj
+++ b/app/src/monkey/ci/events/mailman/nats.clj
@@ -33,7 +33,7 @@
           conn (nats/make-connection conf)
           subjects (types-to-subjects (:prefix conf))
           broker-conf (-> conf
-                          (select-keys [:stream :consumer])
+                          (select-keys [:stream :consumer :poll-opts])
                           (merge {:subject-mapper (comp subjects :type)}))]
       (log/debug "Using broker configuration:" broker-conf)
       (-> this

--- a/app/test/unit/monkey/ci/agent/events_test.clj
+++ b/app/test/unit/monkey/ci/agent/events_test.clj
@@ -289,7 +289,10 @@
     (testing "ignores types other than `build/queued`"
       (is (some? (mmc/post-events broker [{:type :job/queued}])))
       (is (some? (reset! state {})))
-      (is (nil? (sut/poll-next conf router max-reached?))))))
+      (is (nil? (sut/poll-next conf router max-reached?))))
+
+    (testing "posts back resulting events"
+      )))
 
 (deftest poll-loop
   (let [running? (atom true)]

--- a/app/test/unit/monkey/ci/agent/events_test.clj
+++ b/app/test/unit/monkey/ci/agent/events_test.clj
@@ -297,7 +297,9 @@
 (deftest poll-loop
   (let [running? (atom true)]
     (testing "polls next until no longer running"
-      (let [f (future (sut/poll-loop {:poll-interval 100}
+      (let [f (future (sut/poll-loop {:poll-interval 100
+                                      :mailman
+                                      {:broker ::test-broker}}
                                      (constantly nil)
                                      running?
                                      (constantly true)))] 

--- a/app/test/unit/monkey/ci/agent/events_test.clj
+++ b/app/test/unit/monkey/ci/agent/events_test.clj
@@ -13,7 +13,10 @@
             [monkey.ci.test
              [helpers :as h]
              [mailman :as tm]]
-            [monkey.mailman.core :as mmc]))
+            [monkey.mailman
+             [core :as mmc]
+             [mem :as mem]
+             [manifold :as mmm]]))
 
 (deftest routes
   (let [evts [:build/queued :build/end :script/initializing]
@@ -84,12 +87,15 @@
       (is (= ::config (-> (enter {})
                           (sut/get-config)))))))
 
+(defn- random-sid []
+  (repeatedly 3 (comp str random-uuid)))
+
 (deftest fetch-ssh-keys
   (let [{:keys [enter] :as i} (sut/fetch-ssh-keys identity)]
     (is (keyword? (:name i)))
 
     (testing "`enter` fetches keys for repo sid"
-      (let [sid (repeatedly 3 (comp str random-uuid))]
+      (let [sid (random-sid)]
         (is (= sid
                (-> {:event {:sid sid}}
                    (enter)
@@ -210,7 +216,7 @@
           (spec/explain-str ::ss/config conf)))))
 
 (deftest script-init
-  (let [sid (repeatedly 3 (comp str random-uuid))
+  (let [sid (random-sid)
         r (sut/script-init {:credit-multiplier ::cm}
                            {:event {:sid sid}})]
     (testing "returns `build/start`"
@@ -221,3 +227,79 @@
 
     (testing "adds credit multiplier from config"
       (is (= ::cm (-> r first :credit-multiplier))))))
+
+(deftest cleanup
+  (h/with-tmp-dir dir
+    (let [sid (random-sid)
+          conf {:work-dir dir
+                :cleanup? true}
+          wd (sut/build-work-dir conf sid)
+          {:keys [leave] :as i} sut/cleanup]
+      (is (keyword? (:name i)))
+
+      (is (some? (fs/create-dirs wd)))
+      
+      (testing "`leave`"
+        (let [base-ctx {:event {:sid sid}}]
+          (testing "does nothing if not enabled"
+            (let [ctx (-> base-ctx
+                          (sut/set-config (dissoc conf :cleanup?)))]
+              (is (= ctx (leave ctx)))
+              (is (fs/exists? wd))))
+
+          (testing "when enabled, deletes all files in work dir"
+            (let [ctx (sut/set-config base-ctx conf)]
+              (is (= ctx (leave ctx)))
+              (is (not (fs/exists? wd))))))))))
+
+(deftest poll-next
+  (let [broker (mem/make-memory-broker)
+        state (atom {:builds 0
+                     :handled []})
+        router (fn [evt]
+                 (swap! state (fn [s]
+                                (-> s
+                                    (update :builds (fnil inc 0))
+                                    (update :handled conj evt))))
+                 ::handled)
+        conf {:max-builds 1
+              :mailman {:broker broker}}
+        max-reached? (fn []
+                       (= (:max-builds conf) (:builds @state)))]
+    
+    (testing "handles next build/queued event"
+      (let [evt {:type :build/queued
+                 :sid ["first"]}]
+        (is (some? (mmc/post-events broker [evt])))
+        (is (= ::handled (sut/poll-next conf router max-reached?)))
+        (is (= [evt] (:handled @state)))))
+
+    (testing "does not take next event if no capacity"
+      (let [evt {:type :build/queued
+                 :sid ["second"]}]
+        (is (some? (mmc/post-events broker [evt])))
+        (is (nil? (sut/poll-next conf router max-reached?)))
+        (is (= 1 (count (:handled @state))))))
+
+    (testing "when new capacity, again takes next event"
+      (is (some? (swap! state update :builds dec)))
+      (is (= ::handled (sut/poll-next conf router max-reached?)))
+      (is (= 2 (count (:handled @state)))))
+
+    (testing "ignores types other than `build/queued`"
+      (is (some? (mmc/post-events broker [{:type :job/queued}])))
+      (is (some? (reset! state {})))
+      (is (nil? (sut/poll-next conf router max-reached?))))))
+
+(deftest poll-loop
+  (let [running? (atom true)]
+    (testing "polls next until no longer running"
+      (let [f (future (sut/poll-loop {:poll-interval 100}
+                                     (constantly nil)
+                                     running?
+                                     (constantly true)))] 
+        (is (some? f))
+
+        (is (false? (reset! running? false)))
+        (is (nil? (deref f 1000 :timeout))
+            "expect loop to terminate")))))

--- a/app/test/unit/monkey/ci/agent/main_test.clj
+++ b/app/test/unit/monkey/ci/agent/main_test.clj
@@ -12,6 +12,8 @@
                                      (future (.close (:server s))))]
     (h/with-tmp-dir dir
       (let [config-file (fs/path dir "config.edn")]
-        (is (nil? (spit (fs/file config-file) (pr-str tc/base-config))))
+        (is (nil? (spit (fs/file config-file) (-> tc/base-config
+                                                  (assoc :poll-loop {:type :manifold})
+                                                  (pr-str)))))
         (testing "starts agent runtime"
           (is (nil? (sut/-main (str config-file)))))))))

--- a/app/test/unit/monkey/ci/agent/runtime_test.clj
+++ b/app/test/unit/monkey/ci/agent/runtime_test.clj
@@ -83,8 +83,9 @@
         (is (= ["test-key"] (fetcher sid)))))))
 
 (deftest poll-loop
-  (let [conf {:max-builds 0
-              :poll-interval 100}
+  (let [conf {:poll-loop
+              {:max-builds 0
+               :poll-interval 100}}
         p (-> (sut/new-poll-loop conf)
               (assoc :builds (atom {}))
               (co/start))]

--- a/app/test/unit/monkey/ci/events/mailman/nats_test.clj
+++ b/app/test/unit/monkey/ci/events/mailman/nats_test.clj
@@ -8,40 +8,43 @@
             [monkey.ci.events.mailman.nats :as sut]))
 
 (deftest types-to-subjects
-  (letfn [(verify-types [types]
-            (let [f (sut/types-to-subjects "monkeyci.test")]
+  (let [f (sut/types-to-subjects "monkeyci.test")]
+    (letfn [(verify-types [types]
               (doseq [t types]
                 (is (string? (f t))
-                    (str "should map " t)))))]
-    (testing "returns a subject for each event type"
-      (testing "build types"
-        (verify-types [:build/triggered
-                       :build/pending
-                       :build/queued
-                       :build/initializing
-                       :build/start
-                       :build/end
-                       :build/canceled
-                       :build/updated]))
+                    (str "should map " t))))]
+      (testing "returns a subject for each event type"
+        (testing "build types"
+          (verify-types [:build/triggered
+                         :build/pending
+                         :build/queued
+                         :build/initializing
+                         :build/start
+                         :build/end
+                         :build/canceled
+                         :build/updated])
 
-      (testing "script types"
-        (verify-types [:script/initializing
-                       :script/start
-                       :script/end]))
+          (testing "maps `build/queued` to separate subject"
+            (is (not= (f :build/queued) (f :build/end)))))
 
-      (testing "job types"
-        (verify-types [:job/pending
-                       :job/queued
-                       :job/initializing
-                       :job/start
-                       :job/end
-                       :job/skipped
-                       :job/executed]))
+        (testing "script types"
+          (verify-types [:script/initializing
+                         :script/start
+                         :script/end]))
 
-      (testing "container types"
-        (verify-types [:container/pending
-                       :container/initializing
-                       :container/job-queued])))))
+        (testing "job types"
+          (verify-types [:job/pending
+                         :job/queued
+                         :job/initializing
+                         :job/start
+                         :job/end
+                         :job/skipped
+                         :job/executed]))
+
+        (testing "container types"
+          (verify-types [:container/pending
+                         :container/initializing
+                         :container/job-queued]))))))
 
 (deftest nats-component
   (with-redefs [nats/make-connection (constantly ::nats)]

--- a/gui/src/monkey/ci/gui/repo/views.cljs
+++ b/gui/src/monkey/ci/gui/repo/views.cljs
@@ -16,7 +16,7 @@
 
 (defn- trigger-build-btn []
   (let [show? (rf/subscribe [:repo/show-trigger-form?])]
-    [:button.btn.btn-secondary
+    [:button.btn.btn-info
      (cond-> {:type :button
               :on-click #(rf/dispatch [:repo/show-trigger-build])}
        @show? (assoc :disabled true))
@@ -24,7 +24,7 @@
 
 (defn- edit-repo-btn []
   (let [c (rf/subscribe [:route/current])]
-    [:a.btn.btn-secondary
+    [:a.btn.btn-soft-primary
      {:href (r/path-for :page/repo-edit (get-in @c [:parameters :path]))}
      [:span.me-1 [co/icon :pencil-fill]] "Edit"]))
 
@@ -36,8 +36,8 @@
 
 (defn build-actions []
   [:<>
-   [trigger-build-btn]
-   [edit-repo-btn]])
+   [edit-repo-btn]
+   [trigger-build-btn]])
 
 (defn- trigger-type []
   [:select.form-select {:name :trigger-type}
@@ -217,6 +217,15 @@
      [:div.row
       [:div.col
        [:div.mb-2
+        [:label.form-label {:for "url"} "Url"]
+        [:input.form-control
+         {:id "url"
+          :value (:url @e)
+          :on-change (u/form-evt-handler [:repo/url-changed])}]
+        [:div.form-text
+         "This is used when manually triggering a build from the UI. "
+         "Use an ssh url for private repos."]]
+       [:div.mb-2
         [:label.form-label {:for "name"} "Repository name"]
         [:input.form-control
          {:id "name"
@@ -229,13 +238,6 @@
           :value (:main-branch @e)
           :on-change (u/form-evt-handler [:repo/main-branch-changed])}]
         [:div.form-text "Required when you want to determine the 'main branch' in the build script."]]
-       [:div.mb-2
-        [:label.form-label {:for "url"} "Url"]
-        [:input.form-control
-         {:id "url"
-          :value (:url @e)
-          :on-change (u/form-evt-handler [:repo/url-changed])}]
-        [:div.form-text "This is used when manually triggering a build from the UI."]]
        [:div.mb-2
         [:label.form-label {:for "github-id"} "Github Id"]
         [:input.form-control


### PR DESCRIPTION
Instead of handling certain events using an async handler, we're polling for `build/queued` events manually, using a loop.  This because there is a limit on how many builds we can handle, so we can only take from that subject when there is capacity.