### PR TITLE
Feature/event history

### DIFF
--- a/.monkeyci/build.clj
+++ b/.monkeyci/build.clj
@@ -145,7 +145,8 @@
                                         :file (m/in-work ctx (:path uberjar-artifact))}))
                m/success
                m/failure))))
-        (m/depends-on ["app-uberjar"]))))
+        (m/depends-on ["app-uberjar"])
+        (m/restore-artifacts [uberjar-artifact]))))
 
 (def img-base "fra.ocir.io/frjdhmocn5qi")
 (def app-img (str img-base "/monkeyci"))

--- a/app/src/monkey/ci/entities/core.clj
+++ b/app/src/monkey/ci/entities/core.clj
@@ -454,3 +454,23 @@
    :before-update prepare-queued-task
    :after-update  convert-queued-task
    :after-select  convert-queued-task-select})
+
+(def prepare-job-evt
+  (comp (partial prop->edn :details)
+        (partial int->time :time)
+        (partial keyword->str :event)))
+(def convert-job-evt
+  (comp (partial copy-prop :details)
+        (partial time->int :time)
+        (partial str->keyword :event)))
+(def convert-job-evt-select
+  (comp (partial edn->prop :details)
+        (partial time->int :time)
+        (partial str->keyword :event)))
+
+(defaggregate job-event
+  {:before-insert prepare-job-evt
+   :after-insert  convert-job-evt
+   :before-update prepare-job-evt
+   :after-update  convert-job-evt
+   :after-select  convert-job-evt-select})

--- a/app/src/monkey/ci/entities/core.clj
+++ b/app/src/monkey/ci/entities/core.clj
@@ -1,6 +1,7 @@
 (ns monkey.ci.entities.core
   "Core functionality for database entities.  Allows to store/retrieve basic entities."
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.string :as cs]
+            [clojure.tools.logging :as log]
             [honey.sql :as h]
             [honey.sql.helpers :as hh]
             [medley.core :as mc]
@@ -232,8 +233,15 @@
 (def end-time->int (partial time->int :end-time))
 (def int->end-time (partial int->time :end-time))
 
+(defn- serialize-keyword [k]
+  (when k
+    (->> k
+         ((juxt namespace name))
+         (remove nil?)
+         (cs/join "/"))))
+
 (defn- keyword->str [k x]
-  (mc/update-existing x k (u/or-nil name)))
+  (mc/update-existing x k serialize-keyword))
 
 (defn- str->keyword [k x]
   (mc/update-existing x k (u/or-nil keyword)))

--- a/app/src/monkey/ci/entities/job.clj
+++ b/app/src/monkey/ci/entities/job.clj
@@ -18,4 +18,3 @@
            (ec/select conn)
            first
            (ec/convert-job-select)))
-

--- a/app/src/monkey/ci/entities/job.clj
+++ b/app/src/monkey/ci/entities/job.clj
@@ -3,15 +3,15 @@
 
 (defn select-by-sid [conn [org-cuid repo-id build-id job-id]]
   (some->> {:select [[:j.*]
-                     [:c.cuid :org-cuid]
+                     [:o.cuid :org-cuid]
                      [:r.display-id :repo-display-id]
                      [:b.display-id :build-display-id]]
             :from [[:jobs :j]]
             :join [[:builds :b] [:= :b.id :j.build-id]
                    [:repos :r] [:= :r.id :b.repo-id]
-                   [:orgs :c] [:= :c.id :r.org-id]]
+                   [:orgs :o] [:= :o.id :r.org-id]]
             :where [:and
-                    [:= :c.cuid org-cuid]
+                    [:= :o.cuid org-cuid]
                     [:= :r.display-id repo-id]
                     [:= :b.display-id build-id]
                     [:= :j.display-id job-id]]}

--- a/app/src/monkey/ci/entities/job.clj
+++ b/app/src/monkey/ci/entities/job.clj
@@ -18,3 +18,23 @@
            (ec/select conn)
            first
            (ec/convert-job-select)))
