### PR TITLE
Feature/org display ids

### DIFF
--- a/app/src/monkey/ci/entities/core.clj
+++ b/app/src/monkey/ci/entities/core.clj
@@ -356,11 +356,11 @@
 
 (defn insert-user-orgs
   "Batch inserts user/org links"
-  [conn user-id cust-ids]
-  (when-not (empty? cust-ids)
+  [conn user-id org-ids]
+  (when-not (empty? org-ids)
     (insert-entities conn :user-orgs
                      [:user-id :org-id]
-                     (map (partial conj [user-id]) cust-ids))))
+                     (map (partial conj [user-id]) org-ids))))
 
 (defaggregate org-param-value)
 

--- a/app/src/monkey/ci/entities/migrations.clj
+++ b/app/src/monkey/ci/entities/migrations.clj
@@ -658,7 +658,9 @@
    (migration
     (mig-id 50 :org-display-id)
     [{:alter-table :orgs
-      :add-column [:display-id [:varchar 30]]}]
+      :add-column [:display-id [:varchar 30]]}
+     {:alter-table :orgs
+      :add-index [:unique nil :display-id]}]
     [{:alter-table :orgs
       :drop-column :display-id}])])
 

--- a/app/src/monkey/ci/entities/migrations.clj
+++ b/app/src/monkey/ci/entities/migrations.clj
@@ -653,7 +653,14 @@
     [{:alter-table :repos
       :add-column [:public :boolean]}]
     [{:alter-table :repos
-      :drop-column :public}])])
+      :drop-column :public}])
+
+   (migration
+    (mig-id 50 :org-display-id)
+    [{:alter-table :orgs
+      :add-column [:display-id [:varchar 30]]}]
+    [{:alter-table :orgs
+      :drop-column :display-id}])])
 
 (defn prepare-migrations
   "Prepares all migrations by formatting to sql, creates a ragtime migration object from it."

--- a/app/src/monkey/ci/entities/org.clj
+++ b/app/src/monkey/ci/entities/org.clj
@@ -32,3 +32,10 @@
                       :where [:= :c.cuid cuid]})
           (first)
           (assoc :org-id cuid)))
+
+(defn org-display-ids [conn]
+  (->> {:select [:o.display-id]
+        :from [[:orgs :o]]
+        :where [:<> :o.display-id nil]}
+       (ec/select conn)
+       (set)))

--- a/app/src/monkey/ci/entities/org.clj
+++ b/app/src/monkey/ci/entities/org.clj
@@ -39,3 +39,11 @@
         :where [:<> :o.display-id nil]}
        (ec/select conn)
        (set)))
+
+(defn org-id-by-display-id [conn did]
+  (->> {:select [:o.cuid]
+        :from [[:orgs :o]]
+        :where [:= :o.display-id did]}
+       (ec/select conn)
+       first
+       :cuid))

--- a/app/src/monkey/ci/spec/db_entities.clj
+++ b/app/src/monkey/ci/spec/db_entities.clj
@@ -18,6 +18,7 @@
 (s/def :github/secret string?)
 (s/def :db/name (s/and string? not-empty))
 (s/def :db/description string?)
+(s/def :db/display-id string?)
 
 (s/def :db/common
   (s/keys :req-un [:db/cuid]
@@ -32,10 +33,9 @@
       (s/merge :db/common)))
 
 (s/def :db/org
-  (-> (s/keys :req-un [:db/name])
+  (-> (s/keys :req-un [:db/name :db/display-id])
       (s/merge :db/common)))
 
-(s/def :db/display-id string?)
 (s/def :db/org-id id?)
 (s/def :db/public boolean?)
 

--- a/app/src/monkey/ci/spec/entities.clj
+++ b/app/src/monkey/ci/spec/entities.clj
@@ -26,8 +26,10 @@
 (s/def :entity/timed
   (s/keys :opt-un [:entity/start-time :entity/end-time]))
 
+(s/def :org/display-id string?)
+
 (s/def :entity/org
-  (-> (s/keys :req-un [:entity/name])
+  (-> (s/keys :req-un [:entity/name :org/display-id])
       (s/merge :entity/common)))
 
 (s/def :label/name string?)

--- a/app/src/monkey/ci/storage.clj
+++ b/app/src/monkey/ci/storage.clj
@@ -112,6 +112,14 @@
           (filter (comp (partial = did) :display-id))
           (first)))))
 
+(def find-org-id-by-display-id
+  "Optimization for fast id lookup"
+  (override-or
+   [:org :find-id-by-display-id]
+   (fn [s did]
+     (some-> (find-org-by-display-id s did)
+             :id))))
+
 (def delete-org
   (override-or
    [:org :delete]

--- a/app/src/monkey/ci/storage.clj
+++ b/app/src/monkey/ci/storage.clj
@@ -103,6 +103,15 @@
 (defn find-org [s id]
   (p/read-obj s (org-sid id)))
 
+(def find-org-by-display-id
+  (override-or
+   [:org :find-by-display-id]
+   (fn [s did]
+     (->> (p/list-obj s (org-sid))
+          (map (comp (partial p/read-obj s) org-sid))
+          (filter (comp (partial = did) :display-id))
+          (first)))))
+
 (def delete-org
   (override-or
    [:org :delete]

--- a/app/src/monkey/ci/storage/sql.clj
+++ b/app/src/monkey/ci/storage/sql.clj
@@ -178,10 +178,17 @@
     (update-org conn org existing)
     (insert-org conn org)))
 
+(defn- select-org-by-filter [conn f]
+  (some-> (ecu/org-with-repos conn f)
+          (db->org-with-repos)))
+
 (defn- select-org [conn cuid]
   (when cuid
-    (some-> (ecu/org-with-repos conn (ec/by-cuid cuid))
-            (db->org-with-repos))))
+    (select-org-by-filter conn (ec/by-cuid cuid))))
+
+(defn- select-org-by-display-id [st did]
+  (when did
+    (select-org-by-filter (get-conn st) (ec/by-display-id did))))
 
 (defn- org-exists? [conn cuid]
   (some? (ec/select-org conn (ec/by-cuid cuid))))
@@ -1099,6 +1106,7 @@
     :list-credit-consumptions-since select-org-credit-cons-since
     :find-latest-builds select-latest-org-builds
     :find-latest-n-builds select-latest-n-org-builds
+    :find-by-display-id select-org-by-display-id
     :count count-orgs}
    :repo
    {:list-display-ids select-repo-display-ids

--- a/app/src/monkey/ci/storage/sql.clj
+++ b/app/src/monkey/ci/storage/sql.clj
@@ -223,6 +223,10 @@
   (when did
     (select-org-by-filter (get-conn st) (ec/by-display-id did))))
 
+(defn- select-org-id-by-display-id [st did]
+  (when did
+    (ecu/org-id-by-display-id (get-conn st) did)))
+
 (defn- org-exists? [conn cuid]
   (some? (ec/select-org conn (ec/by-cuid cuid))))
 
@@ -1141,6 +1145,7 @@
     :find-latest-builds select-latest-org-builds
     :find-latest-n-builds select-latest-n-org-builds
     :find-by-display-id select-org-by-display-id
+    :find-id-by-display-id select-org-id-by-display-id
     :count count-orgs}
    :repo
    {:list-display-ids select-repo-display-ids

--- a/app/src/monkey/ci/storage/sql.clj
+++ b/app/src/monkey/ci/storage/sql.clj
@@ -145,7 +145,7 @@
 (defn- org->db [org]
   (-> org
       (id->cuid)
-      (select-keys [:cuid :name])))
+      (select-keys [:cuid :name :display-id])))
 
 (def db->org cuid->id)
 

--- a/app/src/monkey/ci/utils.clj
+++ b/app/src/monkey/ci/utils.clj
@@ -4,6 +4,7 @@
              [codecs :as bcc]
              [hash :as bch]]
             [buddy.core.keys.pem :as pem]