+
+(defn select-events [conn [org-cuid repo-id build-id job-id]]
+  (->> {:select [[:e.*]
+                 [:j.display-id :job-display-id]
+                 [:o.cuid :org-cuid]
+                 [:r.display-id :repo-display-id]
+                 [:b.display-id :build-display-id]]
+        :from [[:job-events :e]]
+        :join [[:jobs :j] [:= :j.id :e.job-id]
+               [:builds :b] [:= :b.id :j.build-id]
+               [:repos :r] [:= :r.id :b.repo-id]
+               [:orgs :o] [:= :o.id :r.org-id]]
+        :where [:and
+                [:= :o.cuid org-cuid]
+                [:= :r.display-id repo-id]
+                [:= :b.display-id build-id]
+                [:= :j.display-id job-id]]
+        :order-by [:e.time]}
+       (ec/select conn)
+       (map ec/convert-job-evt-select)))

--- a/app/src/monkey/ci/entities/migrations.clj
+++ b/app/src/monkey/ci/entities/migrations.clj
@@ -543,7 +543,8 @@
 
    (table-migration
     43 :job-events
-    [job-col
+    [id-col
+     job-col
      [:event [:varchar 30] [:not nil]]
      [:time :timestamp]
      [:details :text]

--- a/app/src/monkey/ci/entities/migrations.clj
+++ b/app/src/monkey/ci/entities/migrations.clj
@@ -78,6 +78,7 @@
 (def org-col (fk-col :org-id))
 (def repo-col (fk-col :repo-id))
 (def user-col (fk-col :user-id))
+(def job-col (fk-col :job-id))
 
 (defn fk
   "Defines a foreign key constraint on the column that references another table column."
@@ -89,6 +90,7 @@
 (def fk-org (fk :org-id :customers :id))
 (def fk-repo (fk :repo-id :repos :id))
 (def fk-user (fk :user-id :users :id))
+(def fk-job (fk :job-id :jobs :id))
 
 (defn- idx-name [table col]
   (keyword (str (name table) "-" (name col) "-idx")))
@@ -537,7 +539,16 @@
     [{:alter-table :user-customers
       :rename-table :user-orgs}]
     [{:alter-table :user-orgs
-      :rename-table :user-customers}])])
+      :rename-table :user-customers}])
+
+   (table-migration
+    43 :job-events
+    [job-col
+     [:event [:varchar 30] [:not nil]]
+     [:time :timestamp]
+     [:details :text]
+     fk-job]
+    [(col-idx :job-events :job-id)])])
 
 (defn prepare-migrations
   "Prepares all migrations by formatting to sql, creates a ragtime migration object from it."

--- a/app/src/monkey/ci/spec/db_entities.clj
+++ b/app/src/monkey/ci/spec/db_entities.clj
@@ -182,3 +182,12 @@
 (s/def :db/queued-task
   (-> (s/keys :req-un [:queued-task/creation-time :queued-task/task])
       (s/merge :db/common)))
+
+(s/def :db/job-id id?)
+(s/def :job-evt/time ts?)
+(s/def :job-evt/event keyword?)
+(s/def :job-evt/details map?)
+
+(s/def :db/job-event
+  (s/keys :req-un [:db/job-id :job-evt/time :job-evt/event]
+          :opt-un [:job-evt/details]))

--- a/app/src/monkey/ci/spec/entities.clj
+++ b/app/src/monkey/ci/spec/entities.clj
@@ -65,7 +65,7 @@
 (s/def :job/credit-multiplier (s/int-in 0 100))
 
 (s/def :entity/job
-  (-> (s/keys :req-un [:display/id]
+  (-> (s/keys :req-un [:entity/org-id :entity/repo-id :entity/build-id :display/id]
               :opt-un [:job/status :entity/labels :job/credit-multiplier])
       (s/merge :entity/timed)))
 
@@ -186,8 +186,6 @@
 (s/def :invoice/detail
   (s/keys :req-un [:invoice/net-amount :invoice/vat-perc :entity/description]))
 
-(s/def :runner/details map?)
-
 (s/def :entity/runner keyword?)
 (s/def :runner/details map?)
 
@@ -197,3 +195,13 @@
 (s/def :entity/queued-task
   (-> (s/keys :req-un [:queued-task/creation-time :queued-task/task])
       (s/merge :entity/common)))
+
+(s/def :entity/job-id string?)
+(s/def :job-evt/time ts?)
+(s/def :job-evt/event keyword?)
+(s/def :job-evt/details map?)
+
+(s/def :entity/job-event
+  (s/keys :req-un [:entity/org-id :entity/repo-id :entity/build-id :entity/job-id
+                   :job-evt/time :job-evt/event]
+          :opt-un [:job-evt/details]))

--- a/app/src/monkey/ci/storage/sql.clj
+++ b/app/src/monkey/ci/storage/sql.clj
@@ -405,7 +405,6 @@
 (defn- build->db [build]
   (-> build
       (select-keys [:status :start-time :end-time :idx :git :credits :source :message])
-      (mc/update-existing :status name)
       ;; Drop some sensitive information
       (mc/update-existing :git dissoc :ssh-keys-dir)
       (mc/update-existing-in [:git :ssh-keys] (partial map #(select-keys % [:id :description])))
@@ -415,7 +414,6 @@
 (defn- db->build [build]
   (-> build
       (select-keys [:status :start-time :end-time :idx :git :credits :source :message])
-      (mc/update-existing :status keyword)
       (ec/start-time->int)
       (ec/end-time->int)
       (assoc :build-id (:display-id build)
@@ -428,7 +426,7 @@
 (defn- job->db [job]
   (-> job
       (select-keys [:status :start-time :end-time :credit-multiplier])
-      (mc/update-existing :status (fnil name :error))
+      (mc/update-existing :status (fnil identity :error))
       (assoc :display-id (:id job)
              :details (dissoc job :id :status :start-time :end-time))))
 
@@ -436,7 +434,6 @@
   (-> job
       (select-keys [:status :start-time :end-time])
       (merge (:details job))
-      (mc/update-existing :status keyword)
       (assoc :id (:display-id job))
       (drop-nil)))
 

--- a/app/test/unit/monkey/ci/entities/core_test.clj
+++ b/app/test/unit/monkey/ci/entities/core_test.clj
@@ -427,11 +427,17 @@
           job (-> (eh/gen-job)
                   (assoc :build-id (:id build))
                   (as-> j (sut/insert-job conn j)))
-          evt (-> (eh/gen-job-evt)
-                  (assoc :details {:message "test event"}
-                         :event :job/start
-                         :job-id (:id job))
-                  (as-> e (sut/insert-job-event conn e)))]
-      (is (number? (:id org)))
-      (is (number? (:id job)))
-      (is (some? (:id evt))))))
+          orig-evt (-> (eh/gen-job-evt)
+                       (assoc :details {:message "test event"}
+                              :event :job/start
+                              :job-id (:id job)))
+          evt (sut/insert-job-event conn orig-evt)]
+
+      (testing "can insert"
+        (is (number? (:id org)))
+        (is (number? (:id job)))
+        (is (some? (:id evt))))
+
+      (testing "can select"
+        (is (= [(assoc orig-evt :id (:id evt))]
+               (sut/select-job-events conn (sut/by-id (:id evt)))))))))

--- a/app/test/unit/monkey/ci/entities/core_test.clj
+++ b/app/test/unit/monkey/ci/entities/core_test.clj
@@ -47,9 +47,9 @@
 
 (deftest ^:sql repo-entities
   (eh/with-prepared-db conn
-    (let [cust (sut/insert-org conn (eh/gen-org))
+    (let [org (sut/insert-org conn (eh/gen-org))
           r (sut/insert-repo conn (-> (eh/gen-repo)
-                                      (assoc :org-id (:id cust))))]
+                                      (assoc :org-id (:id org))))]
       (testing "can insert"
         (is (some? (:cuid r)))
         (is (number? (:id r)))
@@ -72,14 +72,14 @@
 
 (deftest ^:sql repo-labels
   (eh/with-prepared-db conn
-    (let [cust (sut/insert-org
-                conn
-                {:name "test org"})
+    (let [org (sut/insert-org
+               conn
+               {:name "test org"})
           repo (sut/insert-repo
                 conn
                 {:name "test repo"
                  :display-id "test-repo"
-                 :org-id (:id cust)
+                 :org-id (:id org)
                  :url "http://test"})
           lbl  (sut/insert-repo-label
                 conn
@@ -101,31 +101,31 @@
 
 (deftest ^:sql org-params
   (eh/with-prepared-db conn
-    (let [cust  (sut/insert-org
-                 conn
-                 (eh/gen-org))
+    (let [org  (sut/insert-org
+                conn
+                (eh/gen-org))
           param (sut/insert-org-param
                  conn
-                 (assoc (eh/gen-org-param) :org-id (:id cust)))]
+                 (assoc (eh/gen-org-param) :org-id (:id org)))]
       (testing "can insert"
         (is (number? (:id param))))
 
       (testing "can select for org"
-        (is (= [param] (->> (sut/select-org-params conn (sut/by-org (:id cust)))
+        (is (= [param] (->> (sut/select-org-params conn (sut/by-org (:id org)))
                             (map #(select-keys % (keys param)))))))
 
       (testing "can delete"
         (is (= 1 (sut/delete-org-params conn (sut/by-id (:id param)))))
-        (is (empty? (sut/select-org-params conn (sut/by-org (:id cust)))))))))
+        (is (empty? (sut/select-org-params conn (sut/by-org (:id org)))))))))
 
 (deftest ^:sql org-param-values
   (eh/with-prepared-db conn
-    (let [cust  (sut/insert-org
-                 conn
-                 (eh/gen-org))
+    (let [org  (sut/insert-org
+                conn
+                (eh/gen-org))
           param (sut/insert-org-param
                  conn
-                 (assoc (eh/gen-org-param) :org-id (:id cust)))
+                 (assoc (eh/gen-org-param) :org-id (:id org)))
           value (sut/insert-org-param-value
                  conn
                  (assoc (eh/gen-param-value) :params-id (:id param)))]
@@ -141,14 +141,14 @@
 
 (deftest ^:sql webhooks
   (eh/with-prepared-db conn
-    (let [cust (sut/insert-org
-                conn
-                (eh/gen-org))
+    (let [org (sut/insert-org
+               conn
+               (eh/gen-org))
           repo (sut/insert-repo
                 conn
                 {:name "test repo"
                  :display-id "test-repo"
-                 :org-id (:id cust)}) 
+                 :org-id (:id org)}) 
           wh   (sut/insert-webhook
                 conn
                 {:repo-id (:id repo)
@@ -165,31 +165,31 @@
 
 (deftest ^:sql ssh-keys
   (eh/with-prepared-db conn
-    (let [cust (sut/insert-org
-                conn
-                (eh/gen-org))
+    (let [org (sut/insert-org
+               conn
+               (eh/gen-org))
           key  (sut/insert-ssh-key
                 conn
-                (assoc (eh/gen-ssh-key) :org-id (:id cust)))]
+                (assoc (eh/gen-ssh-key) :org-id (:id org)))]
       (testing "can insert"
         (is (number? (:id key))))
 
       (testing "can select for org"
-        (is (= [key] (sut/select-ssh-keys conn (sut/by-org (:id cust))))))
+        (is (= [key] (sut/select-ssh-keys conn (sut/by-org (:id org))))))
 
       (testing "can delete"
         (is (= 1 (sut/delete-ssh-keys conn (sut/by-id (:id key)))))
-        (is (empty? (sut/select-ssh-keys conn (sut/by-org (:id cust)))))))))
+        (is (empty? (sut/select-ssh-keys conn (sut/by-org (:id org)))))))))
 
 (deftest ^:sql builds
   (eh/with-prepared-db conn
-    (let [cust  (sut/insert-org
-                 conn
-                 (eh/gen-org))
+    (let [org  (sut/insert-org
+                conn
+                (eh/gen-org))
           repo  (sut/insert-repo
                  conn
                  (-> (eh/gen-repo)
-                     (assoc :org-id (:id cust))))
+                     (assoc :org-id (:id org))))
           build (sut/insert-build
                  conn
                  (-> (eh/gen-build)
@@ -215,17 +215,17 @@
 
 (deftest ^:sql jobs
   (eh/with-prepared-db conn
-    (let [cust  (sut/insert-org
-                 conn
-                 (eh/gen-org))
+    (let [org  (sut/insert-org
+                conn
+                (eh/gen-org))
           repo  (sut/insert-repo
                  conn
                  (-> (eh/gen-repo)
-                     (assoc :org-id (:id cust))))
+                     (assoc :org-id (:id org))))
           build (sut/insert-build
-                conn
-                (-> (eh/gen-build)
-                    (assoc :repo-id (:id repo))))
+                 conn
+                 (-> (eh/gen-build)
+                     (assoc :repo-id (:id repo))))
           job   (sut/insert-job
                  conn
                  (-> (eh/gen-job)
@@ -248,9 +248,9 @@
 
 (deftest ^:sql users
   (eh/with-prepared-db conn
-    (let [cust (sut/insert-org
-                conn
-                {:name "test org"})
+    (let [org (sut/insert-org
+               conn
+               {:name "test org"})
           user (sut/insert-user
                 conn
                 {:type "github"
@@ -264,32 +264,32 @@
 
       (testing "can link to org"
         (is (some? (sut/insert-user-org conn {:user-id (:id user)
-                                                   :org-id (:id cust)}))))
+                                              :org-id (:id org)}))))
 
       (testing "can delete"
         (is (= 1 (sut/delete-user-orgs conn [:and
-                                                  [:= :user-id (:id user)]
-                                                  [:= :org-id (:id cust)]])))
+                                             [:= :user-id (:id user)]
+                                             [:= :org-id (:id org)]])))
         (is (= 1 (sut/delete-users conn (sut/by-id (:id user)))))
         (is (empty? (sut/select-users conn (sut/by-id (:id user)))))))))
 
 (deftest ^:sql join-requests
   (eh/with-prepared-db conn
-    (let [cust (sut/insert-org conn (eh/gen-org))
+    (let [org (sut/insert-org conn (eh/gen-org))
           user (sut/insert-user conn (eh/gen-user))]
       (testing "can insert"
         (is (number? (:id (sut/insert-join-request
                            conn
                            (-> (eh/gen-join-request)
                                (assoc :user-id (:id user)
-                                      :org-id (:id cust))))))))
+                                      :org-id (:id org))))))))
 
       (testing "can select by user id"
         (is (some? (sut/select-join-request conn (sut/by-user (:id user))))))
 
       (testing "can delete"
         (is (= 1 (sut/delete-join-requests conn (sut/by-user (:id user)))))
-        (is (empty? (sut/select-join-requests conn (sut/by-org (:id cust)))))))))
+        (is (empty? (sut/select-join-requests conn (sut/by-org (:id org)))))))))
 
 (deftest ^:sql email-registration
   (eh/with-prepared-db conn
@@ -307,42 +307,42 @@
 
 (deftest ^:sql org-credits
   (eh/with-prepared-db conn
-    (let [cust (sut/insert-org conn (eh/gen-org))
+    (let [org (sut/insert-org conn (eh/gen-org))
           cred (-> (eh/gen-org-credit)
-                   (assoc :org-id (:id cust))
+                   (assoc :org-id (:id org))
                    (dissoc :subscription-id :user-id))]
       (testing "can insert"
         (is (number? (:id (sut/insert-org-credit conn cred)))))
 
       (testing "can select by org"
         (is (= [(:cuid cred)]
-               (->> (sut/select-org-credits conn (sut/by-org (:id cust)))
+               (->> (sut/select-org-credits conn (sut/by-org (:id org)))
                     (map :cuid))))))))
 
 (deftest ^:sql credit-subscriptions
   (eh/with-prepared-db conn
-    (let [cust (sut/insert-org conn (eh/gen-org))
+    (let [org (sut/insert-org conn (eh/gen-org))
           cred (-> (eh/gen-credit-subscription)
-                   (assoc :org-id (:id cust)))]
+                   (assoc :org-id (:id org)))]
       (testing "can insert"
         (is (number? (:id (sut/insert-credit-subscription conn cred)))))
 
       (testing "can select by org"
         (is (= [(:cuid cred)]
-               (->> (sut/select-credit-subscriptions conn (sut/by-org (:id cust)))
+               (->> (sut/select-credit-subscriptions conn (sut/by-org (:id org)))
                     (map :cuid))))))))
 
 (deftest ^:sql credit-consumptions
   (eh/with-prepared-db conn
-    (let [cust (sut/insert-org conn (eh/gen-org))
+    (let [org (sut/insert-org conn (eh/gen-org))
           repo (sut/insert-repo conn (assoc (eh/gen-repo)
-                                            :org-id (:id cust)))
+                                            :org-id (:id org)))
           build (sut/insert-build conn (assoc (eh/gen-build)
                                               :repo-id (:id repo)))
           cred (sut/insert-org-credit
                 conn
-                (-> (eh/gen-cust-credit)
-                    (assoc :org-id (:id cust))
+                (-> (eh/gen-org-credit)
+                    (assoc :org-id (:id org))
                     (dissoc :user-id :subscription-id)))
           ccons (-> (eh/gen-credit-consumption)
                     (assoc :build-id (:id build)
@@ -357,9 +357,9 @@
 
 (deftest ^:sql bb-webhook
   (eh/with-prepared-db conn
-    (let [cust (sut/insert-org conn (eh/gen-org))
+    (let [org (sut/insert-org conn (eh/gen-org))
           repo (sut/insert-repo conn (assoc (eh/gen-repo)
-                                            :org-id (:id cust)))
+                                            :org-id (:id org)))
           wh (sut/insert-webhook conn (-> (eh/gen-webhook)
                                           (assoc :repo-id (:id repo))))
           bb-wh (-> (eh/gen-bb-webhook)
@@ -378,9 +378,9 @@
 
 (deftest ^:sql invoice
   (eh/with-prepared-db conn
-    (let [cust (sut/insert-org conn (eh/gen-org))
+    (let [org (sut/insert-org conn (eh/gen-org))
           inv (-> (eh/gen-invoice)
-                  (assoc :org-id (:id cust)
+                  (assoc :org-id (:id org)
                          :net-amount 100M
                          :vat-perc 21M
                          :details [{:net-amount 100M
@@ -395,7 +395,7 @@
                        (dissoc :id)))))
 
       (testing "can select by org id"
-        (is (= inv (-> (sut/select-invoice conn (sut/by-org (:id cust)))
+        (is (= inv (-> (sut/select-invoice conn (sut/by-org (:id org)))
                        (dissoc :id))))))))
 
 (deftest ^:sql queued-task
@@ -414,3 +414,23 @@
       (testing "can delete"
         (is (= 1 (sut/delete-queued-tasks conn (sut/by-cuid (:cuid task)))))
         (is (empty? (sut/select-queued-tasks conn nil)))))))
+
+(deftest ^:sql job-history
+  (eh/with-prepared-db conn
+    (let [org (sut/insert-org conn (eh/gen-org))
+          repo (-> (eh/gen-repo)
+                   (assoc :org-id (:id org))
+                   (as-> r (sut/insert-repo conn r)))
+          build (-> (eh/gen-build)
+                    (assoc :repo-id (:id repo))
+                    (as-> b (sut/insert-build conn b)))
+          job (-> (eh/gen-job)
+                  (assoc :build-id (:id build))
+                  (as-> j (sut/insert-job conn j)))
+          evt (-> (eh/gen-job-evt)
+                  (assoc :details {:message "test event"}
+                         :event :job/start
+                         :job-id (:id job)))]
+      (is (number? (:id org)))
+      (is (number? (:id job)))
+      (is (some? (:id evt))))))

--- a/app/test/unit/monkey/ci/entities/core_test.clj
+++ b/app/test/unit/monkey/ci/entities/core_test.clj
@@ -415,7 +415,7 @@
         (is (= 1 (sut/delete-queued-tasks conn (sut/by-cuid (:cuid task)))))
         (is (empty? (sut/select-queued-tasks conn nil)))))))
 
-(deftest ^:sql job-history
+(deftest ^:sql job-events
   (eh/with-prepared-db conn
     (let [org (sut/insert-org conn (eh/gen-org))
           repo (-> (eh/gen-repo)
@@ -430,7 +430,8 @@
           evt (-> (eh/gen-job-evt)
                   (assoc :details {:message "test event"}
                          :event :job/start
-                         :job-id (:id job)))]
+                         :job-id (:id job))
+                  (as-> e (sut/insert-job-event conn e)))]
       (is (number? (:id org)))
       (is (number? (:id job)))
       (is (some? (:id evt))))))

--- a/app/test/unit/monkey/ci/entities/helpers.clj
+++ b/app/test/unit/monkey/ci/entities/helpers.clj
@@ -118,3 +118,6 @@
 
 (defn gen-queued-task []
   (gen-spec :db/queued-task))
+
+(defn gen-job-evt []
+  (gen-spec :db/job-event))

--- a/app/test/unit/monkey/ci/storage/sql_test.clj
+++ b/app/test/unit/monkey/ci/storage/sql_test.clj
@@ -797,13 +797,14 @@
 (deftest ^:sql runner-details
   (with-storage conn st
     (let [repo (h/gen-repo)
-          cust (-> (h/gen-org)
-                   (assoc :repos {(:id repo) repo}))
+          org (-> (h/gen-org)
+                  (assoc :repos {(:id repo) repo}))
           build (-> (h/gen-build)
-                    (assoc :org-id (:id cust)
-                           :repo-id (:id repo)))
+                    (assoc :org-id (:id org)
+                           :repo-id (:id repo)
+                           :status :success))
           sid (st/ext-build-sid build)]
-      (is (sid/sid? (st/save-org st cust)))
+      (is (sid/sid? (st/save-org st org)))
       (is (sid/sid? (st/save-build st build)))
       
       (testing "can save and find by build sid"
@@ -828,6 +829,10 @@
       (testing "can delete"
         (is (true? (st/delete-queued-task st (:id task))))
         (is (empty? (st/list-queued-tasks st)))))))
+
+#_(deftest ^:sql job-events
+  (with-storage conn st
+    (let [job (h/gen-job)])))
 
 (deftest make-storage
   (testing "creates sql storage object using connection settings"

--- a/app/test/unit/monkey/ci/storage/sql_test.clj
+++ b/app/test/unit/monkey/ci/storage/sql_test.clj
@@ -830,9 +830,34 @@
         (is (true? (st/delete-queued-task st (:id task))))
         (is (empty? (st/list-queued-tasks st)))))))
 
-#_(deftest ^:sql job-events
+(deftest ^:sql job-events
   (with-storage conn st
-    (let [job (h/gen-job)])))
+    (let [org (h/gen-org)
+          repo (-> (h/gen-repo)
+                   (assoc :org-id (:id org)))
+          build (-> (h/gen-build)
+                    (assoc :repo-id (:id repo)
+                           :org-id (:id org)))
+          job (-> (h/gen-job)
+                  (assoc :org-id (:id org)
+                         :repo-id (:id repo)
+                         :build-id (:build-id build)))
+          evt (-> (h/gen-job-evt)
+                  (assoc :org-id (:id org)
+                         :repo-id (:id repo)
+                         :build-id (:build-id build)
+                         :job-id (:id job)
+                         :details {:status :running}))
+          job->sid (juxt :org-id :repo-id :build-id :id)]
+
+      (is (some? (st/save-org st org)))
+      (is (some? (st/save-repo st repo)))
+      (is (some? (st/save-build st build)))
+      (is (some? (st/save-job st (b/sid build) job)))
+      
+      (testing "can save and list for job"
+        (is (sid/sid? (st/save-job-event st evt)))
+        (is (= [evt] (st/list-job-events st (job->sid job))))))))
 
 (deftest make-storage
   (testing "creates sql storage object using connection settings"

--- a/app/test/unit/monkey/ci/test/helpers.clj
+++ b/app/test/unit/monkey/ci/test/helpers.clj
@@ -282,6 +282,9 @@
       ;; Fixed task, to avoid brittle tests
       (assoc :task {:key :value})))
 
+(defn gen-job-evt []
+  (gen-entity :entity/job-event))
+
 (defn gen-build-sid []
   (repeatedly 3 cuid/random-cuid))
 


### PR DESCRIPTION
Keep track of events in database table.  Later, we will use this table to determine job properties, instead of constantly updating job records, which leads to collisions with multiple events on multiple replicas.