+            [camel-snake-kebab.core :as csk]
             [clojure
              [math :as math]
              [repl :as cr]
@@ -200,3 +201,18 @@
 
 (defn update-nth [c idx f & args]
   (mc/replace-nth idx (apply f (nth c idx) args) c))
+
+(defn name->display-id
+  "Generates a unique display id using the given name.  It checks the `existing?`
+   fn to avoid collisions."
+  [n existing?]
+  (let [;; TODO Check what happens with special chars
+        new-id (csk/->kebab-case n)]
+    (loop [id new-id
+           idx 2]
+      ;; Try a new id until we find one that does not exist yet.
+      ;; Alternatively we could parse the ids to extract the max index (but yagni)
+      (if (existing? id)
+        (recur (str new-id "-" idx)
+               (inc idx))
+        id))))

--- a/app/src/monkey/ci/web/api/org.clj
+++ b/app/src/monkey/ci/web/api/org.clj
@@ -31,9 +31,15 @@
               (sequential? repos) (update :repos (partial zipmap (map :id repos)))))]
     (st/save-org st (repos->map org))))
 
+(defn- find-org
+  "Looks up an organization, either by cuid or display id"
+  [s id]
+  (or (st/find-org s id)
+      (st/find-org-by-display-id s id)))
+
 (c/make-entity-endpoints "org"
                          {:get-id (c/id-getter :org-id)
-                          :getter (comp repos->out st/find-org)
+                          :getter (comp repos->out find-org)
                           :saver save-org
                           :deleter st/delete-org})
 

--- a/app/src/monkey/ci/web/api/org.clj
+++ b/app/src/monkey/ci/web/api/org.clj
@@ -46,7 +46,8 @@
                                :credits {:amount config/free-credits
                                          :from (t/now)}
                                :dek (:enc (crypto/generate-dek req org-id))})]
-      (-> (rur/response org)
+      (-> (st/find-org st (last res))
+          (rur/response)
           (rur/status 201)))))
 
 (defn search-orgs [req]

--- a/app/src/monkey/ci/web/auth.clj
+++ b/app/src/monkey/ci/web/auth.clj
@@ -250,9 +250,14 @@
 (defn- org-checker [kind]
   (fn [_ req]
     (when-let [oid (get-in req [:parameters kind :org-id])]
-      (when-not (and (ba/authenticated? req)
-                     (or (sysadmin? (:identity req))
-                         (contains? (get-in req [:identity :orgs]) oid)))
+      (when-not
+          (and (ba/authenticated? req)
+               (or (sysadmin? (:identity req))
+                   (contains? (get-in req [:identity :orgs])
+                              oid)
+                   ;; Should also match org display ids
+                   (contains? (get-in req [:identity :orgs])
+                              (st/find-org-id-by-display-id (c/req->storage req) oid))))
         (denied-no-org-access oid)))))
 
 (def org-auth-checker

--- a/app/src/monkey/ci/web/auth.clj
+++ b/app/src/monkey/ci/web/auth.clj
@@ -305,8 +305,8 @@
 (defn sysadmin-checker
   "Allows sysadmins"
   [_ req]
-  (log/debug "Checking if user is sysadmin:" (:identity req))
   (when (sysadmin? (:identity req))
+    (log/trace "Granting access to sysadmin:" (:identity req))
     granted))
 
 (defn readonly-checker

--- a/app/src/monkey/ci/web/common.clj
+++ b/app/src/monkey/ci/web/common.clj
@@ -5,7 +5,8 @@
             [monkey.ci
              [labels :as lbl]
              [storage :as st]
-             [time :as t]]
+             [time :as t]
+             [utils :as u]]
             [muuntaja.core :as mc]
             [reitit.ring :as ring]
             [ring.util.response :as rur]
@@ -210,17 +211,8 @@
   [st obj]
   (let [existing? (-> (:org-id obj)
                       (as-> cid (st/list-repo-display-ids st cid))
-                      (set))
-        ;; TODO Check what happens with special chars
-        new-id (csk/->kebab-case (:name obj))]
-    (loop [id new-id
-           idx 2]
-      ;; Try a new id until we find one that does not exist yet.
-      ;; Alternatively we could parse the ids to extract the max index (but yagni)
-      (if (existing? id)
-        (recur (str new-id "-" idx)
-               (inc idx))
-        id))))
+                      (set))]
+    (u/name->display-id (:name obj) existing?)))
 
 (defn make-muuntaja
   "Creates muuntaja instance with custom settings"

--- a/app/test/unit/monkey/ci/entities/migrations_test.clj
+++ b/app/test/unit/monkey/ci/entities/migrations_test.clj
@@ -166,7 +166,8 @@
                                rp/id)
     conn mig
     (is (some? mig))
-    (let [org (ec/insert-org conn (eh/gen-org))
+    (let [org (ec/insert-org conn (-> (eh/gen-org)
+                                      (dissoc :display-id)))
           crypto (ec/insert-crypto conn
                                    {:org-id (:id org)
                                     :iv (v/generate-iv)})

--- a/app/test/unit/monkey/ci/entities/migrations_test.clj
+++ b/app/test/unit/monkey/ci/entities/migrations_test.clj
@@ -15,6 +15,10 @@
              [next-jdbc :as rj]
              [protocols :as rp]]))
 
+(defn- gen-org []
+  (-> (eh/gen-org)
+      (dissoc :display-id)))
+
 (deftest fk
   (testing "creates foreign key constraint with cascading"
     (is (= "CREATE TABLE test (FOREIGN KEY(src_col) REFERENCES dest_table(dest_col) ON DELETE CASCADE)"
@@ -166,8 +170,7 @@
                                rp/id)
     conn mig
     (is (some? mig))
-    (let [org (ec/insert-org conn (-> (eh/gen-org)
-                                      (dissoc :display-id)))
+    (let [org (ec/insert-org conn (gen-org))
           crypto (ec/insert-crypto conn
                                    {:org-id (:id org)
                                     :iv (v/generate-iv)})
@@ -190,7 +193,7 @@
                                rp/id)
     conn mig
     (is (some? mig))
-    (let [org (ec/insert-org conn (eh/gen-org))
+    (let [org (ec/insert-org conn (gen-org))
           pv (ec/insert-org-param conn {:org-id (:id org)})
           crypto (ec/insert-crypto conn
                                    {:org-id (:id org)
@@ -235,7 +238,7 @@
                                rp/id)
       conn mig
     (is (some? mig))
-    (let [org (ec/insert-org conn (eh/gen-org))
+    (let [org (ec/insert-org conn (gen-org))
           sk (ec/insert-ssh-key conn {:org-id (:id org)
                                       :public-key "test-pubkey"
                                       :private-key "vault-encrypted"})

--- a/app/test/unit/monkey/ci/storage/sql_test.clj
+++ b/app/test/unit/monkey/ci/storage/sql_test.clj
@@ -103,17 +103,42 @@
         (is (sid/sid? (st/save-org s org)))
         (is (= (:id org) (:id (st/find-org-by-display-id s "another-org"))))))))
 
-#_(deftest ^:sql init-org
+(deftest ^:sql init-org
   (with-storage conn s
-    (testing "creates new org")
+    (let [org (-> (h/gen-org)
+                  (assoc :name "test org"))
+          user {:id (cuid/random-cuid)
+                :type "github"
+                :type-id "12342"}
+          _ (st/save-user s user)
+          res (st/init-org s {:org org
+                              :user-id (:id user)
+                              :credits {:amount 1000
+                                        :from (t/now)}
+                              :dek "test-dek"})]
+      
+      (testing "creates new org"
+        (is (sid/sid? res))
+        (let [m (st/find-org s (last res))]
+          (is (= (:id org) (:id m)))
+          (is (= "test-org" (:display-id m)))))
 
-    (testing "links org to user")
+      (testing "links org to user"
+        (is (= 1 (count (st/list-user-orgs s (:id user))))))
 
-    (testing "creates credit subscription")
+      (testing "creates credit subscription"
+        (let [cs (st/list-org-credit-subscriptions s (:id org))]
+          (is (= 1 (count cs)))
+          (is (= 1000M (-> cs first :amount)))))
 
-    (testing "creates initial credits")
+      (testing "creates initial credits"
+        (let [c (st/list-org-credits s (:id org))]
+          (is (= 1 (count c)))
+          (is (= 1000M (-> c first :amount)))))
 
-    (testing "creates crypto with dek")))
+      (testing "creates crypto with dek"
+        (is (= "test-dek" (-> (st/find-crypto s (:id org))
+                              :dek)))))))
 
 (deftest ^:sql repos
   (with-storage conn s

--- a/app/test/unit/monkey/ci/storage/sql_test.clj
+++ b/app/test/unit/monkey/ci/storage/sql_test.clj
@@ -96,12 +96,16 @@
     (testing "can count"
       (is (pos? (st/count-orgs s))))
 
-    (testing "can find by display-id"
-      (let [org {:name "another org"
-                 :display-id "another-org"
-                 :id (cuid/random-cuid)}]
-        (is (sid/sid? (st/save-org s org)))
-        (is (= (:id org) (:id (st/find-org-by-display-id s "another-org"))))))))
+    (let [org {:name "another org"
+               :display-id "another-org"
+               :id (cuid/random-cuid)}]
+      (is (sid/sid? (st/save-org s org)))
+      
+      (testing "can find by display-id"
+        (is (= (:id org) (:id (st/find-org-by-display-id s "another-org")))))
+
+      (testing "can find id by display id"
+        (is (= (:id org) (st/find-org-id-by-display-id s "another-org")))))))
 
 (deftest ^:sql init-org
   (with-storage conn s

--- a/app/test/unit/monkey/ci/storage/sql_test.clj
+++ b/app/test/unit/monkey/ci/storage/sql_test.clj
@@ -71,7 +71,7 @@
 
     (testing "can search"
       (let [org (-> (h/gen-org)
-                     (assoc :name "test org"))]
+                    (assoc :name "test org"))]
         (is (sid/sid? (st/save-org s org)))
         
         (testing "by name"
@@ -94,7 +94,14 @@
                       (set)))))))
 
     (testing "can count"
-      (is (pos? (st/count-orgs s))))))
+      (is (pos? (st/count-orgs s))))
+
+    (testing "can find by display-id"
+      (let [org {:name "another org"
+                 :display-id "another-org"
+                 :id (cuid/random-cuid)}]
+        (is (sid/sid? (st/save-org s org)))
+        (is (= (:id org) (:id (st/find-org-by-display-id s "another-org"))))))))
 
 #_(deftest ^:sql init-org
   (with-storage conn s

--- a/app/test/unit/monkey/ci/storage_test.clj
+++ b/app/test/unit/monkey/ci/storage_test.clj
@@ -47,12 +47,17 @@
                                             :from (t/now)}
                                   :dek "test-dek"})]
         (is (sid/sid? res))
-        
-        (testing "creates new org"
-          (is (= org (sut/find-org st (:id org)))))
+
+        (let [m (sut/find-org st (:id org))]
+          (testing "creates new org"
+            (is (= (:id org) (:id m))))
+
+          (testing "assigns display id"
+            (is (= "test-org" (:display-id m)))))
 
         (testing "links org to user"
-          (is (= [org] (sut/list-user-orgs st (:id user)))))
+          (is (= [(:id org)] (->> (sut/list-user-orgs st (:id user))
+                                  (map :id)))))
 
         (testing "creates credit subscription"
           (let [cs (sut/list-org-credit-subscriptions st (:id org))]

--- a/app/test/unit/monkey/ci/storage_test.clj
+++ b/app/test/unit/monkey/ci/storage_test.clj
@@ -15,21 +15,28 @@
 (deftest orgs
   (h/with-memory-store st
     (let [orgs (repeatedly 3 h/gen-org)]
-        (doseq [c orgs]
-          (sut/save-org st c))
-        (testing "can find multiple"
-          (let [r (sut/find-orgs st (->> orgs
-                                         (take 2)
-                                         (map :id)))]
-            (is (= (take 2 orgs) r))))
+      (doseq [c orgs]
+        (sut/save-org st c))
+      (testing "can find multiple"
+        (let [r (sut/find-orgs st (->> orgs
+                                       (take 2)
+                                       (map :id)))]
+          (is (= (take 2 orgs) r))))
 
-        (testing "can count"
-          (is (= 3 (sut/count-orgs st))))
+      (testing "can count"
+        (is (= 3 (sut/count-orgs st))))
 
-        (testing "can delete"
-          (let [org (first orgs)]
-            (is (true? (sut/delete-org st (:id org))))
-            (is (nil? (sut/find-org st (:id org)))))))))
+      (testing "can delete"
+        (let [org (first orgs)]
+          (is (true? (sut/delete-org st (:id org))))
+          (is (nil? (sut/find-org st (:id org)))))))
+
+    (testing "can find by display id"
+      (let [org {:id (cuid/random-cuid)
+                 :name "test org"
+                 :display-id "test-org"}]
+        (is (sid/sid? (sut/save-org st org)))
+        (is (= org (sut/find-org-by-display-id st "test-org")))))))
 
 (deftest init-org
   (h/with-memory-store st

--- a/app/test/unit/monkey/ci/web/api/org_test.clj
+++ b/app/test/unit/monkey/ci/web/api/org_test.clj
@@ -47,7 +47,19 @@
         (is (some? repos))
         (is (not (map? repos)))
         (is (= (select-keys repo [:id :name])
-               (first repos)))))))
+               (first repos))))))
+
+  (testing "retrieves org by display-id"
+    (let [org {:id (st/new-id)
+               :name "Some org"}
+          {st :storage :as rt} (trt/test-runtime)]
+      (is (sid/sid? (st/init-org st {:org org})))
+      (let [r (-> rt
+                  (h/->req)
+                  (h/with-path-param :org-id "some-org")
+                  (sut/get-org)
+                  :body)]
+        (is (= (:id org) (:id r)))))))
 
 (deftest create-org
   (let [r (-> (trt/test-runtime)

--- a/app/test/unit/monkey/ci/web/api/org_test.clj
+++ b/app/test/unit/monkey/ci/web/api/org_test.clj
@@ -50,15 +50,18 @@
                (first repos)))))))
 
 (deftest create-org
-  (testing "returns created org with id"
-    (let [r (-> (trt/test-runtime)
-                (h/->req)
-                (h/with-body {:name "new org"})
-                (sut/create-org)
-                :body)]
+  (let [r (-> (trt/test-runtime)
+              (h/->req)
+              (h/with-body {:name "new org"})
+              (sut/create-org)
+              :body)]
+    (testing "returns created org with id"
       (is (map? r))
       (is (= "new org" (:name r)))
-      (is (string? (:id r)))))
+      (is (string? (:id r))))
+
+    (testing "assigns display id"
+      (is (= "new-org" (:display-id r)))))
 
   (let [user (-> (h/gen-user)
                  (dissoc :orgs))

--- a/app/test/unit/monkey/ci/web/common_test.clj
+++ b/app/test/unit/monkey/ci/web/common_test.clj
@@ -23,7 +23,7 @@
     (is (= "http://test:1234/v1"
            (sut/req->ext-uri
             {:scheme :http
-             :uri "/v1/customer/test-cust"
+             :uri "/v1/org/test-cust"
              :headers {"host" "test:1234"}}
-            "/customer")))))
+            "/org")))))
 

--- a/gui/src/monkey/ci/gui/home/views.cljs
+++ b/gui/src/monkey/ci/gui/home/views.cljs
@@ -21,19 +21,22 @@
    {:href (r/path-for :page/org-join)}
    [:span.me-2 [co/icon :arrow-right-square]] "Join Organization"])
 
-(defn- org-item [{:keys [id name owner?]}]
-  [:div.card
-   {:style {:width "20em"}
-    :on-click #(rf/dispatch [:route/goto :page/org {:org-id id}])}
-   [:div.card-header {:style {:font-size "5em"}}
-    [:a {:href (r/path-for :page/org {:org-id id})} co/org-icon]]
-   [:div.card-body
-    [:div.card-title
-     [:h5
-      [:a {:href (r/path-for :page/org {:org-id id})}
-       name
-       (when owner?
-         [:span.badge.text-bg-success.ms-2 "owner"])]]]]])
+(def org-id (some-fn :display-id :id))
+
+(defn- org-item [{:keys [name owner?] :as org}]
+  (let [id (org-id org)]
+    [:div.card
+     {:style {:width "20em"}
+      :on-click #(rf/dispatch [:route/goto :page/org {:org-id id}])}
+     [:div.card-header {:style {:font-size "5em"}}
+      [:a {:href (r/path-for :page/org {:org-id id})} co/org-icon]]
+     [:div.card-body
+      [:div.card-title
+       [:h5
+        [:a {:href (r/path-for :page/org {:org-id id})}
+         name
+         (when owner?
+           [:span.badge.text-bg-success.ms-2 "owner"])]]]]]))
 
 (defn- linked-orgs [org]
   [:div


### PR DESCRIPTION
Add a display id to orgs, which acts as a human-friendly alternative to the cuid.  This can also be used in the ui, so urls are also more readable.